### PR TITLE
Introduce Phase 1 worker boundary for workspace task execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
-- The notes below summarize the current branch delta on top of `0.4.99`.
+- No unreleased changes yet.
+
+## [0.5.0] - 2026-04-10
 
 ### Highlights (User Impact)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -59,3 +59,7 @@
   * [fleet-rlm Concepts](explanation/concepts.md)
   * [User Interaction Flows](explanation/user-flows.md)
   * [Component UML](explanation/component-uml.md)
+
+## Notes
+
+* [Phase 1: Worker Boundary Extraction](notes/phase-1-worker-boundary.md)

--- a/docs/notes/phase-1-worker-boundary.md
+++ b/docs/notes/phase-1-worker-boundary.md
@@ -1,0 +1,38 @@
+# Phase 1: worker boundary extraction
+
+## What changed
+
+A new internal worker package now defines a stable boundary for running **one workspace task** from Python without depending on FastAPI or websocket transport types:
+
+- `fleet_rlm.worker.contracts`
+  - `WorkspaceTaskRequest`
+  - `WorkspaceTaskResult`
+  - `WorkspaceEvent`
+- `fleet_rlm.worker.streaming`
+  - `stream_workspace_task(request)`
+- `fleet_rlm.worker.runner`
+  - `run_workspace_task(request)`
+- `fleet_rlm.worker.adapters`
+  - normalization/mapping between runtime `StreamEvent` and `WorkspaceEvent`
+
+## What modules it adapts
+
+The worker boundary is an adapter over the existing chat runtime stream path:
+
+- runtime event model: `fleet_rlm.runtime.models.StreamEvent`
+- canonical stream source: `agent.aiter_chat_turn_stream(...)`
+- websocket stream loop now calls `stream_workspace_task(...)` and maps worker events back to existing websocket handling.
+
+## What was intentionally not changed
+
+- No frontend protocol changes.
+- No FastAPI/websocket route redesign.
+- No changes to DSPy recursive core behavior.
+- No Daytona internals rewrite.
+- No movement of `runtime/content`, `runtime/tools`, `runtime/quality`, or `integrations/daytona` ownership.
+
+## Suggested Phase 2 direction
+
+- Move websocket/HTTP orchestration to call worker request construction directly.
+- Keep transport concerns (auth/session/socket) in API routers, but push task execution decisions behind worker calls.
+- Expand worker contracts for additional task modes only after preserving existing behavior through parity tests.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.4.99
+  version: 0.5.0
 paths:
   /health:
     get:
@@ -614,7 +614,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.4.99
+          default: 0.5.0
       type: object
       title: HealthResponse
       description: Response body for the lightweight health endpoint.

--- a/src/fleet_rlm/api/routers/ws/completion.py
+++ b/src/fleet_rlm/api/routers/ws/completion.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fleet_rlm.runtime.models import StreamEvent
+from .types import StreamEventLike
 
 
 def _as_record(value: Any) -> dict[str, Any]:
@@ -38,7 +38,7 @@ def _canonical_run_status(kind: str, payload: dict[str, Any]) -> str:
     return "error"
 
 
