### PR TITLE
Refactor frontend shadcn component tree and workspace assistant UI

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -11,28 +11,17 @@
     "playwright": {
       "type": "local",
       "command": "npx",
-      "tools": [
-        "*"
-      ],
-      "args": [
-        "@playwright/mcp@latest"
-      ]
+      "tools": ["*"],
+      "args": ["@playwright/mcp@latest"]
     },
     "daytona": {
       "type": "local",
       "command": "daytona",
-      "args": [
-        "mcp",
-        "start"
-      ]
+      "args": ["mcp", "start"]
     },
     "agentation": {
       "command": "npx",
-      "args": [
-        "-y",
-        "agentation-mcp",
-        "server"
-      ]
+      "args": ["-y", "agentation-mcp@1.2.0", "server"]
     }
   }
 }

--- a/src/frontend/.mcp.json
+++ b/src/frontend/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "agentation": {
       "command": "npx",
-      "args": ["-y", "agentation-mcp", "server"]
+      "args": ["-y", "agentation-mcp@1.2.0", "server"]
     }
   }
 }

--- a/src/frontend/src/app/workspace/assistant-content/model/runtime-context-badge.tsx
+++ b/src/frontend/src/app/workspace/assistant-content/model/runtime-context-badge.tsx
@@ -6,7 +6,5 @@ export function RuntimeContextBadge({ ctx }: { ctx?: RuntimeContext }) {
   const pills = getRuntimeBadgeStrings(ctx);
   if (pills.length === 0) return null;
 
-  return (
-    <div className={inspectorStyles.runtime.inline}>{pills.join(" · ")}</div>
-  );
+  return <div className={inspectorStyles.runtime.inline}>{pills.join(" · ")}</div>;
 }

--- a/src/frontend/src/app/workspace/assistant-content/model/runtime-context-badge.tsx
+++ b/src/frontend/src/app/workspace/assistant-content/model/runtime-context-badge.tsx
@@ -1,10 +1,12 @@
 import { inspectorStyles } from "@/app/workspace/inspector/inspector-styles";
-import type { RuntimeContext } from "@/screens/workspace/use-workspace";
+import type { RuntimeContext } from "@/lib/workspace/workspace-types";
 import { getRuntimeBadgeStrings } from "./runtime-badges";
 
 export function RuntimeContextBadge({ ctx }: { ctx?: RuntimeContext }) {
   const pills = getRuntimeBadgeStrings(ctx);
   if (pills.length === 0) return null;
 
-  return <div className={inspectorStyles.runtime.inline}>{pills.join(" · ")}</div>;
+  return (
+    <div className={inspectorStyles.runtime.inline}>{pills.join(" · ")}</div>
+  );
 }

--- a/src/frontend/src/app/workspace/transcript/workspace-chat-message-item.tsx
+++ b/src/frontend/src/app/workspace/transcript/workspace-chat-message-item.tsx
@@ -7,15 +7,23 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from "@/app/workspace/confirmation";
-import { Message, MessageContent, MessageResponse } from "@/components/ai-elements/message";
-import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from "@/components/ai-elements/message";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "@/components/ai-elements/reasoning";
 import { ClarificationCard } from "@/app/workspace/clarification-card";
 import {
   ChatMessageLoadingState,
   WorkspaceLegacyStatusCard,
   WorkspaceTracePart,
 } from "@/app/workspace/transcript/trace-part-renderers";
-import type { ChatMessage } from "@/screens/workspace/use-workspace";
+import type { ChatMessage } from "@/lib/workspace/workspace-types";
 import { cn } from "@/lib/utils";
 import { mapConfirmationState } from "@/lib/utils/prompt-kit-state";
 
@@ -64,7 +72,9 @@ export function WorkspaceChatMessageItem({
         </Message>
       ) : null}
 
