### PR TITLE
feat: session and memory sidebar with Documents, Memory, Context, Checkpoint tabs

### DIFF
--- a/src/frontend/src/features/workspace/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/workspace-screen.tsx
@@ -339,10 +339,7 @@ export function WorkspaceScreen() {
               </div>
 
               {/* Composer footer */}
-              <div
-                data-slot="workspace-composer"
-                className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}
-              >
+              <div data-slot="workspace-composer" className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}>
                 <div className="mx-auto w-full max-w-200">
                   <div className="flex flex-col gap-3">
                     {showRuntimeWarning ? (

--- a/src/frontend/src/features/workspace/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/workspace-screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Settings2, TriangleAlert } from "lucide-react";
+import { PanelRight, Settings2, TriangleAlert } from "lucide-react";
 
 import { useTelemetry } from "@/lib/telemetry/use-telemetry";
 import { useAppNavigate } from "@/hooks/use-app-navigate";
@@ -11,6 +11,7 @@ import { WorkspaceComposer, type AttachedFile } from "@/features/workspace/ui/wo
 import { WorkspaceChatEmptyState } from "@/features/workspace/ui/transcript/workspace-chat-empty-state";
 import { WorkspaceMessageList } from "@/features/workspace/ui/transcript/workspace-message-list";
 import { HitlApprovalModal } from "@/features/workspace/ui/hitl-approval-modal";
+import { SessionSidebar } from "@/features/workspace/ui/session-sidebar";
 import {
   useChatHistoryStore,
   useChatStore,
@@ -131,6 +132,8 @@ export function WorkspaceScreen() {
     requestedConversationId,
     clearRequestedConversation,
     pendingHitlMessageId,
+    sidebarOpen,
+    toggleSidebar,
   } = useWorkspaceUiStore();
 
   // Chat history
@@ -251,110 +254,142 @@ export function WorkspaceScreen() {
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
       <HitlApprovalModal message={pendingHitlMessage} onResolveHitl={resolveHitl} />
-      {showDesktopLandingState ? (
-        <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
-          <div
-            data-slot="workspace-landing-state"
-            className="mx-auto flex w-full max-w-[760px] flex-col items-center gap-5"
+      {/* Context toggle button — fixed to top-right corner of the workspace */}
+      {!isMobile && (
+        <div className="absolute top-2 right-3 z-10">
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn(
+              "h-7 gap-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground",
+              sidebarOpen && "bg-muted text-foreground",
+            )}
+            onClick={toggleSidebar}
+            aria-pressed={sidebarOpen}
           >
-            <WorkspaceChatEmptyState isMobile={false} onSuggestionClick={setInputValue} />
-
-            {showRuntimeWarning ? (
-              <Alert className="w-full border-amber-500/25 bg-amber-500/5 text-foreground rounded-xl">
-                <TriangleAlert className="text-amber-500" />
-                <AlertTitle className="text-sm font-medium">{runtimeWarningTitle}</AlertTitle>
-                <AlertDescription>
-                  <div className="flex flex-col gap-3 mt-1.5">
-                    <p className="text-sm text-muted-foreground leading-relaxed">
-                      Connect to a Daytona sandbox to enable secure code execution. Your code runs
-                      in an isolated environment with persistent storage.
-                    </p>
-                    {warningGuidance.length > 0 && (
-                      <ul className="text-xs text-muted-foreground/80 space-y-1 pl-4 list-disc">
-                        {warningGuidance.map((msg) => (
-                          <li key={msg}>{msg}</li>
-                        ))}
-                      </ul>
-                    )}
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-fit rounded-lg gap-2"
-                      onClick={handleOpenRuntimeSettings}
-                    >
-                      <Settings2 className="size-3.5" />
-                      Configure Sandbox
-                    </Button>
-                  </div>
-                </AlertDescription>
-              </Alert>
-            ) : null}
-
-            <div
-              data-slot="workspace-landing-composer"
-              className="w-full rounded-3xl p-1.5 shadow-lg shadow-black/[0.03] backdrop-blur-sm transition-shadow hover:shadow-xl hover:shadow-black/[0.05]"
-            >
-              {composer}
-            </div>
-          </div>
+            <PanelRight className="size-3.5" />
+            Context
+          </Button>
         </div>
-      ) : (
-        <>
-          {/* Transcript area */}
-          <div className="flex-1 min-h-0" data-slot="workspace-transcript">
-            <WorkspaceMessageList
-              messages={messages}
-              isTyping={isTyping}
-              isMobile={isMobile}
-              showEmptyState={isMobile}
-              onSuggestionClick={setInputValue}
-              onResolveHitl={resolveHitl}
-              onResolveClarification={resolveClarification}
-            />
-          </div>
+      )}
 
-          {/* Composer footer */}
-          <div data-slot="workspace-composer" className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}>
-            <div className="mx-auto w-full max-w-200">
-              <div className="flex flex-col gap-3">
+      <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+        {/* Main chat column */}
+        <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+          {showDesktopLandingState ? (
+            <div className="flex min-h-0 flex-1 items-center justify-center px-6 pt-16 pb-8 lg:pt-24">
+              <div
+                data-slot="workspace-landing-state"
+                className="mx-auto flex w-full max-w-[760px] flex-col items-center gap-5"
+              >
+                <WorkspaceChatEmptyState isMobile={false} onSuggestionClick={setInputValue} />
+
                 {showRuntimeWarning ? (
-                  <Alert className="border-amber-500/25 bg-amber-500/5 text-foreground rounded-lg">
-                    <TriangleAlert className="text-amber-500 size-4" />
+                  <Alert className="w-full border-amber-500/25 bg-amber-500/5 text-foreground rounded-xl">
+                    <TriangleAlert className="text-amber-500" />
                     <AlertTitle className="text-sm font-medium">{runtimeWarningTitle}</AlertTitle>
                     <AlertDescription>
-                      <div className="mt-1 flex flex-col gap-3">
-                        <div className="flex items-start justify-between gap-4">
-                          <p className="text-xs text-muted-foreground leading-relaxed">
-                            Connect to a Daytona sandbox to enable secure code execution. Your code
-                            runs in an isolated environment with persistent storage.
-                          </p>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-7 shrink-0 gap-1.5 rounded-lg text-xs"
-                            onClick={handleOpenRuntimeSettings}
-                          >
-                            <Settings2 className="size-3" />
-                            Configure
-                          </Button>
-                        </div>
-                        {warningGuidance.length > 0 ? (
-                          <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground/80">
+                      <div className="flex flex-col gap-3 mt-1.5">
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          Connect to a Daytona sandbox to enable secure code execution. Your code
+                          runs in an isolated environment with persistent storage.
+                        </p>
+                        {warningGuidance.length > 0 && (
+                          <ul className="text-xs text-muted-foreground/80 space-y-1 pl-4 list-disc">
                             {warningGuidance.map((msg) => (
                               <li key={msg}>{msg}</li>
                             ))}
                           </ul>
-                        ) : null}
+                        )}
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="w-fit rounded-lg gap-2"
+                          onClick={handleOpenRuntimeSettings}
+                        >
+                          <Settings2 className="size-3.5" />
+                          Configure Sandbox
+                        </Button>
                       </div>
                     </AlertDescription>
                   </Alert>
                 ) : null}
-                <div className="mx-auto w-full max-w-175">{composer}</div>
+
+                <div
+                  data-slot="workspace-landing-composer"
+                  className="w-full rounded-3xl p-1.5 shadow-lg shadow-black/[0.03] backdrop-blur-sm transition-shadow hover:shadow-xl hover:shadow-black/[0.05]"
+                >
+                  {composer}
+                </div>
               </div>
             </div>
-          </div>
-        </>
-      )}
+          ) : (
+            <>
+              {/* Transcript area */}
+              <div className="flex-1 min-h-0" data-slot="workspace-transcript">
+                <WorkspaceMessageList
+                  messages={messages}
+                  isTyping={isTyping}
+                  isMobile={isMobile}
+                  showEmptyState={isMobile}
+                  onSuggestionClick={setInputValue}
+                  onResolveHitl={resolveHitl}
+                  onResolveClarification={resolveClarification}
+                />
+              </div>
+
+              {/* Composer footer */}
+              <div
+                data-slot="workspace-composer"
+                className={cn("shrink-0 px-4 pb-6 pt-4 md:px-6")}
+              >
+                <div className="mx-auto w-full max-w-200">
+                  <div className="flex flex-col gap-3">
+                    {showRuntimeWarning ? (
+                      <Alert className="border-amber-500/25 bg-amber-500/5 text-foreground rounded-lg">
+                        <TriangleAlert className="text-amber-500 size-4" />
+                        <AlertTitle className="text-sm font-medium">
+                          {runtimeWarningTitle}
+                        </AlertTitle>
+                        <AlertDescription>
+                          <div className="mt-1 flex flex-col gap-3">
+                            <div className="flex items-start justify-between gap-4">
+                              <p className="text-xs text-muted-foreground leading-relaxed">
+                                Connect to a Daytona sandbox to enable secure code execution. Your
+                                code runs in an isolated environment with persistent storage.
+                              </p>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 shrink-0 gap-1.5 rounded-lg text-xs"
+                                onClick={handleOpenRuntimeSettings}
+                              >
+                                <Settings2 className="size-3" />
+                                Configure
+                              </Button>
+                            </div>
+                            {warningGuidance.length > 0 ? (
+                              <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground/80">
+                                {warningGuidance.map((msg) => (
+                                  <li key={msg}>{msg}</li>
+                                ))}
+                              </ul>
+                            ) : null}
+                          </div>
+                        </AlertDescription>
+                      </Alert>
+                    ) : null}
+                    <div className="mx-auto w-full max-w-175">{composer}</div>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Session sidebar */}
+        {sidebarOpen && !isMobile && <SessionSidebar messages={messages} />}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add collapsible right sidebar (`SessionSidebar`) to workspace with four tabs: Documents, Memory, Context, Checkpoint
- Extend `workspace-ui-store` with `sidebarOpen`/`sidebarTab` state (localStorage-persisted), `memoryEntries`, `pendingHitlMessageId`, and `runtimeContext`
- Wire `memory_update` WS events to populate `memoryEntries` in the store via `backend-chat-event-adapter`
- Add "Context" toggle button (`PanelRight` icon) to workspace header; sidebar slides in as a fixed-width (280px) flex column

## Tab details

- **Documents**: Scans messages for tool input paths (`document_path`, `loaded_path`, `path`) and lists unique paths; empty state if none
- **Memory**: Lists memory entries captured from `memory_update` events with timestamp and truncated content
- **Context**: Key-value display of `WsRuntimeContext` fields (volume, workspace path, sandbox ID, execution mode, etc.); empty state if null
- **Checkpoint**: Shows HITL approval pending indicator with message ID; static guidance note

## Test plan

- [x] `pnpm run type-check` — passes (0 errors)
- [x] `pnpm run test:unit` — 62 files, 320 tests, all passing
- [ ] Verify toggle button appears top-right on desktop, hidden on mobile
- [ ] Toggle sidebar open/closed; verify `localStorage` key `workspace.sidebarOpen` is updated
- [ ] Send a chat message; when `memory_update` event arrives, Memory tab populates
- [ ] Inspect Context tab after runtime context is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)