### PR TITLE
ci(frontend): migrate ci and release preflight to bun gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Release hygiene checks
+        run: |
+          uv run python scripts/check_release_hygiene.py
+          uv run python scripts/check_release_metadata.py
+
       - name: Lint with Ruff
         run: |
           uv run ruff check src tests config/test_responses_endpoint.py
@@ -44,3 +49,36 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+      - name: Set up Bun for frontend checks
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.10"
+
+      - name: Cache Bun packages
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('src/frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Frontend install
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        run: |
+          cd src/frontend
+          bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        run: |
+          cd src/frontend
+          bunx playwright install --with-deps chromium
+
+      - name: Frontend quality gate
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        run: |
+          cd src/frontend
+          bun run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
 
           echo "✅ Version $TOML_VERSION matches workflow input '$INPUT_VERSION'"
 
+      - name: Release hygiene checks
+        run: |
+          uv run python scripts/check_release_hygiene.py
+          uv run python scripts/check_release_metadata.py
+
       - name: Lint with Ruff
         run: |
           uv run ruff check src tests config/test_responses_endpoint.py
@@ -70,6 +75,39 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+      - name: Set up Bun for frontend checks
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.10"
+
+      - name: Cache Bun packages
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('src/frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Frontend install
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        run: |
+          cd src/frontend
+          bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        run: |
+          cd src/frontend
+          bunx playwright install --with-deps chromium
+
+      - name: Frontend quality gate
+        if: ${{ hashFiles('src/frontend/package.json') != '' }}
+        run: |
+          cd src/frontend
+          bun run check
 
   build:
     name: Build Distribution


### PR DESCRIPTION
## Summary
- Migrates frontend CI and release preflight steps from npm to Bun.
- Adds pinned Bun setup, Bun cache keyed by `src/frontend/bun.lock`, deterministic Playwright install, and canonical `bun run check` gate.

## Validation
- Manual workflow diff sanity review ✅
- Confirmed no npm/npx frontend execution commands remain in CI/release workflow frontend steps ✅

## Risk
- Medium. CI behavior changes, but commands are now consistent with local frontend policy.