-      {message.type === "assistant" || message.type === "trace" || message.type === "reasoning" ? (
+      {message.type === "assistant" ||
+      message.type === "trace" ||
+      message.type === "reasoning" ? (
         <Message from="assistant" className="mb-2.5">
           <MessageContent className="w-full flex flex-col gap-2.5">
             {message.renderParts?.map((part, index) => (
@@ -79,7 +89,9 @@ export function WorkspaceChatMessageItem({
                 <MessageResponse>{message.content}</MessageResponse>
               </div>
             ) : null}
-            {message.type === "assistant" && message.streaming && !message.content ? (
+            {message.type === "assistant" &&
+            message.streaming &&
+            !message.content ? (
               <div className="max-w-content rounded-bubble border border-border-subtle/60 bg-card/60 px-4 py-3.5 md:px-5 md:py-4">
                 <ChatMessageLoadingState />
               </div>
@@ -102,8 +114,12 @@ export function WorkspaceChatMessageItem({
                     : undefined,
             }}
           >
-            <ConfirmationTitle className="text-sm font-medium">Checkpoint</ConfirmationTitle>
-            <div className="mt-2 text-sm text-muted-foreground">{message.hitlData.question}</div>
+            <ConfirmationTitle className="text-sm font-medium">
+              Checkpoint
+            </ConfirmationTitle>
+            <div className="mt-2 text-sm text-muted-foreground">
+              {message.hitlData.question}
+            </div>
             <ConfirmationRequest>
               <ConfirmationActions>
                 {message.hitlData.actions.map((action) => (
@@ -143,7 +159,9 @@ export function WorkspaceChatMessageItem({
         </div>
       ) : null}
 
-      {message.type === "reasoning" && message.reasoningData && !message.renderParts?.length ? (
+      {message.type === "reasoning" &&
+      message.reasoningData &&
+      !message.renderParts?.length ? (
         <div className="mb-2.5">
           <Reasoning
             isStreaming={message.reasoningData.isThinking}

--- a/src/frontend/src/app/workspace/transcript/workspace-chat-message-item.tsx
+++ b/src/frontend/src/app/workspace/transcript/workspace-chat-message-item.tsx
@@ -7,16 +7,8 @@ import {
   ConfirmationRequest,
   ConfirmationTitle,
 } from "@/app/workspace/confirmation";
-import {
-  Message,
-  MessageContent,
-  MessageResponse,
-} from "@/components/ai-elements/message";
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from "@/components/ai-elements/reasoning";
+import { Message, MessageContent, MessageResponse } from "@/components/ai-elements/message";
+import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { ClarificationCard } from "@/app/workspace/clarification-card";
 import {
   ChatMessageLoadingState,
@@ -72,9 +64,7 @@ export function WorkspaceChatMessageItem({
         </Message>
       ) : null}
 
-      {message.type === "assistant" ||
-      message.type === "trace" ||
-      message.type === "reasoning" ? (
+      {message.type === "assistant" || message.type === "trace" || message.type === "reasoning" ? (
         <Message from="assistant" className="mb-2.5">
           <MessageContent className="w-full flex flex-col gap-2.5">
             {message.renderParts?.map((part, index) => (
@@ -89,9 +79,7 @@ export function WorkspaceChatMessageItem({
                 <MessageResponse>{message.content}</MessageResponse>
               </div>
             ) : null}
-            {message.type === "assistant" &&
-            message.streaming &&
-            !message.content ? (
+            {message.type === "assistant" && message.streaming && !message.content ? (
               <div className="max-w-content rounded-bubble border border-border-subtle/60 bg-card/60 px-4 py-3.5 md:px-5 md:py-4">
                 <ChatMessageLoadingState />
               </div>
@@ -114,12 +102,8 @@ export function WorkspaceChatMessageItem({
                     : undefined,
             }}
           >
-            <ConfirmationTitle className="text-sm font-medium">
-              Checkpoint
-            </ConfirmationTitle>
-            <div className="mt-2 text-sm text-muted-foreground">
-              {message.hitlData.question}
-            </div>
+            <ConfirmationTitle className="text-sm font-medium">Checkpoint</ConfirmationTitle>
+            <div className="mt-2 text-sm text-muted-foreground">{message.hitlData.question}</div>
             <ConfirmationRequest>
               <ConfirmationActions>
                 {message.hitlData.actions.map((action) => (
@@ -159,9 +143,7 @@ export function WorkspaceChatMessageItem({
         </div>
       ) : null}
 
-      {message.type === "reasoning" &&
-      message.reasoningData &&
-      !message.renderParts?.length ? (
+      {message.type === "reasoning" && message.reasoningData && !message.renderParts?.length ? (
         <div className="mb-2.5">
           <Reasoning
             isStreaming={message.reasoningData.isThinking}

--- a/src/frontend/src/components/ai-elements/suggestion.tsx
+++ b/src/frontend/src/components/ai-elements/suggestion.tsx
@@ -5,14 +5,22 @@ import type { ComponentProps } from "react";
 import { useCallback } from "react";
 
 export type SuggestionsProps = ComponentProps<typeof ScrollArea> & {
+  contentClassName?: string;
   wrap?: boolean;
 };
 
-export const Suggestions = ({ className, children, wrap = false, ...props }: SuggestionsProps) => (
+export const Suggestions = ({
+  className,
+  contentClassName,
+  children,
+  wrap = false,
+  ...props
+}: SuggestionsProps) => (
   <ScrollArea
     className={cn(
       "w-full whitespace-nowrap",
       wrap ? "overflow-visible whitespace-normal" : "overflow-x-auto",
+      className,
     )}
     {...props}
   >
@@ -20,7 +28,7 @@ export const Suggestions = ({ className, children, wrap = false, ...props }: Sug
       className={cn(
         "flex items-center gap-2",
         wrap ? "flex-wrap justify-center" : "w-max flex-nowrap",
-        className,
+        contentClassName,
       )}
     >
       {children}

--- a/src/frontend/src/components/ui/toggle-group.tsx
+++ b/src/frontend/src/components/ui/toggle-group.tsx
@@ -5,15 +5,14 @@ import { type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 import { toggleVariants } from "@/components/ui/toggle-variants";
 
-type ToggleGroupVariant = NonNullable<VariantProps<typeof toggleVariants>["variant"]> | "card";
+type ToggleGroupVariant =
+  | NonNullable<VariantProps<typeof toggleVariants>["variant"]>
+  | "card";
 
 const ToggleGroupContext = React.createContext<{
   size?: VariantProps<typeof toggleVariants>["size"];
   variant?: ToggleGroupVariant;
-}>({
-  size: "default",
-  variant: "default",
-});
+}>({});
 
 function ToggleGroup({
   className,
@@ -56,8 +55,8 @@ function ToggleGroupItem({
     variant?: ToggleGroupVariant;
   }) {
   const context = React.useContext(ToggleGroupContext);
-  const resolvedVariant = context.variant || variant;
-  const resolvedSize = context.size || size;
+  const resolvedVariant = context.variant ?? variant ?? "default";
+  const resolvedSize = context.size ?? size ?? "default";
 
   return (
     <ToggleGroupPrimitive.Item
@@ -70,7 +69,9 @@ function ToggleGroupItem({
           : cn(
               toggleVariants({
                 size: resolvedSize,
-                variant: resolvedVariant as VariantProps<typeof toggleVariants>["variant"],
+                variant: resolvedVariant as VariantProps<
+                  typeof toggleVariants
+                >["variant"],
               }),
               "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
             ),

--- a/src/frontend/src/components/ui/toggle-group.tsx
+++ b/src/frontend/src/components/ui/toggle-group.tsx
@@ -5,9 +5,7 @@ import { type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 import { toggleVariants } from "@/components/ui/toggle-variants";
 
-type ToggleGroupVariant =
-  | NonNullable<VariantProps<typeof toggleVariants>["variant"]>
-  | "card";
+type ToggleGroupVariant = NonNullable<VariantProps<typeof toggleVariants>["variant"]> | "card";
 
 const ToggleGroupContext = React.createContext<{
   size?: VariantProps<typeof toggleVariants>["size"];
@@ -69,9 +67,7 @@ function ToggleGroupItem({
           : cn(
               toggleVariants({
                 size: resolvedSize,
-                variant: resolvedVariant as VariantProps<
-                  typeof toggleVariants
-                >["variant"],
+                variant: resolvedVariant as VariantProps<typeof toggleVariants>["variant"],
               }),
               "min-w-0 flex-1 shrink-0 rounded-none shadow-none first:rounded-l-md last:rounded-r-md focus:z-10 focus-visible:z-10 data-[variant=outline]:border-l-0 data-[variant=outline]:first:border-l",
             ),


### PR DESCRIPTION
## Summary
- reorganize frontend UI primitives and prompt input components around a cleaner shadcn-style component tree
- update workspace shell, composer, transcript, inspector, and assistant-content flows to use the refactored structure
- refresh related auth, runtime, websocket, and navigation integrations to match the new component boundaries
- expand and adjust frontend tests for the updated workspace and UI behavior

## Testing
- Not run (not requested)