-def _build_fallback_final_artifact(event: StreamEvent) -> dict[str, Any] | None:
+def _build_fallback_final_artifact(event: StreamEventLike) -> dict[str, Any] | None:
     if event.kind != "final":
         return None
     return {
@@ -54,7 +54,7 @@ def _build_fallback_final_artifact(event: StreamEvent) -> dict[str, Any] | None:
 
 def _build_minimum_summary(
     *,
-    event: StreamEvent,
+    event: StreamEventLike,
     summary_payload: dict[str, Any],
     warnings: list[Any],
 ) -> dict[str, Any]:
@@ -69,7 +69,7 @@ def _build_minimum_summary(
 
 def build_execution_completion_summary(
     *,
-    event: StreamEvent,
+    event: StreamEventLike,
     request_message: str,
     run_id: str,
 ) -> dict[str, Any]:

--- a/src/fleet_rlm/api/routers/ws/stream.py
+++ b/src/fleet_rlm/api/routers/ws/stream.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -18,7 +18,7 @@ from fleet_rlm.integrations.observability.trace_context import (
     runtime_telemetry_enabled_context,
 )
 from fleet_rlm.runtime.execution.streaming import is_terminal_stream_event_kind
-from fleet_rlm.runtime.models import StreamEvent
+from fleet_rlm.worker import WorkspaceEvent, WorkspaceTaskRequest, stream_workspace_task
 
 from ...dependencies import ServerState
 from ...events import ExecutionEventEmitter, ExecutionStep, ExecutionStepBuilder
@@ -288,20 +288,22 @@ async def _stream_agent_events(
     analytics_enabled: bool | None,
     persist_session_state: LocalPersistFn,
 ) -> None:
-    with runtime_telemetry_enabled_context(analytics_enabled):
-        event_stream = agent.aiter_chat_turn_stream(
-            message=message,
-            trace=trace,
-            cancel_check=cancel_check,
-            docs_path=docs_path,
-        )
+    worker_request = WorkspaceTaskRequest(
+        agent=agent,
+        message=message,
+        trace=trace,
+        docs_path=docs_path,
+        cancel_check=cancel_check,
+        execution_mode=getattr(agent, "execution_mode", None),
+    )
 
-        async for event in event_stream:
+    with runtime_telemetry_enabled_context(analytics_enabled):
+        async for worker_event in stream_workspace_task(worker_request):
             await _emit_stream_event(
                 websocket=websocket,
                 lifecycle=lifecycle,
                 step_builder=step_builder,
-                event=event,
+                event=worker_event,
                 persist_session_state=persist_session_state,
                 request_message=request_message,
             )
@@ -316,7 +318,7 @@ async def _emit_stream_event(
     websocket: WebSocket,
     lifecycle: ExecutionLifecycleManager,
     step_builder: ExecutionStepBuilder,
-    event: StreamEvent,
+    event: WorkspaceEvent,
     persist_session_state: LocalPersistFn,
     request_message: str,
 ) -> None:
@@ -330,17 +332,18 @@ async def _emit_stream_event(
                 payload if isinstance(payload, dict) else None
             ),
         )
-    event_dict = build_stream_event_dict(event=event, payload=payload)
+    event_dict = build_stream_event_dict(event=cast(Any, event), payload=payload)
     is_terminal_event = is_terminal_stream_event_kind(event.kind)
     if not is_terminal_event:
         if not await _try_send_json(websocket, {"type": "event", "data": event_dict}):
             raise WebSocketDisconnect(code=1001)
 
+    event_timestamp = event.timestamp.timestamp() if event.timestamp else 0.0
     step = step_builder.from_stream_event(
         kind=event.kind,
         text=event.text,
         payload=payload,
-        timestamp=event.timestamp.timestamp(),
+        timestamp=event_timestamp,
     )
     if step is not None:
         await lifecycle.emit_step(step)
@@ -351,7 +354,7 @@ async def _emit_stream_event(
         await handle_terminal_stream_event(
             websocket=websocket,
             lifecycle=lifecycle,
-            event=event,
+            event=cast(Any, event),
             event_dict=event_dict,
             step=step,
             persist_session_state=persist_session_state,

--- a/src/fleet_rlm/api/routers/ws/stream.py
+++ b/src/fleet_rlm/api/routers/ws/stream.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -332,7 +332,7 @@ async def _emit_stream_event(
                 payload if isinstance(payload, dict) else None
             ),
         )
-    event_dict = build_stream_event_dict(event=cast(Any, event), payload=payload)
+    event_dict = build_stream_event_dict(event=event, payload=payload)
     is_terminal_event = is_terminal_stream_event_kind(event.kind)
     if not is_terminal_event:
         if not await _try_send_json(websocket, {"type": "event", "data": event_dict}):
@@ -354,7 +354,7 @@ async def _emit_stream_event(
         await handle_terminal_stream_event(
             websocket=websocket,
             lifecycle=lifecycle,
-            event=cast(Any, event),
+            event=event,
             event_dict=event_dict,
             step=step,
             persist_session_state=persist_session_state,

--- a/src/fleet_rlm/api/routers/ws/stream.py
+++ b/src/fleet_rlm/api/routers/ws/stream.py
@@ -338,7 +338,7 @@ async def _emit_stream_event(
         if not await _try_send_json(websocket, {"type": "event", "data": event_dict}):
             raise WebSocketDisconnect(code=1001)
 
-    event_timestamp = event.timestamp.timestamp() if event.timestamp else 0.0
+    event_timestamp = event.timestamp.timestamp()
     step = step_builder.from_stream_event(
         kind=event.kind,
         text=event.text,

--- a/src/fleet_rlm/api/routers/ws/terminal.py
+++ b/src/fleet_rlm/api/routers/ws/terminal.py
@@ -9,25 +9,24 @@ from typing import Any
 from fastapi import WebSocket, WebSocketDisconnect
 
 from fleet_rlm.integrations.database import RunStatus
-from fleet_rlm.runtime.models import StreamEvent
 
 from ...events import ExecutionStep
 from .completion import final_event_failed, build_execution_completion_summary
 from .helpers import _try_send_json
 from .lifecycle import ExecutionLifecycleManager
-from .types import LocalPersistFn
+from .types import LocalPersistFn, StreamEventLike
 
 logger = logging.getLogger(__name__)
 
 
-def _final_run_status(event: StreamEvent) -> RunStatus:
+def _final_run_status(event: StreamEventLike) -> RunStatus:
     payload = event.payload if isinstance(event.payload, dict) else {}
     return RunStatus.FAILED if final_event_failed(payload) else RunStatus.COMPLETED
 
 
 def build_stream_event_dict(
     *,
-    event: StreamEvent,
+    event: StreamEventLike,
     payload: Any,
 ) -> dict[str, Any]:
     """Serialize one stream event for websocket delivery."""
@@ -45,7 +44,7 @@ async def handle_terminal_stream_event(
     *,
     websocket: WebSocket,
     lifecycle: ExecutionLifecycleManager,
-    event: StreamEvent,
+    event: StreamEventLike,
     event_dict: dict[str, Any],
     step: ExecutionStep | None,
     persist_session_state: LocalPersistFn,

--- a/src/fleet_rlm/api/routers/ws/types.py
+++ b/src/fleet_rlm/api/routers/ws/types.py
@@ -31,7 +31,8 @@ class StreamEventLike(Protocol):
     def text(self) -> str: ...
 
     @property
-    def payload(self) -> dict[str, Any]: ...
+    def payload(self) -> dict[str, Any]:
+        raise NotImplementedError
 
     @property
     def timestamp(self) -> datetime:

--- a/src/fleet_rlm/api/routers/ws/types.py
+++ b/src/fleet_rlm/api/routers/ws/types.py
@@ -25,7 +25,8 @@ class StreamEventLike(Protocol):
     """
 
     @property
-    def kind(self) -> str: ...
+    def kind(self) -> str:
+        raise NotImplementedError
 
     @property
     def text(self) -> str: ...

--- a/src/fleet_rlm/api/routers/ws/types.py
+++ b/src/fleet_rlm/api/routers/ws/types.py
@@ -34,7 +34,8 @@ class StreamEventLike(Protocol):
     def payload(self) -> dict[str, Any]: ...
 
     @property
-    def timestamp(self) -> datetime: ...
+    def timestamp(self) -> datetime:
+        raise NotImplementedError
 
 
 class MaintenanceInterpreterProtocol(Protocol):

--- a/src/fleet_rlm/api/routers/ws/types.py
+++ b/src/fleet_rlm/api/routers/ws/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import AbstractContextManager
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Protocol
 
 from fleet_rlm.runtime.models import StreamEvent
@@ -13,6 +14,27 @@ from ...schemas import WSMessage
 
 LocalPersistFn = Callable[..., Awaitable[None]]
 PreStreamSetupFn = Callable[[], Awaitable[None]]
+
+
+class StreamEventLike(Protocol):
+    """Minimal stream-event surface required by WS terminal/completion helpers.
+
+    Both ``StreamEvent`` (runtime model) and ``WorkspaceEvent`` (worker
+    contract) satisfy this protocol, so the helpers in ``terminal.py`` and
+    ``completion.py`` can accept either without unsafe casts.
+    """
+
+    @property
+    def kind(self) -> str: ...
+
+    @property
+    def text(self) -> str: ...
+
+    @property
+    def payload(self) -> dict[str, Any]: ...
+
+    @property
+    def timestamp(self) -> datetime: ...
 
 
 class MaintenanceInterpreterProtocol(Protocol):

--- a/src/fleet_rlm/worker/__init__.py
+++ b/src/fleet_rlm/worker/__init__.py
@@ -1,0 +1,13 @@
+"""Internal worker boundary for running one workspace task."""
+
+from .contracts import WorkspaceEvent, WorkspaceTaskRequest, WorkspaceTaskResult
+from .runner import run_workspace_task
+from .streaming import stream_workspace_task
+
+__all__ = [
+    "WorkspaceEvent",
+    "WorkspaceTaskRequest",
+    "WorkspaceTaskResult",
+    "run_workspace_task",
+    "stream_workspace_task",
+]

--- a/src/fleet_rlm/worker/adapters.py
+++ b/src/fleet_rlm/worker/adapters.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from .contracts import WorkspaceEvent, WorkspaceTaskRequest, WorkspaceTaskStatus
+from fleet_rlm.runtime.execution.streaming import is_terminal_stream_event_kind
 
-_TERMINAL_EVENT_KINDS = frozenset({"final", "cancelled", "error"})
+from .contracts import WorkspaceEvent, WorkspaceTaskRequest, WorkspaceTaskStatus
 
 
 def build_agent_stream_kwargs(request: WorkspaceTaskRequest) -> dict[str, Any]:
@@ -42,7 +42,7 @@ def to_workspace_event(event: Any) -> WorkspaceEvent:
         text=str(getattr(event, "text", "") or ""),
         payload=dict(getattr(event, "payload", {}) or {}),
         timestamp=timestamp,
-        terminal=str(getattr(event, "kind", "")) in _TERMINAL_EVENT_KINDS,
+        terminal=is_terminal_stream_event_kind(str(getattr(event, "kind", ""))),
     )
 
 

--- a/src/fleet_rlm/worker/adapters.py
+++ b/src/fleet_rlm/worker/adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 from .contracts import WorkspaceEvent, WorkspaceTaskRequest, WorkspaceTaskStatus
@@ -28,11 +29,13 @@ def build_agent_stream_kwargs(request: WorkspaceTaskRequest) -> dict[str, Any]:
 def to_workspace_event(event: Any) -> WorkspaceEvent:
     """Normalize a runtime-style stream event into a worker event."""
 
+    raw_ts = getattr(event, "timestamp", None)
+    timestamp = raw_ts if isinstance(raw_ts, datetime) else datetime.now(timezone.utc)
     return WorkspaceEvent(
         kind=str(getattr(event, "kind", "status")),
         text=str(getattr(event, "text", "") or ""),
         payload=dict(getattr(event, "payload", {}) or {}),
-        timestamp=getattr(event, "timestamp", None),
+        timestamp=timestamp,
         terminal=str(getattr(event, "kind", "")) in _TERMINAL_EVENT_KINDS,
     )
 

--- a/src/fleet_rlm/worker/adapters.py
+++ b/src/fleet_rlm/worker/adapters.py
@@ -1,0 +1,45 @@
+"""Adapters that map runtime stream payloads into worker contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import WorkspaceEvent, WorkspaceTaskRequest, WorkspaceTaskStatus
+
+_TERMINAL_EVENT_KINDS = frozenset({"final", "cancelled", "error"})
+
+
+def build_agent_stream_kwargs(request: WorkspaceTaskRequest) -> dict[str, Any]:
+    """Build canonical runtime stream kwargs from a worker request."""
+
+    return {
+        "message": request.message,
+        "trace": request.trace,
+        "cancel_check": request.cancel_check,
+        "docs_path": request.docs_path,
+        "repo_url": request.repo_url,
+        "repo_ref": request.repo_ref,
+        "context_paths": list(request.context_paths),
+        "batch_concurrency": request.batch_concurrency,
+        "volume_name": request.workspace_id,
+    }
+
+
+def to_workspace_event(event: Any) -> WorkspaceEvent:
+    """Normalize a runtime-style stream event into a worker event."""
+
+    return WorkspaceEvent(
+        kind=str(getattr(event, "kind", "status")),
+        text=str(getattr(event, "text", "") or ""),
+        payload=dict(getattr(event, "payload", {}) or {}),
+        timestamp=getattr(event, "timestamp", None),
+        terminal=str(getattr(event, "kind", "")) in _TERMINAL_EVENT_KINDS,
+    )
+
+
+def status_from_terminal_kind(kind: str) -> WorkspaceTaskStatus:
+    if kind == "final":
+        return "completed"
+    if kind == "cancelled":
+        return "cancelled"
+    return "error"

--- a/src/fleet_rlm/worker/adapters.py
+++ b/src/fleet_rlm/worker/adapters.py
@@ -13,17 +13,23 @@ _TERMINAL_EVENT_KINDS = frozenset({"final", "cancelled", "error"})
 def build_agent_stream_kwargs(request: WorkspaceTaskRequest) -> dict[str, Any]:
     """Build canonical runtime stream kwargs from a worker request."""
 
-    return {
+    kwargs: dict[str, Any] = {
         "message": request.message,
         "trace": request.trace,
         "cancel_check": request.cancel_check,
         "docs_path": request.docs_path,
-        "repo_url": request.repo_url,
-        "repo_ref": request.repo_ref,
-        "context_paths": list(request.context_paths),
-        "batch_concurrency": request.batch_concurrency,
-        "volume_name": request.workspace_id,
     }
+    if request.repo_url is not None:
+        kwargs["repo_url"] = request.repo_url
+    if request.repo_ref is not None:
+        kwargs["repo_ref"] = request.repo_ref
+    if request.context_paths is not None:
+        kwargs["context_paths"] = list(request.context_paths)
+    if request.batch_concurrency is not None:
+        kwargs["batch_concurrency"] = request.batch_concurrency
+    if request.workspace_id is not None:
+        kwargs["volume_name"] = request.workspace_id
+    return kwargs
 
 
 def to_workspace_event(event: Any) -> WorkspaceEvent:

--- a/src/fleet_rlm/worker/contracts.py
+++ b/src/fleet_rlm/worker/contracts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Literal, Protocol
 
 WorkspaceTaskStatus = Literal["completed", "cancelled", "error"]
@@ -55,7 +55,7 @@ class WorkspaceEvent:
     kind: str
     text: str = ""
     payload: dict[str, Any] = field(default_factory=dict)
-    timestamp: datetime | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     terminal: bool = False
 
 

--- a/src/fleet_rlm/worker/contracts.py
+++ b/src/fleet_rlm/worker/contracts.py
@@ -13,7 +13,8 @@ WorkspaceTaskStatus = Literal["completed", "cancelled", "error"]
 class WorkspaceTaskAgent(Protocol):
     """Minimal runtime agent surface required by the worker boundary."""
 
-    def set_execution_mode(self, execution_mode: str) -> None: ...
+    def set_execution_mode(self, execution_mode: str) -> None:
+        raise NotImplementedError
 
     def aiter_chat_turn_stream(
         self,
@@ -27,7 +28,8 @@ class WorkspaceTaskAgent(Protocol):
         context_paths: list[str] | None = None,
         batch_concurrency: int | None = None,
         volume_name: str | None = None,
-    ) -> AsyncIterator[object]: ...
+    ) -> AsyncIterator[object]:
+        raise NotImplementedError
 
 
 @dataclass(slots=True)

--- a/src/fleet_rlm/worker/contracts.py
+++ b/src/fleet_rlm/worker/contracts.py
@@ -1,0 +1,70 @@
+"""Transport-agnostic contracts for running a single workspace task."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, Protocol
+
+WorkspaceTaskStatus = Literal["completed", "cancelled", "error"]
+
+
+class WorkspaceTaskAgent(Protocol):
+    """Minimal runtime agent surface required by the worker boundary."""
+
+    def set_execution_mode(self, execution_mode: str) -> None: ...
+
+    def aiter_chat_turn_stream(
+        self,
+        message: str,
+        trace: bool = True,
+        cancel_check: Callable[[], bool] | None = None,
+        *,
+        docs_path: str | None = None,
+        repo_url: str | None = None,
+        repo_ref: str | None = None,
+        context_paths: list[str] | None = None,
+        batch_concurrency: int | None = None,
+        volume_name: str | None = None,
+    ) -> AsyncIterator[object]: ...
+
+
+@dataclass(slots=True)
+class WorkspaceTaskRequest:
+    """Input needed to execute one workspace task end-to-end."""
+
+    agent: WorkspaceTaskAgent
+    message: str
+    execution_mode: str | None = None
+    trace: bool = True
+    docs_path: str | None = None
+    repo_url: str | None = None
+    repo_ref: str | None = None
+    context_paths: list[str] = field(default_factory=list)
+    batch_concurrency: int | None = None
+    workspace_id: str | None = None
+    cancel_check: Callable[[], bool] | None = None
+    prepare: Callable[[], Awaitable[None]] | None = None
+
+
+@dataclass(slots=True)
+class WorkspaceEvent:
+    """Normalized worker event shape for streaming and collection."""
+
+    kind: str
+    text: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime | None = None
+    terminal: bool = False
+
+
+@dataclass(slots=True)
+class WorkspaceTaskResult:
+    """Collected result for one completed workspace task."""
+
+    status: WorkspaceTaskStatus
+    terminal_event: WorkspaceEvent
+    output_text: str
+    payload: dict[str, Any]
+    events: list[WorkspaceEvent] = field(default_factory=list)

--- a/src/fleet_rlm/worker/contracts.py
+++ b/src/fleet_rlm/worker/contracts.py
@@ -13,8 +13,7 @@ WorkspaceTaskStatus = Literal["completed", "cancelled", "error"]
 class WorkspaceTaskAgent(Protocol):
     """Minimal runtime agent surface required by the worker boundary."""
 
-    def set_execution_mode(self, execution_mode: str) -> None:
-        raise NotImplementedError
+    def set_execution_mode(self, execution_mode: str) -> None: ...
 
     def aiter_chat_turn_stream(
         self,
@@ -28,8 +27,7 @@ class WorkspaceTaskAgent(Protocol):
         context_paths: list[str] | None = None,
         batch_concurrency: int | None = None,
         volume_name: str | None = None,
-    ) -> AsyncIterator[object]:
-        raise NotImplementedError
+    ) -> AsyncIterator[object]: ...
 
 
 @dataclass(slots=True)

--- a/src/fleet_rlm/worker/contracts.py
+++ b/src/fleet_rlm/worker/contracts.py
@@ -41,7 +41,7 @@ class WorkspaceTaskRequest:
     docs_path: str | None = None
     repo_url: str | None = None
     repo_ref: str | None = None
-    context_paths: list[str] = field(default_factory=list)
+    context_paths: list[str] | None = None
     batch_concurrency: int | None = None
     workspace_id: str | None = None
     cancel_check: Callable[[], bool] | None = None

--- a/src/fleet_rlm/worker/runner.py
+++ b/src/fleet_rlm/worker/runner.py
@@ -1,0 +1,31 @@
+"""Non-streaming runner entrypoint for the workspace-task worker boundary."""
+
+from __future__ import annotations
+
+from .adapters import status_from_terminal_kind
+from .contracts import WorkspaceEvent, WorkspaceTaskRequest, WorkspaceTaskResult
+from .streaming import stream_workspace_task
+
+
+async def run_workspace_task(request: WorkspaceTaskRequest) -> WorkspaceTaskResult:
+    """Execute one workspace task and collect a terminal result."""
+
+    events: list[WorkspaceEvent] = []
+    terminal_event: WorkspaceEvent | None = None
+
+    async for event in stream_workspace_task(request):
+        events.append(event)
+        if event.terminal:
+            terminal_event = event
+            break
+
+    if terminal_event is None:
+        raise RuntimeError("Workspace task stream ended without a terminal event")
+
+    return WorkspaceTaskResult(
+        status=status_from_terminal_kind(terminal_event.kind),
+        terminal_event=terminal_event,
+        output_text=terminal_event.text,
+        payload=dict(terminal_event.payload or {}),
+        events=events,
+    )

--- a/src/fleet_rlm/worker/streaming.py
+++ b/src/fleet_rlm/worker/streaming.py
@@ -1,0 +1,24 @@
+"""Streaming entrypoint for the workspace-task worker boundary."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from .adapters import build_agent_stream_kwargs, to_workspace_event
+from .contracts import WorkspaceEvent, WorkspaceTaskRequest
+
+
+async def stream_workspace_task(
+    request: WorkspaceTaskRequest,
+) -> AsyncIterator[WorkspaceEvent]:
+    """Stream one workspace task through the canonical runtime agent."""
+
+    if request.execution_mode is not None:
+        request.agent.set_execution_mode(request.execution_mode)
+    if request.prepare is not None:
+        await request.prepare()
+
+    async for runtime_event in request.agent.aiter_chat_turn_stream(
+        **build_agent_stream_kwargs(request)
+    ):
+        yield to_workspace_event(runtime_event)

--- a/src/frontend/openapi/fleet-rlm.openapi.yaml
+++ b/src/frontend/openapi/fleet-rlm.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.4.99
+  version: 0.5.0
 paths:
   /health:
     get:
@@ -614,7 +614,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.4.99
+          default: 0.5.0
       type: object
       title: HealthResponse
       description: Response body for the lightweight health endpoint.

--- a/src/frontend/src/lib/rlm-api/__tests__/config.test.ts
+++ b/src/frontend/src/lib/rlm-api/__tests__/config.test.ts
@@ -24,9 +24,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("ws://custom-host:9000/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "ws://custom-host:9000/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("ws://custom-host:9000/api/v1/ws/execution/events");
   });
 
   it("rewrites the legacy explicit chat websocket URL to execution", async () => {
@@ -35,9 +33,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("ws://custom-host:9000/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "ws://custom-host:9000/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("ws://custom-host:9000/api/v1/ws/execution/events");
   });
 
   it("rewrites a legacy explicit chat websocket suffix even when the URL is malformed", async () => {
@@ -46,9 +42,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("custom-host/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "custom-host/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("custom-host/api/v1/ws/execution/events");
   });
 
   it("leaves a malformed explicit websocket URL unchanged when it is not legacy chat", async () => {
@@ -67,9 +61,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("ws://localhost:8000/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "ws://localhost:8000/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("ws://localhost:8000/api/v1/ws/execution/events");
   });
 
   it("maps https:// to wss:// when deriving from VITE_FLEET_API_URL", async () => {
@@ -78,9 +70,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("wss://api.example.com/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "wss://api.example.com/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("wss://api.example.com/api/v1/ws/execution/events");
   });
 
   it("always sets the path to /api/v1/ws/execution when deriving from API URL", async () => {
@@ -89,9 +79,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("ws://localhost:8000/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "ws://localhost:8000/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("ws://localhost:8000/api/v1/ws/execution/events");
   });
 
   // ── VITE_FLEET_WS_URL takes precedence ──────────────────────────────────────
@@ -101,9 +89,7 @@ describe("rlmApiConfig — wsUrl derivation", () => {
 
     const { rlmApiConfig } = await loadRlmApiConfigModule();
     expect(rlmApiConfig.wsUrl).toBe("ws://explicit:1234/api/v1/ws/execution");
-    expect(rlmApiConfig.wsExecutionUrl).toBe(
-      "ws://explicit:1234/api/v1/ws/execution/events",
-    );
+    expect(rlmApiConfig.wsExecutionUrl).toBe("ws://explicit:1234/api/v1/ws/execution/events");
   });
 
   // ── other config fields ──────────────────────────────────────────────────────

--- a/src/frontend/src/lib/rlm-api/config.ts
+++ b/src/frontend/src/lib/rlm-api/config.ts
@@ -32,10 +32,7 @@ function normalizeExplicitWsUrl(wsUrl: string, path: string): string {
   try {
     const url = new URL(normalized);
     if (/\/api\/v1\/ws\/(?:chat|execution(?:\/events)?)$/.test(url.pathname)) {
-      url.pathname = url.pathname.replace(
-        /\/api\/v1\/ws\/(?:chat|execution(?:\/events)?)$/,
-        path,
-      );
+      url.pathname = url.pathname.replace(/\/api\/v1\/ws\/(?:chat|execution(?:\/events)?)$/, path);
       return url.toString().replace(/\/$/, "");
     }
   } catch {

--- a/src/frontend/src/lib/rlm-api/generated/openapi.ts
+++ b/src/frontend/src/lib/rlm-api/generated/openapi.ts
@@ -272,7 +272,7 @@ export interface components {
       /**
        * Version
        * @description Package version currently serving the API.
-       * @default 0.4.99
+       * @default 0.5.0
        */
       version?: string;
     };

--- a/tests/unit/worker/test_worker_boundary.py
+++ b/tests/unit/worker/test_worker_boundary.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import ast
+import asyncio
+import importlib
+from pathlib import Path
+
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
-
-import asyncio
 
 from fleet_rlm.worker import (
     WorkspaceTaskRequest,
@@ -64,14 +67,21 @@ class _FakeAgent:
 
 
 def test_worker_contracts_do_not_import_transport_types() -> None:
-    contracts_source = __import__(
-        "fleet_rlm.worker.contracts", fromlist=["__name__"]
-    ).__file__
+    module = importlib.import_module("fleet_rlm.worker.contracts")
+    contracts_source = module.__file__
     assert contracts_source is not None
-    with open(contracts_source, encoding="utf-8") as handle:
-        content = handle.read()
-    assert "fastapi" not in content
-    assert "WebSocket" not in content
+
+    tree = ast.parse(Path(contracts_source).read_text(encoding="utf-8"))
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imported_modules.add(node.module)
+
+    assert all(
+        not name.startswith(("fastapi", "starlette")) for name in imported_modules
+    )
 
 
 def test_run_workspace_task_executes_end_to_end() -> None:

--- a/tests/unit/worker/test_worker_boundary.py
+++ b/tests/unit/worker/test_worker_boundary.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import ast
 import asyncio
 import importlib
-from pathlib import Path
-
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from fleet_rlm.worker import (
@@ -79,8 +78,11 @@ def test_worker_contracts_do_not_import_transport_types() -> None:
         elif isinstance(node, ast.ImportFrom) and node.module is not None:
             imported_modules.add(node.module)
 
-    assert all(
-        not name.startswith(("fastapi", "starlette")) for name in imported_modules
+    forbidden_imports = sorted(
+        name for name in imported_modules if name.startswith(("fastapi", "starlette"))
+    )
+    assert not forbidden_imports, (
+        f"Found forbidden transport imports in worker contracts: {forbidden_imports}"
     )
 
 

--- a/tests/unit/worker/test_worker_boundary.py
+++ b/tests/unit/worker/test_worker_boundary.py
@@ -118,3 +118,26 @@ def test_stream_workspace_task_yields_normalized_workspace_events() -> None:
 
     assert [event.kind for event in events] == ["status", "final"]
     assert events[-1].terminal is True
+    assert agent.stream_calls[0]["context_paths"] is None
+
+
+def test_stream_workspace_task_preserves_unspecified_optional_overrides() -> None:
+    agent = _FakeAgent()
+    request = WorkspaceTaskRequest(agent=agent, message="hello")
+
+    async def _collect() -> None:
+        async for _event in stream_workspace_task(request):
+            pass
+
+    asyncio.run(_collect())
+
+    assert agent.stream_calls[0] == {
+        "message": "hello",
+        "trace": True,
+        "docs_path": None,
+        "repo_url": None,
+        "repo_ref": None,
+        "context_paths": None,
+        "batch_concurrency": None,
+        "volume_name": None,
+    }

--- a/tests/unit/worker/test_worker_boundary.py
+++ b/tests/unit/worker/test_worker_boundary.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncio
+
+from fleet_rlm.worker import (
+    WorkspaceTaskRequest,
+    run_workspace_task,
+    stream_workspace_task,
+)
+
+
+@dataclass(slots=True)
+class _FakeRuntimeEvent:
+    kind: str
+    text: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.execution_mode: str | None = None
+        self.stream_calls: list[dict[str, object]] = []
+
+    def set_execution_mode(self, execution_mode: str) -> None:
+        self.execution_mode = execution_mode
+
+    async def aiter_chat_turn_stream(
+        self,
+        message: str,
+        trace: bool = True,
+        cancel_check=None,
+        *,
+        docs_path: str | None = None,
+        repo_url: str | None = None,
+        repo_ref: str | None = None,
+        context_paths: list[str] | None = None,
+        batch_concurrency: int | None = None,
+        volume_name: str | None = None,
+    ) -> AsyncIterator[object]:
+        self.stream_calls.append(
+            {
+                "message": message,
+                "trace": trace,
+                "docs_path": docs_path,
+                "repo_url": repo_url,
+                "repo_ref": repo_ref,
+                "context_paths": context_paths,
+                "batch_concurrency": batch_concurrency,
+                "volume_name": volume_name,
+            }
+        )
+        yield _FakeRuntimeEvent(kind="status", text="running")
+        yield _FakeRuntimeEvent(
+            kind="final",
+            text="done",
+            payload={"run_result": {"status": "completed"}},
+        )
+
+
+def test_worker_contracts_do_not_import_transport_types() -> None:
+    contracts_source = __import__(
+        "fleet_rlm.worker.contracts", fromlist=["__name__"]
+    ).__file__
+    assert contracts_source is not None
+    with open(contracts_source, encoding="utf-8") as handle:
+        content = handle.read()
+    assert "fastapi" not in content
+    assert "WebSocket" not in content
+
+
+def test_run_workspace_task_executes_end_to_end() -> None:
+    agent = _FakeAgent()
+    prepared = False
+
+    async def _prepare() -> None:
+        nonlocal prepared
+        prepared = True
+
+    request = WorkspaceTaskRequest(
+        agent=agent,
+        message="Investigate the repository",
+        execution_mode="tools_only",
+        trace=True,
+        docs_path="docs/readme.md",
+        workspace_id="ws-1",
+        repo_url="https://example.invalid/repo.git",
+        repo_ref="main",
+        context_paths=["src"],
+        batch_concurrency=2,
+        prepare=_prepare,
+    )
+
+    result = asyncio.run(run_workspace_task(request))
+
+    assert prepared is True
+    assert agent.execution_mode == "tools_only"
+    assert result.status == "completed"
+    assert result.output_text == "done"
+    assert result.terminal_event.kind == "final"
+    assert [event.kind for event in result.events] == ["status", "final"]
+    assert agent.stream_calls[0]["volume_name"] == "ws-1"
+
+
+def test_stream_workspace_task_yields_normalized_workspace_events() -> None:
+    agent = _FakeAgent()
+    request = WorkspaceTaskRequest(agent=agent, message="hello")
+
+    async def _collect() -> list[Any]:
+        return [event async for event in stream_workspace_task(request)]
+
+    events = asyncio.run(_collect())
+
+    assert [event.kind for event in events] == ["status", "final"]
+    assert events[-1].terminal is True


### PR DESCRIPTION
## Summary
- add a new internal `fleet_rlm.worker` package with explicit transport-agnostic contracts:
  - `WorkspaceTaskRequest`
  - `WorkspaceTaskResult`
  - `WorkspaceEvent`
- add worker entrypoints:
  - `run_workspace_task(request)` in `worker/runner.py`
  - `stream_workspace_task(request)` in `worker/streaming.py`
- add `worker/adapters.py` to normalize/marshal runtime stream payloads into worker events
- route websocket workspace-task streaming through the new worker boundary (`api/routers/ws/stream.py`) while preserving existing event/lifecycle behavior
- document the phase-1 architecture seam in `docs/notes/phase-1-worker-boundary.md`
- add unit coverage in `tests/unit/worker/test_worker_boundary.py` for Python-callable worker usage, end-to-end run collection, and streaming behavior

## What was intentionally not changed
- no frontend protocol changes
- no FastAPI/websocket API shape redesign
- no DSPy recursive runtime rewrites
- no Daytona internals rewrites
- no movement of runtime/content, runtime/tools, runtime/quality, or integrations/daytona ownership

## Validation
- `make format`
- `make lint`
- `make typecheck`
- `uv run pytest -q tests/unit/worker/test_worker_boundary.py`

## Caveats
- Existing ws unit test modules in this environment currently fail at import time due a Python 3.10 + Pydantic TypedDict compatibility issue in upstream runtime signatures (pre-existing, unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8c52cbbe4832dbd9a1050abd0b136)