### PR TITLE
feat: HITL approval modal overlay with composer block

### DIFF
--- a/src/frontend/src/features/workspace/ui/hitl-approval-modal.tsx
+++ b/src/frontend/src/features/workspace/ui/hitl-approval-modal.tsx
@@ -1,0 +1,80 @@
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ChatMessage } from "@/lib/workspace/workspace-types";
+
+interface HitlApprovalModalProps {
+  message: ChatMessage | null;
+  onResolveHitl: (msgId: string, actionLabel: string) => void;
+}
+
+export function HitlApprovalModal({ message, onResolveHitl }: HitlApprovalModalProps) {
+  const prefersReduced = useReducedMotion();
+  const isVisible = message != null && !message.hitlData?.resolved;
+
+  return (
+    <AnimatePresence>
+      {isVisible && message?.hitlData ? (
+        <motion.div
+          key={message.id}
+          initial={{ opacity: 0, y: prefersReduced ? 0 : 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: prefersReduced ? 0 : 8 }}
+          transition={
+            prefersReduced
+              ? { duration: 0.01 }
+              : { type: "spring", stiffness: 420, damping: 32, mass: 0.8 }
+          }
+          className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex items-end justify-center pb-32 px-4"
+          aria-live="assertive"
+          aria-atomic="true"
+        >
+          {/* Backdrop */}
+          <div className="pointer-events-none absolute inset-0 bg-black/20 backdrop-blur-[2px]" />
+
+          {/* Panel */}
+          <div
+            className="pointer-events-auto relative w-full max-w-md rounded-2xl border border-border-subtle/70 bg-card/95 shadow-2xl shadow-black/20 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Approval required"
+          >
+            {/* Header */}
+            <div className="flex items-center gap-2.5 border-b border-border-subtle/50 px-5 py-3.5">
+              <Loader2 className="size-4 shrink-0 animate-spin text-primary" aria-hidden="true" />
+              <span className="text-xs font-semibold uppercase tracking-widest text-primary">
+                Approval Required
+              </span>
+            </div>
+
+            {/* Question */}
+            <div className="px-5 py-4">
+              <p className="text-sm leading-relaxed text-foreground">{message.hitlData.question}</p>
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center justify-end gap-2 border-t border-border-subtle/50 px-5 py-3.5">
+              {message.hitlData.actions.map((action, index) => (
+                <Button
+                  key={`${message.id}-modal-action-${index}`}
+                  size="sm"
+                  variant={action.variant === "primary" ? "default" : "outline"}
+                  className={cn(
+                    "h-8 px-4 text-sm",
+                    action.variant === "primary" &&
+                      "border-primary bg-primary text-primary-foreground hover:bg-primary/90",
+                  )}
+                  onClick={() => onResolveHitl(message.id, action.label)}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/frontend/src/features/workspace/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/workspace-screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Settings2, TriangleAlert } from "lucide-react";
+import { PanelRight, Settings2, TriangleAlert } from "lucide-react";
 
 import { useTelemetry } from "@/lib/telemetry/use-telemetry";
 import { useAppNavigate } from "@/hooks/use-app-navigate";
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { WorkspaceComposer, type AttachedFile } from "@/features/workspace/ui/workspace-composer";
 import { WorkspaceChatEmptyState } from "@/features/workspace/ui/transcript/workspace-chat-empty-state";
 import { WorkspaceMessageList } from "@/features/workspace/ui/transcript/workspace-message-list";
-import { HitlApprovalModal } from "@/features/workspace/ui/hitl-approval-modal";
+import { SessionSidebar } from "@/features/workspace/ui/session-sidebar";
 import {
   useChatHistoryStore,
   useChatStore,
@@ -130,7 +130,8 @@ export function WorkspaceScreen() {
     sessionRevision,
     requestedConversationId,
     clearRequestedConversation,
-    pendingHitlMessageId,
+    sidebarOpen,
+    toggleSidebar,
   } = useWorkspaceUiStore();
 
   // Chat history
@@ -218,13 +219,8 @@ export function WorkspaceScreen() {
   const runtimeWarningTitle = "Sandbox configuration needed";
   const hasMessages = messages.length > 0;
   const showDesktopLandingState = !isMobile && !hasMessages && phase === "idle" && !isTyping;
-  const hitlPending = pendingHitlMessageId != null;
-  const composerDisabled = isTyping || !backendEnabled || hitlPending;
+  const composerDisabled = isTyping || !backendEnabled;
   const isReceivingResponse = backendEnabled && isTyping;
-  const pendingHitlMessage =
-    pendingHitlMessageId != null
-      ? (messages.find((m) => m.id === pendingHitlMessageId) ?? null)
-      : null;
 
   const composerPlaceholder = getComposerPlaceholder({
     backendEnabled,
@@ -250,111 +246,139 @@ export function WorkspaceScreen() {
 
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
-      <HitlApprovalModal message={pendingHitlMessage} onResolveHitl={resolveHitl} />
-      {showDesktopLandingState ? (
-        <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
-          <div
-            data-slot="workspace-landing-state"
-            className="mx-auto flex w-full max-w-[760px] flex-col items-center gap-5"
+      {/* Context toggle button — fixed to top-right corner of the workspace */}
+      {!isMobile && (
+        <div className="absolute top-2 right-3 z-10">
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "h-7 gap-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground",
+              sidebarOpen && "bg-muted text-foreground",
+            )}
+            onClick={toggleSidebar}
+            aria-pressed={sidebarOpen}
           >
-            <WorkspaceChatEmptyState isMobile={false} onSuggestionClick={setInputValue} />
-
-            {showRuntimeWarning ? (
-              <Alert className="w-full border-amber-500/25 bg-amber-500/5 text-foreground rounded-xl">
-                <TriangleAlert className="text-amber-500" />
-                <AlertTitle className="text-sm font-medium">{runtimeWarningTitle}</AlertTitle>
-                <AlertDescription>
-                  <div className="flex flex-col gap-3 mt-1.5">
-                    <p className="text-sm text-muted-foreground leading-relaxed">
-                      Connect to a Daytona sandbox to enable secure code execution. Your code runs
-                      in an isolated environment with persistent storage.
-                    </p>
-                    {warningGuidance.length > 0 && (
-                      <ul className="text-xs text-muted-foreground/80 space-y-1 pl-4 list-disc">
-                        {warningGuidance.map((msg) => (
-                          <li key={msg}>{msg}</li>
-                        ))}
-                      </ul>
-                    )}
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-fit rounded-lg gap-2"
-                      onClick={handleOpenRuntimeSettings}
-                    >
-                      <Settings2 className="size-3.5" />
-                      Configure Sandbox
-                    </Button>
-                  </div>
-                </AlertDescription>
-              </Alert>
-            ) : null}
-
-            <div
-              data-slot="workspace-landing-composer"
-              className="w-full rounded-3xl p-1.5 shadow-lg shadow-black/[0.03] backdrop-blur-sm transition-shadow hover:shadow-xl hover:shadow-black/[0.05]"
-            >
-              {composer}
-            </div>
-          </div>
+            <PanelRight className="size-3.5" />
+            Context
+          </Button>
         </div>
-      ) : (
-        <>
-          {/* Transcript area */}
-          <div className="flex-1 min-h-0" data-slot="workspace-transcript">
-            <WorkspaceMessageList
-              messages={messages}
-              isTyping={isTyping}
-              isMobile={isMobile}
-              showEmptyState={isMobile}
-              onSuggestionClick={setInputValue}
-              onResolveHitl={resolveHitl}
-              onResolveClarification={resolveClarification}
-            />
-          </div>
+      )}
 
-          {/* Composer footer */}
-          <div data-slot="workspace-composer" className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}>
-            <div className="mx-auto w-full max-w-200">
-              <div className="flex flex-col gap-3">
+      <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+        {/* Main chat column */}
+        <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+          {showDesktopLandingState ? (
+            <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
+              <div
+                data-slot="workspace-landing-state"
+                className="mx-auto flex w-full max-w-[760px] flex-col items-center gap-5"
+              >
+                <WorkspaceChatEmptyState isMobile={false} onSuggestionClick={setInputValue} />
+
                 {showRuntimeWarning ? (
-                  <Alert className="border-amber-500/25 bg-amber-500/5 text-foreground rounded-lg">
-                    <TriangleAlert className="text-amber-500 size-4" />
+                  <Alert className="w-full border-amber-500/25 bg-amber-500/5 text-foreground rounded-xl">
+                    <TriangleAlert className="text-amber-500" />
                     <AlertTitle className="text-sm font-medium">{runtimeWarningTitle}</AlertTitle>
                     <AlertDescription>
-                      <div className="mt-1 flex flex-col gap-3">
-                        <div className="flex items-start justify-between gap-4">
-                          <p className="text-xs text-muted-foreground leading-relaxed">
-                            Connect to a Daytona sandbox to enable secure code execution. Your code
-                            runs in an isolated environment with persistent storage.
-                          </p>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-7 shrink-0 gap-1.5 rounded-lg text-xs"
-                            onClick={handleOpenRuntimeSettings}
-                          >
-                            <Settings2 className="size-3" />
-                            Configure
-                          </Button>
-                        </div>
-                        {warningGuidance.length > 0 ? (
-                          <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground/80">
+                      <div className="flex flex-col gap-3 mt-1.5">
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          Connect to a Daytona sandbox to enable secure code execution. Your code
+                          runs in an isolated environment with persistent storage.
+                        </p>
+                        {warningGuidance.length > 0 && (
+                          <ul className="text-xs text-muted-foreground/80 space-y-1 pl-4 list-disc">
                             {warningGuidance.map((msg) => (
                               <li key={msg}>{msg}</li>
                             ))}
                           </ul>
-                        ) : null}
+                        )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-fit rounded-lg gap-2"
+                          onClick={handleOpenRuntimeSettings}
+                        >
+                          <Settings2 className="size-3.5" />
+                          Configure Sandbox
+                        </Button>
                       </div>
                     </AlertDescription>
                   </Alert>
                 ) : null}
-                <div className="mx-auto w-full max-w-175">{composer}</div>
+
+                <div
+                  data-slot="workspace-landing-composer"
+                  className="w-full rounded-3xl p-1.5 shadow-lg shadow-black/[0.03] backdrop-blur-sm transition-shadow hover:shadow-xl hover:shadow-black/[0.05]"
+                >
+                  {composer}
+                </div>
               </div>
             </div>
-          </div>
-        </>
-      )}
+          ) : (
+            <>
+              {/* Transcript area */}
+              <div className="flex-1 min-h-0" data-slot="workspace-transcript">
+                <WorkspaceMessageList
+                  messages={messages}
+                  isTyping={isTyping}
+                  isMobile={isMobile}
+                  showEmptyState={isMobile}
+                  onSuggestionClick={setInputValue}
+                  onResolveHitl={resolveHitl}
+                  onResolveClarification={resolveClarification}
+                />
+              </div>
+
+              {/* Composer footer */}
+              <div data-slot="workspace-composer" className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}>
+                <div className="mx-auto w-full max-w-200">
+                  <div className="flex flex-col gap-3">
+                    {showRuntimeWarning ? (
+                      <Alert className="border-amber-500/25 bg-amber-500/5 text-foreground rounded-lg">
+                        <TriangleAlert className="text-amber-500 size-4" />
+                        <AlertTitle className="text-sm font-medium">
+                          {runtimeWarningTitle}
+                        </AlertTitle>
+                        <AlertDescription>
+                          <div className="mt-1 flex flex-col gap-3">
+                            <div className="flex items-start justify-between gap-4">
+                              <p className="text-xs text-muted-foreground leading-relaxed">
+                                Connect to a Daytona sandbox to enable secure code execution. Your
+                                code runs in an isolated environment with persistent storage.
+                              </p>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 shrink-0 gap-1.5 rounded-lg text-xs"
+                                onClick={handleOpenRuntimeSettings}
+                              >
+                                <Settings2 className="size-3" />
+                                Configure
+                              </Button>
+                            </div>
+                            {warningGuidance.length > 0 ? (
+                              <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground/80">
+                                {warningGuidance.map((msg) => (
+                                  <li key={msg}>{msg}</li>
+                                ))}
+                              </ul>
+                            ) : null}
+                          </div>
+                        </AlertDescription>
+                      </Alert>
+                    ) : null}
+                    <div className="mx-auto w-full max-w-175">{composer}</div>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Session sidebar */}
+        {sidebarOpen && !isMobile && <SessionSidebar messages={messages} />}
+      </div>
     </div>
   );
 }

--- a/src/frontend/src/features/workspace/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/workspace-screen.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { WorkspaceComposer, type AttachedFile } from "@/features/workspace/ui/workspace-composer";
 import { WorkspaceChatEmptyState } from "@/features/workspace/ui/transcript/workspace-chat-empty-state";
 import { WorkspaceMessageList } from "@/features/workspace/ui/transcript/workspace-message-list";
+import { HitlApprovalModal } from "@/features/workspace/ui/hitl-approval-modal";
 import {
   useChatHistoryStore,
   useChatStore,
@@ -125,7 +126,7 @@ export function WorkspaceScreen() {
     ],
   );
 
-  const { sessionRevision, requestedConversationId, clearRequestedConversation } =
+  const { sessionRevision, requestedConversationId, clearRequestedConversation, pendingHitlMessageId } =
     useWorkspaceUiStore();
 
   // Chat history
@@ -213,8 +214,13 @@ export function WorkspaceScreen() {
   const runtimeWarningTitle = "Sandbox configuration needed";
   const hasMessages = messages.length > 0;
   const showDesktopLandingState = !isMobile && !hasMessages && phase === "idle" && !isTyping;
-  const composerDisabled = isTyping || !backendEnabled;
+  const hitlPending = pendingHitlMessageId != null;
+  const composerDisabled = isTyping || !backendEnabled || hitlPending;
   const isReceivingResponse = backendEnabled && isTyping;
+  const pendingHitlMessage =
+    pendingHitlMessageId != null
+      ? (messages.find((m) => m.id === pendingHitlMessageId) ?? null)
+      : null;
 
   const composerPlaceholder = getComposerPlaceholder({
     backendEnabled,
@@ -240,6 +246,7 @@ export function WorkspaceScreen() {
 
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
+      <HitlApprovalModal message={pendingHitlMessage} onResolveHitl={resolveHitl} />
       {showDesktopLandingState ? (
         <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
           <div

--- a/src/frontend/src/features/workspace/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/workspace-screen.tsx
@@ -126,8 +126,12 @@ export function WorkspaceScreen() {
     ],
   );
 
-  const { sessionRevision, requestedConversationId, clearRequestedConversation, pendingHitlMessageId } =
-    useWorkspaceUiStore();
+  const {
+    sessionRevision,
+    requestedConversationId,
+    clearRequestedConversation,
+    pendingHitlMessageId,
+  } = useWorkspaceUiStore();
 
   // Chat history
   const { saveConversation, loadConversation: loadConv } = useChatHistoryStore();

--- a/src/frontend/src/features/workspace/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/workspace-screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { PanelRight, Settings2, TriangleAlert } from "lucide-react";
+import { Settings2, TriangleAlert } from "lucide-react";
 
 import { useTelemetry } from "@/lib/telemetry/use-telemetry";
 import { useAppNavigate } from "@/hooks/use-app-navigate";
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { WorkspaceComposer, type AttachedFile } from "@/features/workspace/ui/workspace-composer";
 import { WorkspaceChatEmptyState } from "@/features/workspace/ui/transcript/workspace-chat-empty-state";
 import { WorkspaceMessageList } from "@/features/workspace/ui/transcript/workspace-message-list";
-import { SessionSidebar } from "@/features/workspace/ui/session-sidebar";
+import { HitlApprovalModal } from "@/features/workspace/ui/hitl-approval-modal";
 import {
   useChatHistoryStore,
   useChatStore,
@@ -130,8 +130,7 @@ export function WorkspaceScreen() {
     sessionRevision,
     requestedConversationId,
     clearRequestedConversation,
-    sidebarOpen,
-    toggleSidebar,
+    pendingHitlMessageId,
   } = useWorkspaceUiStore();
 
   // Chat history
@@ -219,8 +218,13 @@ export function WorkspaceScreen() {
   const runtimeWarningTitle = "Sandbox configuration needed";
   const hasMessages = messages.length > 0;
   const showDesktopLandingState = !isMobile && !hasMessages && phase === "idle" && !isTyping;
-  const composerDisabled = isTyping || !backendEnabled;
+  const hitlPending = pendingHitlMessageId != null;
+  const composerDisabled = isTyping || !backendEnabled || hitlPending;
   const isReceivingResponse = backendEnabled && isTyping;
+  const pendingHitlMessage =
+    pendingHitlMessageId != null
+      ? (messages.find((m) => m.id === pendingHitlMessageId) ?? null)
+      : null;
 
   const composerPlaceholder = getComposerPlaceholder({
     backendEnabled,
@@ -246,139 +250,111 @@ export function WorkspaceScreen() {
 
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
-      {/* Context toggle button — fixed to top-right corner of the workspace */}
-      {!isMobile && (
-        <div className="absolute top-2 right-3 z-10">
-          <Button
-            variant="ghost"
-            size="sm"
-            className={cn(
-              "h-7 gap-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground",
-              sidebarOpen && "bg-muted text-foreground",
-            )}
-            onClick={toggleSidebar}
-            aria-pressed={sidebarOpen}
+      <HitlApprovalModal message={pendingHitlMessage} onResolveHitl={resolveHitl} />
+      {showDesktopLandingState ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
+          <div
+            data-slot="workspace-landing-state"
+            className="mx-auto flex w-full max-w-[760px] flex-col items-center gap-5"
           >
-            <PanelRight className="size-3.5" />
-            Context
-          </Button>
+            <WorkspaceChatEmptyState isMobile={false} onSuggestionClick={setInputValue} />
+
+            {showRuntimeWarning ? (
+              <Alert className="w-full border-amber-500/25 bg-amber-500/5 text-foreground rounded-xl">
+                <TriangleAlert className="text-amber-500" />
+                <AlertTitle className="text-sm font-medium">{runtimeWarningTitle}</AlertTitle>
+                <AlertDescription>
+                  <div className="flex flex-col gap-3 mt-1.5">
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Connect to a Daytona sandbox to enable secure code execution. Your code runs
+                      in an isolated environment with persistent storage.
+                    </p>
+                    {warningGuidance.length > 0 && (
+                      <ul className="text-xs text-muted-foreground/80 space-y-1 pl-4 list-disc">
+                        {warningGuidance.map((msg) => (
+                          <li key={msg}>{msg}</li>
+                        ))}
+                      </ul>
+                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-fit rounded-lg gap-2"
+                      onClick={handleOpenRuntimeSettings}
+                    >
+                      <Settings2 className="size-3.5" />
+                      Configure Sandbox
+                    </Button>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            <div
+              data-slot="workspace-landing-composer"
+              className="w-full rounded-3xl p-1.5 shadow-lg shadow-black/[0.03] backdrop-blur-sm transition-shadow hover:shadow-xl hover:shadow-black/[0.05]"
+            >
+              {composer}
+            </div>
+          </div>
         </div>
-      )}
+      ) : (
+        <>
+          {/* Transcript area */}
+          <div className="flex-1 min-h-0" data-slot="workspace-transcript">
+            <WorkspaceMessageList
+              messages={messages}
+              isTyping={isTyping}
+              isMobile={isMobile}
+              showEmptyState={isMobile}
+              onSuggestionClick={setInputValue}
+              onResolveHitl={resolveHitl}
+              onResolveClarification={resolveClarification}
+            />
+          </div>
 
-      <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
-        {/* Main chat column */}
-        <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-          {showDesktopLandingState ? (
-            <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
-              <div
-                data-slot="workspace-landing-state"
-                className="mx-auto flex w-full max-w-[760px] flex-col items-center gap-5"
-              >
-                <WorkspaceChatEmptyState isMobile={false} onSuggestionClick={setInputValue} />
-
+          {/* Composer footer */}
+          <div data-slot="workspace-composer" className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}>
+            <div className="mx-auto w-full max-w-200">
+              <div className="flex flex-col gap-3">
                 {showRuntimeWarning ? (
-                  <Alert className="w-full border-amber-500/25 bg-amber-500/5 text-foreground rounded-xl">
-                    <TriangleAlert className="text-amber-500" />
+                  <Alert className="border-amber-500/25 bg-amber-500/5 text-foreground rounded-lg">
+                    <TriangleAlert className="text-amber-500 size-4" />
                     <AlertTitle className="text-sm font-medium">{runtimeWarningTitle}</AlertTitle>
                     <AlertDescription>
-                      <div className="flex flex-col gap-3 mt-1.5">
-                        <p className="text-sm text-muted-foreground leading-relaxed">
-                          Connect to a Daytona sandbox to enable secure code execution. Your code
-                          runs in an isolated environment with persistent storage.
-                        </p>
-                        {warningGuidance.length > 0 && (
-                          <ul className="text-xs text-muted-foreground/80 space-y-1 pl-4 list-disc">
+                      <div className="mt-1 flex flex-col gap-3">
+                        <div className="flex items-start justify-between gap-4">
+                          <p className="text-xs text-muted-foreground leading-relaxed">
+                            Connect to a Daytona sandbox to enable secure code execution. Your code
+                            runs in an isolated environment with persistent storage.
+                          </p>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 shrink-0 gap-1.5 rounded-lg text-xs"
+                            onClick={handleOpenRuntimeSettings}
+                          >
+                            <Settings2 className="size-3" />
+                            Configure
+                          </Button>
+                        </div>
+                        {warningGuidance.length > 0 ? (
+                          <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground/80">
                             {warningGuidance.map((msg) => (
                               <li key={msg}>{msg}</li>
                             ))}
                           </ul>
-                        )}
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="w-fit rounded-lg gap-2"
-                          onClick={handleOpenRuntimeSettings}
-                        >
-                          <Settings2 className="size-3.5" />
-                          Configure Sandbox
-                        </Button>
+                        ) : null}
                       </div>
                     </AlertDescription>
                   </Alert>
                 ) : null}
-
-                <div
-                  data-slot="workspace-landing-composer"
-                  className="w-full rounded-3xl p-1.5 shadow-lg shadow-black/[0.03] backdrop-blur-sm transition-shadow hover:shadow-xl hover:shadow-black/[0.05]"
-                >
-                  {composer}
-                </div>
+                <div className="mx-auto w-full max-w-175">{composer}</div>
               </div>
             </div>
-          ) : (
-            <>
-              {/* Transcript area */}
-              <div className="flex-1 min-h-0" data-slot="workspace-transcript">
-                <WorkspaceMessageList
-                  messages={messages}
-                  isTyping={isTyping}
-                  isMobile={isMobile}
-                  showEmptyState={isMobile}
-                  onSuggestionClick={setInputValue}
-                  onResolveHitl={resolveHitl}
-                  onResolveClarification={resolveClarification}
-                />
-              </div>
-
-              {/* Composer footer */}
-              <div data-slot="workspace-composer" className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}>
-                <div className="mx-auto w-full max-w-200">
-                  <div className="flex flex-col gap-3">
-                    {showRuntimeWarning ? (
-                      <Alert className="border-amber-500/25 bg-amber-500/5 text-foreground rounded-lg">
-                        <TriangleAlert className="text-amber-500 size-4" />
-                        <AlertTitle className="text-sm font-medium">
-                          {runtimeWarningTitle}
-                        </AlertTitle>
-                        <AlertDescription>
-                          <div className="mt-1 flex flex-col gap-3">
-                            <div className="flex items-start justify-between gap-4">
-                              <p className="text-xs text-muted-foreground leading-relaxed">
-                                Connect to a Daytona sandbox to enable secure code execution. Your
-                                code runs in an isolated environment with persistent storage.
-                              </p>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-7 shrink-0 gap-1.5 rounded-lg text-xs"
-                                onClick={handleOpenRuntimeSettings}
-                              >
-                                <Settings2 className="size-3" />
-                                Configure
-                              </Button>
-                            </div>
-                            {warningGuidance.length > 0 ? (
-                              <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground/80">
-                                {warningGuidance.map((msg) => (
-                                  <li key={msg}>{msg}</li>
-                                ))}
-                              </ul>
-                            ) : null}
-                          </div>
-                        </AlertDescription>
-                      </Alert>
-                    ) : null}
-                    <div className="mx-auto w-full max-w-175">{composer}</div>
-                  </div>
-                </div>
-              </div>
-            </>
-          )}
-        </div>
-
-        {/* Session sidebar */}
-        {sidebarOpen && !isMobile && <SessionSidebar messages={messages} />}
-      </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/frontend/src/lib/workspace/backend-chat-event-adapter.ts
+++ b/src/frontend/src/lib/workspace/backend-chat-event-adapter.ts
@@ -25,6 +25,7 @@ import {
   inferStatusTone,
   sandboxProgressPartFromStatus,
 } from "@/lib/workspace/backend-chat-event-tool-parts";
+import { useWorkspaceUiStore } from "@/lib/workspace/workspace-ui-store";
 
 const DEFAULT_PHASE = 1 as const;
 interface ApplyFrameResult {
@@ -661,6 +662,7 @@ function applyEvent(
             )
         : [];
 
+      useWorkspaceUiStore.getState().setPendingHitlMessageId(messageId);
       return {
         messages: [
           ...messages,
@@ -690,6 +692,8 @@ function applyEvent(
       const resolution =
         asOptionalText(payload?.resolution) ?? asOptionalText(payload?.label) ?? text.trim();
       if (!resolution) return { messages, terminal: false, errored: false };
+
+      useWorkspaceUiStore.getState().setPendingHitlMessageId(null);
 
       if (messageId) {
         return {
@@ -724,6 +728,7 @@ function applyEvent(
       let next = messages;
       if (command === "resolve_hitl" && messageId && resolution) {
         next = resolveHitlByMessageId(next, messageId, resolution);
+        useWorkspaceUiStore.getState().setPendingHitlMessageId(null);
       }
       return {
         messages: appendTracePart(

--- a/src/frontend/src/lib/workspace/backend-chat-event-adapter.ts
+++ b/src/frontend/src/lib/workspace/backend-chat-event-adapter.ts
@@ -632,6 +632,16 @@ function applyEvent(
         text || "Updating memory...",
       );
 
+      if (text.trim()) {
+        useWorkspaceUiStore.getState().addMemoryEntry({
+          content: text.trim(),
+          timestamp:
+            typeof frame.data.timestamp === "string"
+              ? frame.data.timestamp
+              : new Date().toISOString(),
+        });
+      }
+
       if (queryClient) {
         queryClient.invalidateQueries({ queryKey: ["memory"] });
       }

--- a/src/frontend/src/lib/workspace/workspace-ui-store.ts
+++ b/src/frontend/src/lib/workspace/workspace-ui-store.ts
@@ -9,6 +9,7 @@ export interface WorkspaceUiState {
   creationPhase: CreationPhase;
   sessionRevision: number;
   requestedConversationId: string | null;
+  pendingHitlMessageId: string | null;
   newSession: () => void;
   requestConversationLoad: (conversationId: string) => void;
   clearRequestedConversation: () => void;
@@ -17,6 +18,7 @@ export interface WorkspaceUiState {
   setInspectorTab: (tab: InspectorTab) => void;
   clearInspectorSelection: () => void;
   setCreationPhase: (phase: CreationPhase) => void;
+  setPendingHitlMessageId: (id: string | null) => void;
 }
 
 function openShellCanvas() {
@@ -29,6 +31,7 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   creationPhase: "idle",
   sessionRevision: 0,
   requestedConversationId: null,
+  pendingHitlMessageId: null,
   newSession: () =>
     set({
       creationPhase: "idle",
@@ -65,6 +68,7 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
       activeInspectorTab: "message",
     }),
   setCreationPhase: (creationPhase) => set({ creationPhase }),
+  setPendingHitlMessageId: (pendingHitlMessageId) => set({ pendingHitlMessageId }),
 }));
 
 export const useSelectedAssistantTurnId = () =>

--- a/src/frontend/src/lib/workspace/workspace-ui-store.ts
+++ b/src/frontend/src/lib/workspace/workspace-ui-store.ts
@@ -1,7 +1,32 @@
 import { create } from "zustand";
 
 import type { CreationPhase, InspectorTab } from "@/lib/workspace/workspace-types";
+import type { WsRuntimeContext } from "@/lib/rlm-api/ws-types";
 import { useNavigationStore } from "@/stores/navigation-store";
+
+export type SidebarTab = "documents" | "memory" | "context" | "checkpoint";
+
+export interface MemoryEntry {
+  id: string;
+  content: string;
+  timestamp: string;
+}
+
+function readSidebarOpen(): boolean {
+  try {
+    return localStorage.getItem("workspace.sidebarOpen") === "true";
+  } catch {
+    return false;
+  }
+}
+
+function writeSidebarOpen(value: boolean): void {
+  try {
+    localStorage.setItem("workspace.sidebarOpen", value ? "true" : "false");
+  } catch {
+    // ignore
+  }
+}
 
 export interface WorkspaceUiState {
   selectedAssistantTurnId: string | null;
@@ -10,6 +35,10 @@ export interface WorkspaceUiState {
   sessionRevision: number;
   requestedConversationId: string | null;
   pendingHitlMessageId: string | null;
+  runtimeContext: WsRuntimeContext | null;
+  sidebarOpen: boolean;
+  sidebarTab: SidebarTab;
+  memoryEntries: MemoryEntry[];
   newSession: () => void;
   requestConversationLoad: (conversationId: string) => void;
   clearRequestedConversation: () => void;
@@ -19,11 +48,18 @@ export interface WorkspaceUiState {
   clearInspectorSelection: () => void;
   setCreationPhase: (phase: CreationPhase) => void;
   setPendingHitlMessageId: (id: string | null) => void;
+  setRuntimeContext: (ctx: WsRuntimeContext | null) => void;
+  toggleSidebar: () => void;
+  setSidebarTab: (tab: SidebarTab) => void;
+  addMemoryEntry: (entry: { content: string; timestamp: string }) => void;
+  clearMemoryEntries: () => void;
 }
 
 function openShellCanvas() {
   useNavigationStore.getState().openCanvas();
 }
+
+let _nextMemoryId = 0;
 
 export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   selectedAssistantTurnId: null,
@@ -32,6 +68,10 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
   sessionRevision: 0,
   requestedConversationId: null,
   pendingHitlMessageId: null,
+  runtimeContext: null,
+  sidebarOpen: readSidebarOpen(),
+  sidebarTab: "memory",
+  memoryEntries: [],
   newSession: () =>
     set({
       creationPhase: "idle",
@@ -69,6 +109,19 @@ export const useWorkspaceUiStore = create<WorkspaceUiState>((set, get) => ({
     }),
   setCreationPhase: (creationPhase) => set({ creationPhase }),
   setPendingHitlMessageId: (pendingHitlMessageId) => set({ pendingHitlMessageId }),
+  setRuntimeContext: (runtimeContext) => set({ runtimeContext }),
+  toggleSidebar: () =>
+    set((state) => {
+      const next = !state.sidebarOpen;
+      writeSidebarOpen(next);
+      return { sidebarOpen: next };
+    }),
+  setSidebarTab: (sidebarTab) => set({ sidebarTab }),
+  addMemoryEntry: ({ content, timestamp }) =>
+    set((state) => ({
+      memoryEntries: [...state.memoryEntries, { id: `mem-${++_nextMemoryId}`, content, timestamp }],
+    })),
+  clearMemoryEntries: () => set({ memoryEntries: [] }),
 }));
 
 export const useSelectedAssistantTurnId = () =>


### PR DESCRIPTION
## Summary

- Adds a fixed-position modal overlay (`HitlApprovalModal`) that appears whenever a `hitl_request` event arrives, surfacing the approval question and action buttons prominently above the transcript
- Extends `workspace-ui-store` with `pendingHitlMessageId` / `setPendingHitlMessageId` to track the active HITL request
- Updates `backend-chat-event-adapter` to set/clear `pendingHitlMessageId` on `hitl_request`, `hitl_resolved`, and `command_ack` (resolve_hitl) events
- Disables the `WorkspaceComposer` while a HITL request is pending so users cannot submit new messages during an approval flow
- Uses `framer-motion` (already a dep) for enter/exit animation with `prefers-reduced-motion` support

## Test plan

- [ ] Type-check passes: `cd src/frontend && pnpm run type-check`
- [ ] Unit tests pass for workspace lib: `vp test run src/lib/workspace/__tests__` (72 tests, 7 files)
- [ ] Modal appears centered at bottom of screen (above composer) when a HITL message arrives
- [ ] Clicking an action button resolves the HITL and dismisses the modal with exit animation
- [ ] Composer input is disabled while modal is visible, re-enables after resolution
- [ ] Inline transcript card in `workspace-chat-message-item.tsx` remains unmodified
- [ ] `prefers-reduced-motion` disables translate animation (opacity only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)