### PR TITLE
refactor: decouple agent_host from api/ via SessionStoreProtocol

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,10 @@ requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [dependency-groups]
-dev = ["pytest-timeout>=2.4.0"]
+dev = [
+    "pytest-timeout>=2.4.0",
+    "ty>=0.0.29",
+]
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/fleet_rlm/agent_host/sessions.py
+++ b/src/fleet_rlm/agent_host/sessions.py
@@ -8,13 +8,10 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from fleet_rlm.utils.identity import (
-    owner_fingerprint,
-    sanitize_id as _sanitize_id,
-    session_key,
-)
-
-from ..api.dependencies import ServerState
+from fleet_rlm.utils.identity import owner_fingerprint
+from fleet_rlm.utils.identity import sanitize_id as _sanitize_id
+from fleet_rlm.utils.identity import session_key
+from .types import SessionStoreProtocol
 from .checkpoints import (
     ContinuationCheckpoint,
     OrchestrationCheckpointState,
@@ -320,7 +317,7 @@ def build_orchestration_session_context(
 
 async def switch_orchestration_session(
     *,
-    state: ServerState,
+    state: SessionStoreProtocol,
     agent: ChatAgentProtocol,
     interpreter: object | None,
     workspace_id: str,

--- a/src/fleet_rlm/agent_host/types.py
+++ b/src/fleet_rlm/agent_host/types.py
@@ -1,0 +1,13 @@
+"""Agent host protocols — define the narrow surface the host needs from api/."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import Protocol
+
+
+class SessionStoreProtocol(Protocol):
+    """Minimal session storage surface needed by agent_host/."""
+
+    sessions: dict[str, dict[str, Any]]

--- a/uv.lock
+++ b/uv.lock
@@ -1768,6 +1768,7 @@ server = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest-timeout" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -1842,7 +1843,10 @@ requires-dist = [
 provides-extras = ["dev", "mcp", "server", "full"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest-timeout", specifier = ">=2.4.0" }]
+dev = [
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ty", specifier = ">=0.0.29" },
+]
 
 [[package]]
 name = "fonttools"


### PR DESCRIPTION
## Summary

- Add `fleet_rlm/utils/identity.py` with `sanitize_id`, `owner_fingerprint`, and `session_key` — implementation preserved exactly from `api/server_utils.py` and `api/dependencies.py`
- Add `fleet_rlm/agent_host/types.py` with `SessionStoreProtocol` — a structural protocol requiring only `sessions: dict[str, dict[str, Any]]`
- Update `agent_host/sessions.py` to import from `utils/identity` instead of `api/dependencies` and `api/server_utils`; replace `state: ServerState` parameter type with `state: SessionStoreProtocol`

`ServerState` satisfies `SessionStoreProtocol` structurally, so no callers change.

## Test plan

- [x] `uv run --active python -c "from fleet_rlm.agent_host.sessions import switch_orchestration_session"` — passes, no `api/` import needed
- [x] `uv run pytest tests/unit -q` — 914 passed
- [x] Pre-existing `ty` failure (`fastmcp` unresolved import in `integrations/mcp/server.py`) is unrelated; our new files pass `ty` cleanly
- [x] Pre-existing UI test failures in `test_chat_stream.py` (MLflow metadata) are unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)