### PR TITLE
docs: rewrite live docs to match current codebase

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,76 +1,73 @@
 # fleet-rlm Documentation
 
-`fleet-rlm` provides an adaptive recursive language model workspace with a Web
-UI, API, and optional MCP server. The maintained product path is DSPy-native
-and Daytona-backed, with one shared workspace and transport contract.
+`fleet-rlm` is a Daytona-backed recursive DSPy workbench. The maintained product is the live workbench, the durable volumes browser, the optimization surface, runtime settings and diagnostics, and the session history and replay view. This documentation mirrors that current product and keeps migration history separate.
 
 This documentation is for both:
 
 - users operating `fleet-rlm` locally or in deployment workflows
-- contributors building integrations, extending runtime behavior, or maintaining the codebase
+- contributors extending the current runtime, transport, or frontend shell
 
 ## Quickstart
 
 ```bash
-uv init
-uv add fleet-rlm
+uv sync --all-extras
 uv run fleet web
 ```
 
 Then open `http://localhost:8000`.
 
-Next steps:
+## Current Docs
 
-- [Installation details](how-to-guides/installation.md)
-- [Runtime settings](how-to-guides/runtime-settings.md)
-- [Deploying the API server](how-to-guides/deploying-server.md)
+- [Product Spec](explanation/product-spec.md)
+- [Architecture Overview](architecture.md)
+- [Reference Index](reference/index.md)
+- [Explanation Index](explanation/index.md)
+- [Frontend Product Surface Guide](guides/frontend-product-surface.md)
+- [Optimization Page Spec](specs/optimization-page.md)
+- [Wiring Analysis](wiring-analysis.md)
+- [Runtime Settings](how-to-guides/runtime-settings.md)
+- [Deploying the API Server](how-to-guides/deploying-server.md)
+- [Frontend/Backend Integration](reference/frontend-backend-integration.md)
 
-## Choose Your Path
-
-## Use the product
+## Use the Product
 
 - [Installation](how-to-guides/installation.md)
-- [Adaptive RLM Product Spec](explanation/product-spec.md)
 - [Runtime settings](how-to-guides/runtime-settings.md)
-- [LiteLLM proxy model availability](litellm-models.md)
-- [Deploying the API server](how-to-guides/deploying-server.md)
 - [Troubleshooting](how-to-guides/troubleshooting.md)
+- [LiteLLM proxy model availability](litellm-models.md)
 
-## Contribute to the project
-
-- [Contributing guide](../CONTRIBUTING.md)
-
-## Build integrations
+## Build and Integrate
 
 - [HTTP and WebSocket API](reference/http-api.md)
 - [Python API](reference/python-api.md)
 - [CLI reference](reference/cli.md)
 - [Using the MCP server](how-to-guides/using-mcp-server.md)
 
-## Understand architecture
+## Understand the System
 
 - [Architecture overview](architecture.md)
 - [Concepts](explanation/concepts.md)
 - [User interaction flows](explanation/user-flows.md)
 - [Component UML](explanation/component-uml.md)
 
-## Documentation Map (Diataxis)
+## Historical Notes
+
+- [Historical snapshots](historical/index.md)
+- [Architecture and migration history](historical/index.md#architecture-and-migration-history)
+
+## Documentation Map
 
 - [Tutorials](tutorials/index.md)
 - [How-to Guides](how-to-guides/index.md)
 - [Reference](reference/index.md)
 - [Explanation](explanation/index.md)
+- [Complete table of contents](SUMMARY.md)
 
-## Source-of-Truth Policy
+## Source of Truth
 
-When docs conflict with implementation, treat these as authoritative:
+When docs conflict with implementation, trust:
 
 - CLI truth: `uv run fleet-rlm --help` and `uv run fleet --help`
 - API truth: `openapi.yaml`
 - WebSocket truth: `src/fleet_rlm/api/routers/ws/endpoint.py` and adjacent helpers in `src/fleet_rlm/api/routers/ws/`
-
-## Archive Note
-
-Historical docs are archived and non-operational:
-
-- Legacy planning docs are stored under the local-only `plans/archive/docs-legacy/` path.
+- Runtime truth: `src/fleet_rlm/runtime/agent/chat_agent.py`, `src/fleet_rlm/runtime/agent/recursive_runtime.py`, `src/fleet_rlm/integrations/daytona/interpreter.py`, and `src/fleet_rlm/integrations/daytona/runtime.py`

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,11 +1,15 @@
 # Table of contents
 
 * [Documentation Home](index.md)
+* [fleet-rlm Documentation](README.md)
+* [Product Spec](explanation/product-spec.md)
 * [Architecture Overview](architecture.md)
 * [Current Architecture and Transition Note](notes/current-architecture-transition.md)
-* [fleet-rlm Documentation](README.md)
-* [Contributing to fleet-rlm](../CONTRIBUTING.md)
-* [LiteLLM Proxy Model Availability](litellm-models.md)
+* [Frontend Product Surface Guide](guides/frontend-product-surface.md)
+* [Optimization Page Spec](specs/optimization-page.md)
+* [Wiring Analysis](wiring-analysis.md)
+* [Reference Index](reference/index.md)
+* [Explanation Index](explanation/index.md)
 
 ## Tutorials
 
@@ -34,29 +38,30 @@
 ## Reference
 
 * [Reference Documentation](reference/index.md)
-  * [CLI Reference](reference/cli.md)
-  * [HTTP and WebSocket API Reference](reference/http-api.md)
-  * [Python API Reference](reference/python-api.md)
-  * [Auth Modes (Dev vs Entra)](reference/auth.md)
+  * [CLI Commands](reference/cli.md)
+  * [HTTP and WebSocket API](reference/http-api.md)
+  * [Python API](reference/python-api.md)
+  * [Auth Modes](reference/auth.md)
   * [Database Architecture](reference/database.md)
   * [Sandbox File System](reference/sandbox-fs.md)
-  * [Source Layout (src/fleet_rlm)](reference/source-layout.md)
-  * [Python Backend Module Map](reference/module-map.md)
-  * [fleet-rlm Codebase Map](reference/codebase-map.md)
+  * [Source Layout](reference/source-layout.md)
   * [Frontend Architecture](reference/frontend-architecture.md)
-  * [Frontend ↔ Backend Integration](reference/frontend-backend-integration.md)
+  * [Frontend Feature Spec](reference/frontend-feature-spec.md)
+  * [Frontend Backend Integration](reference/frontend-backend-integration.md)
   * [Daytona Runtime Architecture](reference/daytona-runtime-architecture.md)
-  * [fleet-rlm v0.4.99 Release Notes](reference/release-notes-0.4.99.md)
-  * [fleet-rlm v0.4.94 Release Notes](reference/release-notes-0.4.94.md)
+  * [Codebase Map](reference/codebase-map.md)
+  * [Module Map](reference/module-map.md)
   * [Architecture Decision Records](reference/adr/README.md)
     * [ADR-001: RLM Runtime Architecture](reference/adr/001-rlm-runtime-architecture.md)
     * [ADR-003: Neon/Postgres with RLS](reference/adr/003-neon-postgres-rls-persistence.md)
     * [ADR-004: Dual Auth Modes](reference/adr/004-dual-auth-modes.md)
+  * [Release Notes 0.4.99](reference/release-notes-0.4.99.md)
+  * [Release Notes 0.4.94](reference/release-notes-0.4.94.md)
 
 ## Explanation
 
 * [Explanation](explanation/index.md)
-  * [Adaptive RLM Product Spec](explanation/product-spec.md)
+  * [Product Spec](explanation/product-spec.md)
   * [fleet-rlm Concepts](explanation/concepts.md)
   * [User Interaction Flows](explanation/user-flows.md)
   * [Component UML](explanation/component-uml.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,125 +1,104 @@
 # Architecture Overview
 
-`fleet-rlm` is best understood as a recursive DSPy + Daytona runtime core wrapped by two thinner outer layers:
+`fleet-rlm` is a Daytona-backed recursive runtime wrapped by a thin transport shell and a narrow hosted-policy layer.
+
+## Current Layering
 
 1. **Thin FastAPI/WebSocket transport** in `src/fleet_rlm/api/`
-2. **Narrow but real Agent Framework outer orchestration host** in `src/fleet_rlm/agent_host/`
-3. **Daytona-backed recursive DSPy worker/runtime core** in `src/fleet_rlm/worker/`, `src/fleet_rlm/runtime/`, and `src/fleet_rlm/integrations/daytona/`
-
-Two additional layers matter when reading the current tree:
-
-- **Transitional bridge**: `src/fleet_rlm/orchestration_app/` and `src/fleet_rlm/api/orchestration/`
-- **Offline quality layer**: `src/fleet_rlm/runtime/quality/`
-
-## Current Runtime Status
-
-- The main cognition loop lives in `src/fleet_rlm/runtime/agent/chat_agent.py` and `src/fleet_rlm/runtime/agent/recursive_runtime.py`.
-- The execution and durable-workspace substrate lives in `src/fleet_rlm/integrations/daytona/interpreter.py` and `src/fleet_rlm/integrations/daytona/runtime.py`.
-- `src/fleet_rlm/agent_host/workflow.py` is the hosted policy seam around the worker boundary, not the core engine.
-- `src/fleet_rlm/api/main.py`, `src/fleet_rlm/api/routers/ws/*`, and `src/fleet_rlm/api/runtime_services/*` should stay transport-thin: auth, request parsing, session extraction, lifecycle, and event-envelope delivery.
-- `src/fleet_rlm/orchestration_app/*` and `src/fleet_rlm/api/orchestration/*` remain compatibility layers during the transition; they should shrink rather than gain new product logic.
-- `src/fleet_rlm/runtime/quality/*` is the offline DSPy evaluation and optimization surface, not the online request path.
-
-## Layered View
+2. **Narrow but real Agent Framework outer host** in `src/fleet_rlm/agent_host/`
+3. **Worker/runtime core** in `src/fleet_rlm/worker/`, `src/fleet_rlm/runtime/`, and `src/fleet_rlm/integrations/daytona/`
+4. **Offline evaluation and optimization** in `src/fleet_rlm/runtime/quality/`
 
 ```mermaid
 graph TB
-    CLIENTS["CLI / Web UI / MCP clients"] --> API
-    API["Thin transport\napi/main.py\napi/routers/ws/*\napi/runtime_services/*"] --> HOST
-    HOST["Outer orchestration host\nagent_host/*"] --> BRIDGE
-    BRIDGE["Transitional bridge\norchestration_app/*\napi/orchestration/*"] --> CORE
-    CORE["Recursive runtime core\nworker/*\nruntime/agent/*\nruntime/models/*\nintegrations/daytona/*"] --> QUALITY
-    QUALITY["Offline quality layer\nruntime/quality/*"]
+    CLIENTS["CLI / Web UI / MCP clients"] --> API["FastAPI transport\napi/main.py\napi/routers/*\napi/runtime_services/*"]
+    API --> HOST["agent_host/\nhosted policy + HITL + checkpoints"]
+    HOST --> WORKER["worker/\nworkspace task stream boundary"]
+    WORKER --> RUNTIME["runtime/\nchat agent + execution helpers + models"]
+    RUNTIME --> DAYTONA["integrations/daytona/\ninterpreter + runtime + volumes"]
+    API --> EVENTS["api/events/\nexecution event shaping"]
+    API --> PERSISTENCE["integrations/local_store.py\nintegrations/database/"]
+    RUNTIME --> QUALITY["runtime/quality/\noffline GEPA + DSPy optimization"]
 ```
 
 ## What Each Layer Owns
 
-### 1. Thin FastAPI/WebSocket transport
+### 1. Transport
 
 Primary files:
 
 - `src/fleet_rlm/api/main.py`
-- `src/fleet_rlm/api/routers/ws/*`
-- `src/fleet_rlm/api/runtime_services/*`
+- `src/fleet_rlm/api/routers/ws/endpoint.py`
+- `src/fleet_rlm/api/runtime_services/chat_runtime.py`
+- `src/fleet_rlm/api/runtime_services/chat_persistence.py`
+- `src/fleet_rlm/api/runtime_services/diagnostics.py`
+- `src/fleet_rlm/api/runtime_services/settings.py`
+- `src/fleet_rlm/api/runtime_services/volumes.py`
 
 Responsibilities:
 
-- App factory and lifespan wiring
-- HTTP and websocket route registration
-- Auth and session/user extraction
-- Request normalization and websocket lifecycle
-- Event shaping and envelope delivery
-- Runtime settings, diagnostics, and volume browsing service orchestration
+- App factory, lifespan, route mounting, and SPA asset serving
+- Auth-derived HTTP and websocket identity
+- Session lookup, runtime preparation, and service orchestration
+- Websocket lifecycle and execution-event envelope delivery
+- Runtime settings, diagnostics, and Daytona volume browsing
 
-Non-goals:
-
-- Owning the recursive cognition loop
-- Becoming the primary orchestration layer
-- Holding Daytona execution semantics that belong in runtime/provider code
-
-### 2. Narrow but real Agent Framework outer orchestration host
+### 2. Hosted policy
 
 Primary files:
 
-- `src/fleet_rlm/agent_host/app.py`
 - `src/fleet_rlm/agent_host/workflow.py`
 - `src/fleet_rlm/agent_host/hitl_flow.py`
+- `src/fleet_rlm/agent_host/terminal_flow.py`
 - `src/fleet_rlm/agent_host/checkpoints.py`
+- `src/fleet_rlm/agent_host/sessions.py`
+- `src/fleet_rlm/agent_host/execution_events.py`
 - `src/fleet_rlm/agent_host/repl_bridge.py`
 - `src/fleet_rlm/agent_host/startup_status.py`
 
 Responsibilities:
 
-- Host workflow construction and hosted execution policy
-- Session/HITL/checkpoint coordination around the worker seam
-- Agent Framework integration for websocket execution turns
-- Outer policy around streamed worker execution
+- Hosted Agent Framework workflow around the worker seam
+- HITL checkpointing, terminal ordering, and session continuation policy
+- Startup-status gating for slow initial turns
+- REPL bridge and execution-event coordination around the runtime stream
 
-Non-goals:
-
-- Replacing the runtime core
-- Owning Daytona interpreter behavior
-- Reimplementing transport responsibilities that belong in `api/`
-
-### 3. Daytona-backed recursive DSPy worker/runtime core
+### 3. Worker/runtime core
 
 Primary files:
 
-- `src/fleet_rlm/worker/*`
+- `src/fleet_rlm/worker/streaming.py`
+- `src/fleet_rlm/worker/contracts.py`
+- `src/fleet_rlm/runtime/factory.py`
 - `src/fleet_rlm/runtime/agent/chat_agent.py`
 - `src/fleet_rlm/runtime/agent/recursive_runtime.py`
+- `src/fleet_rlm/runtime/execution/*`
 - `src/fleet_rlm/runtime/models/*`
-- `src/fleet_rlm/integrations/daytona/interpreter.py`
-- `src/fleet_rlm/integrations/daytona/runtime.py`
 
 Responsibilities:
 
-- The shared ReAct + recursive `dspy.RLM` cognition loop
-- Tool selection, recursive delegation, and streaming turn execution
-- Daytona sandbox/session lifecycle and durable workspace semantics
-- Provider-native memory, repo/context staging, and runtime metadata
+- Shared chat/runtime execution
+- Recursive delegation and tool execution
+- Execution-event assembly and workbench hydration inputs
+- Runtime model assembly and registry management
 
-This is the system's center of gravity. When the architecture description and the file layout disagree, start here and work outward.
-
-### 4. Transitional bridge layers
+### 4. Daytona substrate
 
 Primary files:
 
-- `src/fleet_rlm/orchestration_app/*`
-- `src/fleet_rlm/api/orchestration/*`
+- `src/fleet_rlm/integrations/daytona/interpreter.py`
+- `src/fleet_rlm/integrations/daytona/runtime.py`
+- `src/fleet_rlm/integrations/daytona/runtime_helpers.py`
+- `src/fleet_rlm/integrations/daytona/volumes.py`
+- `src/fleet_rlm/integrations/daytona/diagnostics.py`
 
 Responsibilities:
 
-- Compatibility shims and migration seams retained during the Agent Framework transition
-- Legacy policy adapters that still bridge transport and host behavior
+- Sandbox and interpreter lifecycle
+- Repo checkout, workspace path staging, and durable mounted volumes
+- Provider-specific diagnostics and volume normalization
 
-Direction of travel:
-
-- Keep only still-needed seams
-- Reduce wrapper clutter and duplicated ownership signals
-- Prefer forwarding to `agent_host/` or the runtime core instead of growing new logic here
-
-### 5. Offline worker quality layer
+### 5. Offline quality
 
 Primary files:
 
@@ -128,61 +107,54 @@ Primary files:
 Responsibilities:
 
 - DSPy evaluation
-- Optimization workflows
-- Scoring, metrics, and offline quality runs
+- GEPA optimization
+- Offline scoring, datasets, and module registry management
 
-This layer supports the runtime core but is not the online websocket execution path.
-
-## Current-State Module Map
-
-| Area | Role now | Read first |
-| --- | --- | --- |
-| `api/` | thin transport shell | `api/main.py`, `api/routers/ws/endpoint.py`, `api/routers/ws/stream.py` |
-| `agent_host/` | outer orchestration host | `agent_host/workflow.py`, `agent_host/app.py` |
-| `orchestration_app/` | transitional bridge | `orchestration_app/coordinator.py`, `orchestration_app/terminal_flow.py` |
-| `api/orchestration/` | compatibility shims | `api/orchestration/*.py` |
-| `worker/` | worker boundary and task contract | `worker/contracts.py`, `worker/adapters.py` |
-| `runtime/agent/` | main cognition loop | `runtime/agent/chat_agent.py`, `runtime/agent/recursive_runtime.py` |
-| `runtime/models/` | runtime module/model registry and exports | `runtime/models/builders.py`, `runtime/models/registry.py` |
-| `integrations/daytona/` | execution and memory substrate | `integrations/daytona/interpreter.py`, `integrations/daytona/runtime.py` |
-| `runtime/quality/` | offline evaluation/optimization | `runtime/quality/*` |
-
-## Cleanup Guidance for the First Pass
-
-The current cleanup pass should stay structural and documentary.
-
-Safe targets:
-
-- Reduce compatibility clutter in `src/fleet_rlm/api/orchestration/*`
-- Reduce compatibility clutter in wrapper files under `src/fleet_rlm/api/routers/ws/*`
-- Shrink `src/fleet_rlm/orchestration_app/*` toward only the still-needed transition seams
-- Remove stale ownership descriptions and deleted-file references from docs
-
-Do not do in this pass:
-
-- Redesign the runtime
-- Broadly refactor transport/host/runtime boundaries
-- Rewrite recursive worker behavior
-- Move cognition into orchestration layers
-- Move Daytona execution or memory semantics into transport or host state
-- Change websocket/public contract semantics as part of the docs cleanup
-
-## Canonical Shared Endpoints
+## Canonical Runtime Surfaces
 
 - `/health`
 - `/ready`
 - `GET /api/v1/auth/me`
 - `GET /api/v1/sessions/state`
-- `/api/v1/runtime/*`
-- `POST /api/v1/traces/feedback`
+- `GET /api/v1/sessions`
+- `GET /api/v1/sessions/{id}`
+- `GET /api/v1/sessions/{id}/turns`
+- `DELETE /api/v1/sessions/{id}`
+- `POST /api/v1/sessions/{id}/export`
+- `GET /api/v1/runtime/settings`
+- `PATCH /api/v1/runtime/settings`
+- `POST /api/v1/runtime/tests/daytona`
+- `POST /api/v1/runtime/tests/lm`
+- `GET /api/v1/runtime/status`
+- `GET /api/v1/runtime/volume/tree`
+- `GET /api/v1/runtime/volume/file`
 - `GET /api/v1/optimization/status`
 - `POST /api/v1/optimization/run`
+- `GET /api/v1/optimization/modules`
+- `POST /api/v1/optimization/runs`
+- `GET /api/v1/optimization/runs`
+- `GET /api/v1/optimization/runs/{run_id}`
+- `GET /api/v1/optimization/runs/{run_id}/results`
+- `GET /api/v1/optimization/runs/compare`
+- `POST /api/v1/optimization/datasets`
+- `GET /api/v1/optimization/datasets`
+- `GET /api/v1/optimization/datasets/{dataset_id}`
 - `/api/v1/ws/execution`
 - `/api/v1/ws/execution/events`
 
-## Recommended Companion Docs
+## Reading Order
 
-- [Current architecture and transition note](notes/current-architecture-transition.md)
-- [Focused codebase map](reference/codebase-map.md)
-- [Python backend module map](reference/module-map.md)
-- [Frontend/backend integration](reference/frontend-backend-integration.md)
+When you need the current backend story, start here:
+
+1. `src/fleet_rlm/api/main.py`
+2. `src/fleet_rlm/api/routers/ws/endpoint.py`
+3. `src/fleet_rlm/agent_host/workflow.py`
+4. `src/fleet_rlm/worker/streaming.py`
+5. `src/fleet_rlm/runtime/factory.py`
+6. `src/fleet_rlm/runtime/agent/chat_agent.py`
+7. `src/fleet_rlm/integrations/daytona/interpreter.py`
+8. `src/fleet_rlm/integrations/daytona/runtime.py`
+
+## Historical Note
+
+Older transition notes may still mention `orchestration_app/` and `api/orchestration/`. Those labels are historical only and are intentionally absent from the current tree.

--- a/docs/explanation/concepts.md
+++ b/docs/explanation/concepts.md
@@ -1,8 +1,7 @@
 # fleet-rlm Concepts
 
 `fleet-rlm` combines a ReAct chat orchestrator with recursive long-context
-execution over shared interpreter backends. Daytona is the primary backend
-today, while Modal remains supported.
+execution over a shared Daytona-backed interpreter runtime.
 
 ## Core Concepts
 
@@ -38,9 +37,9 @@ Benefits:
 
 Current backend shape:
 
-- Daytona is the primary workspace/runtime backend
-- Modal remains available for compatible flows
-- both backends feed the same ReAct + recursive `dspy.RLM` runtime
+- Daytona is the maintained workspace/runtime backend
+- the public product/runtime contract is Daytona-only
+- the same ReAct + recursive `dspy.RLM` runtime serves the CLI, API, and web app
 
 ## 4. Runtime Surfaces
 
@@ -55,7 +54,7 @@ All surfaces converge on shared orchestration/runtime modules.
 The system emits:
 
 - chat stream events (`/api/v1/ws/execution`)
-- execution graph events (`/api/v1/ws/execution`)
+- execution graph events (`/api/v1/ws/execution/events`)
 
 Persistence model:
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,9 +1,15 @@
 # Explanation
 
-Conceptual documentation describing how the system works and why it is structured this way.
+Conceptual documentation for the current maintained product and runtime. Historical audits and migration notes live under `docs/historical/` and `docs/notes/`.
 
-- [Adaptive RLM Product Spec](product-spec.md)
+## Current Concepts
+
+- [Product Spec](product-spec.md)
 - [Concepts](concepts.md)
 - [Architecture Overview](../architecture.md)
 - [User Interaction Flows](user-flows.md)
 - [Component UML](component-uml.md)
+
+## Current-State Notes
+
+- [Current Architecture and Transition Note](../notes/current-architecture-transition.md)

--- a/docs/explanation/product-spec.md
+++ b/docs/explanation/product-spec.md
@@ -1,74 +1,26 @@
-# Adaptive RLM Product Spec
+# fleet-rlm Product Spec
 
-This document describes `fleet-rlm` from a user-product perspective.
-
-The goal is not to describe every internal module. The goal is to define what
-the system is for, what a user can expect from it, and what the maintained
-product contract is.
+This document describes the maintained product contract from the user point of view. It intentionally avoids internal implementation detail except where that detail is part of the public runtime contract.
 
 ## Product Statement
 
-`fleet-rlm` is an adaptive workspace for recursive AI task execution.
+`fleet-rlm` is a persistent Daytona-backed recursive DSPy workbench.
 
-Users provide a goal and optional context. The system uses recursive language
-models, structured DSPy programs, tools, and a Daytona sandbox to choose an
-appropriate reasoning and execution strategy for the task.
+Users give the system a task and optional context. The maintained runtime uses a shared `daytona_pilot` path to decide whether to answer directly, recurse, call tools, or execute inside a Daytona sandbox.
 
-The product is centered on adaptable capability, not on repository analysis as
-the primary experience.
+Repository analysis is one supported use case, not the product identity. The product is the workbench.
 
-Repositories are one supported source of context. They are not the product's
-identity.
+## Maintained Surfaces
 
-## Product Goals
-
-The product exists to let a user:
-
-- express a task in natural language
-- attach useful context in whatever form they have it
-- let the runtime adapt its reasoning depth and execution strategy
-- inspect what the system did and why
-- keep useful outputs and state over time
-
-The product should feel like a single intelligent workspace rather than a
-collection of separate tools.
-
-## Who It Is For
-
-Primary users:
-
-- developers solving code, document, and systems tasks
-- technical operators who need inspectable task execution
-- advanced users who want a programmable AI workspace rather than a one-shot chat
-
-Typical tasks:
-
-- analyze a codebase or a subset of files
-- reason over local documents or notes
-- combine URLs, staged files, and instructions into one task
-- execute code or transformations in a safe environment
-- iterate on a task over multiple turns with persistent context
-- evaluate or optimize DSPy programs
-
-## Core User Model
-
-The intended user model is:
-
-1. I give the system a task.
-2. I optionally attach sources, files, or constraints.
-3. The system decides how much reasoning and execution the task needs.
-4. I can watch the process, inspect the outputs, and continue the session.
-
-Users should not need to think in terms of runtime backends or provider modes.
-
-## Supported Product Surfaces
-
-The maintained surfaces are:
+The current shell exposes five surfaces:
 
 - `Workbench`
 - `Volumes`
 - `Optimization`
 - `Settings`
+- `History`
+
+The first four are the primary maintained product surfaces. `History` is the supporting session browsing and replay surface.
 
 ### Workbench
 
@@ -77,10 +29,10 @@ The maintained surfaces are:
 It is where a user:
 
 - starts or resumes a session
-- sends tasks to the adaptive agent
-- stages optional sources such as files, URLs, or repositories
-- watches live reasoning and execution events
-- inspects final answers, artifacts, evidence, and run summaries
+- sends a task to the runtime
+- attaches optional context such as files, URLs, or repo refs
+- watches reasoning, tool use, sandbox activity, and HITL state
+- inspects the final answer, summary, artifacts, and evidence
 
 ### Volumes
 
@@ -90,17 +42,17 @@ It is where a user:
 
 - inspects persisted files
 - retrieves generated artifacts
-- understands what survived beyond the live execution session
+- understands what survived beyond the live turn
 
 ### Optimization
 
-`Optimization` is the DSPy quality surface.
+`Optimization` is the offline DSPy quality surface.
 
 It is where a user:
 
 - runs evaluation workflows
-- triggers optimization or compilation paths
-- measures and improves the quality of DSPy programs
+- launches optimization or compilation paths
+- compares results across modules or datasets
 
 ### Settings
 
@@ -108,14 +60,25 @@ It is where a user:
 
 It is where a user:
 
-- validates language-model connectivity
+- validates model connectivity
 - validates Daytona connectivity
 - inspects runtime health and readiness
 - adjusts allowed local runtime settings
 
-## Inputs and Sources
+### History
 
-The system should accept tasks that start from any of these:
+`History` is the session browsing and replay surface.
+
+It is where a user:
+
+- reviews prior sessions
+- opens the turn transcript for a session
+- replays or inspects session output
+- exports session history into durable datasets
+
+## Inputs and Context
+
+The system accepts tasks that begin from:
 
 - plain-language instructions
 - local files
@@ -125,90 +88,67 @@ The system should accept tasks that start from any of these:
 - repository URLs and refs
 - existing session history
 
-The maintained product stance is:
+The maintained stance is:
 
+- the task itself is the primary input
 - repos are optional context sources
 - documents are optional context sources
 - URLs are optional context sources
-- the task itself is always the primary input
 
-## Capability Model
+## Runtime Contract
 
-The runtime is designed to adapt to the task.
+The current backend is Daytona-only and is exposed through FastAPI.
 
-Depending on the task, the system may:
+Public network surfaces include:
 
-- answer directly
-- decompose the task into subproblems
-- recurse through child reasoning steps
-- use tools
-- read or stage documents
-- inspect or modify files
-- execute code in a sandbox
-- persist outputs for later reuse
-- recover and continue a previous session
+- `/health`
+- `/ready`
+- `GET /api/v1/auth/me`
+- `GET /api/v1/sessions/state`
+- `GET /api/v1/sessions`
+- `GET /api/v1/sessions/{id}`
+- `GET /api/v1/sessions/{id}/turns`
+- `DELETE /api/v1/sessions/{id}`
+- `GET /api/v1/runtime/status`
+- `GET/PATCH /api/v1/runtime/settings`
+- `POST /api/v1/runtime/tests/lm`
+- `POST /api/v1/runtime/tests/daytona`
+- `GET /api/v1/runtime/volume/tree`
+- `GET /api/v1/runtime/volume/file`
+- `GET /api/v1/optimization/status`
+- `POST /api/v1/optimization/run`
+- `GET /api/v1/optimization/modules`
+- `POST /api/v1/optimization/runs`
+- `GET /api/v1/optimization/runs`
+- `GET /api/v1/optimization/runs/{run_id}`
+- `GET /api/v1/optimization/runs/{run_id}/results`
+- `GET /api/v1/optimization/runs/compare`
+- `POST /api/v1/optimization/datasets`
+- `GET /api/v1/optimization/datasets`
+- `GET /api/v1/optimization/datasets/{dataset_id}`
+- `POST /api/v1/traces/feedback`
+- `/api/v1/ws/execution`
+- `/api/v1/ws/execution/events`
 
-This adaptive behavior is the main product value.
+## WebSocket Model
 
-## Technical Capability Contract
+The websocket contract is split by purpose:
 
-The current stack is:
+- `/api/v1/ws/execution` is the canonical conversational turn stream
+- `/api/v1/ws/execution/events` is the passive execution/workbench event stream
 
-- FastAPI as the transport and product backend
-- DSPy as the program and reasoning framework
-- Daytona as the sandboxed execution backend
+Current rules:
 
-### FastAPI
+- identity comes from auth, not client-supplied `workspace_id` or `user_id`
+- `session_id` is message-scoped on `/api/v1/ws/execution`
+- query `session_id` is required on `/api/v1/ws/execution/events`
+- `execution_completed.summary` is the canonical workbench hydration payload
+- `execution_mode` is a per-turn hint for the Daytona-backed runtime
+- `repo_url`, `repo_ref`, `context_paths`, and `batch_concurrency` are the Daytona request controls
 
-FastAPI owns:
+## Durable State
 
-- HTTP routes
-- websocket transport
-- auth integration
-- runtime settings and diagnostics
-- app startup and lifecycle wiring
-
-### DSPy
-
-DSPy owns:
-
-- task contracts through `Signature`
-- program composition through `Module`
-- tool-using task execution through `ReAct`
-- recursive reasoning through `dspy.RLM`
-- optimization and evaluation through DSPy-native optimizers and evaluators
-
-The maintained implementation direction is to use DSPy-native classes as much as
-possible rather than building parallel custom abstractions.
-
-### Daytona
-
-Daytona owns:
-
-- sandbox creation and recovery
-- mounted durable storage
-- sandbox file operations
-- code-interpreter contexts
-- idle stop/archive lifecycle
-- recoverable execution sessions
-
-The maintained implementation direction is to stay close to the Daytona SDK
-instead of building a parallel runtime model above it.
-
-## Session Model
-
-The product distinguishes between live session state and durable workspace state.
-
-### Live State
-
-Live state includes:
-
-- current websocket turn execution
-- current sandbox/session binding
-- active interpreter context
-- in-flight reasoning and tool activity
-
-### Durable State
+Live state includes the current websocket turn, sandbox binding, and in-flight reasoning/tool activity.
 
 Durable state includes:
 
@@ -224,25 +164,24 @@ The durable mounted roots are:
 - `buffers/`
 - `meta/`
 
-Users should expect durable files to survive runtime sleep/recovery, while raw
-in-memory interpreter state is less authoritative than persisted state.
+Session manifests on durable storage live under:
 
-## Adaptive Execution Model
+`meta/workspaces/<workspace_id>/users/<user_id>/react-session-<session_id>.json`
 
-The product should choose execution style based on the task.
+Users should expect durable files to survive runtime sleep or recovery, while in-memory interpreter state is less authoritative than persisted state.
+
+## Runtime Behavior
+
+The runtime adapts to the task.
 
 Examples:
 
-- a short conceptual question may only need direct DSPy reasoning
-- a long document question may require document loading and chunking
-- a code or filesystem task may require Daytona sandbox execution
-- a broader task may require recursive delegation and multiple tool steps
+- a short conceptual task may only need direct reasoning
+- a long document task may require loading and chunking
+- a filesystem task may require Daytona sandbox execution
+- a broader task may require recursion and multiple tool steps
 
-The system should make these choices with as little user friction as possible.
-
-## Runtime Lifecycle and Cost Model
-
-The maintained backend is Daytona-only and is designed to avoid wasted compute.
+The maintained runtime should keep those choices inspectable instead of hiding them behind a black box.
 
 The runtime lifecycle should behave like this:
 
@@ -252,42 +191,14 @@ The runtime lifecycle should behave like this:
 - reconnecting recovers the sandbox when possible
 - persistent state is rehydrated from durable sources
 
-This gives users a persistent workspace model without forcing every session to
-stay fully hot forever.
+Daytona idle lifecycle uses provider-minute timers:
 
-## User-Facing Contract
+- `auto_stop_interval=30`
+- `auto_archive_interval=60`
 
-### Main Entry Point
+## What Users Can Observe
 
-The main product command is:
-
-```bash
-# from a uv-managed environment
-uv run fleet web
-```
-
-### Main Network Surfaces
-
-The user-facing backend contract centers on:
-
-- `/health`
-- `/ready`
-- `GET /api/v1/auth/me`
-- `GET /api/v1/sessions/state`
-- `/api/v1/runtime/*`
-- `POST /api/v1/traces/feedback`
-- `GET /api/v1/optimization/status`
-- `POST /api/v1/optimization/run`
-- `/api/v1/ws/execution`
-
-`/api/v1/ws/execution` is the canonical live stream for both conversational
-turns and execution/workbench events.
-
-## What the User Should Be Able to Observe
-
-The product should remain inspectable.
-
-A user should be able to observe:
+Users should be able to observe:
 
 - current runtime status
 - reasoning and trajectory steps
@@ -296,39 +207,34 @@ A user should be able to observe:
 - final answers
 - persisted artifacts and evidence
 
-The system is not intended to be a black box.
-
 ## Non-Goals
 
 The product is not primarily:
 
 - a repository browser
-- a stateless chat application
+- a stateless chat app
 - a multi-backend runtime platform
-- a generic framework shell that exposes provider choice as a user concern
+- a generic framework shell that exposes provider choice to users
 
-Those capabilities may exist internally or as optional inputs, but they are not
-the core product promise.
+Those capabilities may exist internally or as optional inputs, but they are not the core product promise.
 
 ## Product Promise
 
-The product promise is:
-
-Give the system a goal and optional context, and it will adapt its reasoning,
-tool use, and sandboxed execution strategy to complete the task in an
-inspectable and persistent workspace.
+Give the system a task and optional context, and it will adapt its reasoning, tool use, and sandboxed execution strategy to complete the task in an inspectable and persistent workspace.
 
 ## User Flow
 
 ```mermaid
 flowchart LR
-    User["User goal"] --> Context["Optional context<br/>files / urls / repo / history"]
-    Context --> Workbench["Workbench"]
-    Workbench --> Agent["DSPy ReAct + dspy.RLM"]
-    Agent --> Decide["Choose strategy<br/>reason / tool / recurse / execute"]
-    Decide --> Daytona["Daytona sandbox when needed"]
-    Decide --> Result["Answer + artifacts + trace"]
-    Daytona --> Result
-    Result --> Volumes["Durable outputs in Volumes"]
-    Result --> Next["Next turn or follow-up task"]
+  User["Task + optional context"] --> Workbench["Workbench"]
+  Workbench --> WS["/api/v1/ws/execution"]
+  WS --> Host["agent_host workflow"]
+  Host --> Runtime["worker + recursive DSPy runtime"]
+  Runtime --> Daytona["Daytona sandbox"]
+  Runtime --> Summary["execution_completed.summary"]
+  Summary --> Workbench
+  Summary --> Volumes["Volumes"]
+  Summary --> History["History"]
+  Workbench --> Optimize["Optimization"]
+  Workbench --> Settings["Settings"]
 ```

--- a/docs/explanation/user-flows.md
+++ b/docs/explanation/user-flows.md
@@ -1,111 +1,111 @@
-# User Interaction Flows
+# Frontend User Flows
 
-Visualizing the key sequence of events during user interactions with `fleet-rlm`.
+This document describes the current frontend runtime and navigation flows for
+`fleet-rlm`. It reflects the live React/TanStack Router/Zustand shell and the
+Daytona-backed workspace runtime.
 
-## 1. Standard Chat Turn
+## Shell And Routing
 
-Simple question and answer flow without tools.
+The URL is the source of truth. TanStack Router owns route selection, while the
+shell stores the active nav item and canvas state in Zustand.
+
+```mermaid
+flowchart LR
+  A["/"] --> B["/app/workspace"]
+  B --> C["/app/volumes"]
+  B --> D["/app/optimization"]
+  B --> E["/app/history"]
+  B --> F["/app/settings"]
+
+  B --> G["RootLayout"]
+  C --> G
+  D --> G
+  E --> G
+  F --> G
+
+  G --> H["RouteSync"]
+  G --> I["Sidebar / Header / Canvas"]
+
+  H --> J["NavigationStore"]
+  J --> B
+  J --> C
+  J --> D
+  J --> E
+  J --> F
+```
+
+Key behavior:
+
+- `/` and `/app/` redirect to `/app/workspace`.
+- `RootLayout` renders the sidebar, header, main content, and optional canvas.
+- `RouteSync` reads the URL and updates shell state. The reverse direction is
+  handled by navigation helpers and route transitions.
+- The canvas opens automatically on Volumes, closes on Optimization, History,
+  and Settings, and stays available on Workbench.
+- Mobile uses a bottom tab bar and a bottom sheet for the canvas. Desktop uses a
+  split panel layout.
+
+## Workbench Turn
+
+The workspace is the primary execution flow. The composer submits a task, the
+frontend opens a websocket stream, and the transcript plus workbench state are
+updated from backend frames.
 
 ```mermaid
 sequenceDiagram
-    actor User
-    participant WebSocket
-    participant Agent
-    participant LLM
+  actor User
+  participant UI as "WorkspaceScreen"
+  participant RT as "useWorkspaceRuntime"
+  participant WS as "/api/v1/ws/execution"
+  participant CH as "chat store + adapters"
+  participant WB as "run-workbench store"
+  participant EVT as "/api/v1/ws/execution/events"
 
-    User->>WebSocket: "Hello, who are you?"
-    WebSocket->>Agent: Receive Message
-    Agent->>LLM: Prompt (History + User Request)
-    LLM-->>Agent: "I am fleet-rlm, an AI agent..."
-    Agent->>WebSocket: Stream Response
-    WebSocket-->>User: "I am fleet-rlm, an AI agent..."
+  User->>UI: Enter prompt and send
+  UI->>RT: handleSubmit()
+  RT->>WS: message payload with session_id and runtime controls
+  WS-->>CH: live chat / reasoning / tool / final frames
+  CH-->>WB: hydrate transcript and workbench state
+  WS-->>EVT: execution_started / execution_step / execution_completed
+  EVT-->>WB: canonical summary + final artifact hydration
+  WB-->>UI: stable inspector and run panel state
 ```
 
-## 2. Tool-Assisted Chat Turn
+The important rules are:
 
-User asks for information requiring a tool (e.g., read a file).
+- `WorkspaceScreen` owns local task entry, runtime mode initialization, session
+  persistence, and follow-up UX.
+- `useWorkspace()` owns the runtime lifecycle: submit, stream, cancel, HITL
+  resolution, and conversation loading.
+- `useChatStore` stores the live transcript state.
+- `useRunWorkbenchStore` stores the execution summary, artifacts, iterations,
+  callbacks, sources, and completion metadata.
+- `run-workbench-hydration.ts` is the canonical reducer for the run panel.
 
-```mermaid
-sequenceDiagram
-    actor User
-    participant WebSocket
-    participant Agent
-    participant Tools
-    participant LLM
+## Secondary Flows
 
-    User->>WebSocket: "What's in README.md?"
-    WebSocket->>Agent: Receive Message
-    Agent->>LLM: Prompt (History + Request)
-    LLM-->>Agent: Thought: "I need to read README.md"
-    LLM-->>Agent: Action: load_document("README.md")
+### Volumes
 
-    Agent->>Tools: load_document("README.md")
-    Tools->>Tools: Read File Content
-    Tools-->>Agent: "File loaded successfully. Content: # Project..."
+- `VolumesScreen` browses the mounted Daytona volume tree.
+- Selecting a file opens the canvas preview.
+- Leaving Volumes clears the selected file via `RouteSync`.
 
-    Agent->>LLM: Prompt (Observation: File Content)
-    LLM-->>Agent: Thought: "I have the content now."
-    LLM-->>Agent: "The README says this project is..."
+### History
 
-    Agent->>WebSocket: Stream Response
-    WebSocket-->>User: "The README says this project is..."
-```
+- `HistoryScreen` is a first-class route at `/app/history`.
+- It shows backend session history and local conversation history.
+- Selecting a session opens the detail drawer without leaving the shell.
 
-## 3. RLM Delegation Flow
+### Optimization
 
-User requests complex analysis requiring the Recursive Language Model.
+- `OptimizationScreen` exposes modules, datasets, runs, and compare tabs.
+- It is a separate product surface, not part of the live workbench turn flow.
 
-```mermaid
-sequenceDiagram
-    actor User
-    participant Agent
-    participant RLM
-    participant Sandbox
-    participant LLM
+### Settings
 
-    User->>Agent: "Analyze the deployment logs for errors."
-    Agent->>LLM: Prompt
-    LLM-->>Agent: Action: extract_from_logs()
+- `SettingsScreen` opens as a dialog first and falls back to the routed page.
+- Sections are `appearance`, `telemetry`, `litellm`, `runtime`, and
+  `optimization`.
+- Runtime settings and connectivity checks are handled in the settings feature
+  tree, not in the workspace runtime.
 
-    rect rgb(240, 240, 240)
-        note right of Agent: Delegation to RLM
-        Agent->>RLM: Start RLM Pipeline
-
-        loop RLM Reasoning
-            RLM->>LLM: "How do I extract errors?"
-            LLM-->>RLM: Code: "grep 'ERROR' logs.txt"
-            RLM->>Sandbox: Execute Code
-            Sandbox-->>RLM: "Found 5 errors..."
-            RLM->>RLM: Refine / Iterate
-        end
-
-        RLM-->>Agent: Structured Result (JSON)
-    end
-
-    Agent->>LLM: Prompt (Observation: Analysis Result)
-    LLM-->>Agent: "I found 5 critical errors..."
-    Agent->>User: Final Response
-```
-
-## 4. Sandbox Code Editing
-
-User asks to modify a file, triggering sandbox interaction.
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Agent
-    participant Sandbox
-    participant FileSystem
-
-    User->>Agent: "Change 'port=80' to 'port=8080' in config.py"
-    Agent->>Sandbox: edit_file("config.py", "port=80", "port=8080")
-
-    note right of Sandbox: Robust Edit Logic
-    Sandbox->>FileSystem: Read config.py
-    Sandbox->>Sandbox: Verify snippet uniqueness
-    Sandbox->>FileSystem: Write updated content
-
-    Sandbox-->>Agent: "Success: File updated."
-    Agent-->>User: "I've updated the port to 8080."
-```

--- a/docs/guides/frontend-product-surface.md
+++ b/docs/guides/frontend-product-surface.md
@@ -1,328 +1,85 @@
 # Frontend Product Surface Guide
 
-This guide documents the frontend architecture for the Fleet RLM workbench — the primary product surface for the Daytona-backed recursive DSPy runtime.
+This guide documents the current product surfaces in the Fleet RLM frontend.
+It is intentionally aligned with the live `features/*` ownership model and the
+Daytona-backed runtime contract.
 
 ## Product Flow Overview
 
-The supported product flow is a **chat-first execution workbench**:
+The supported product flow is a chat-first execution workbench:
 
-1. **User submits a task** via the composer
-2. **Backend creates a Daytona sandbox** and begins execution
-3. **Streaming events** flow through the websocket showing progress
-4. **Trajectory steps** display reasoning and tool calls
-5. **Final result** appears as an assistant turn with summary
+1. The user submits a task in Workbench.
+2. The frontend creates or reuses a session id and opens `/api/v1/ws/execution`.
+3. The backend streams live reasoning, tool, status, and final frames.
+4. The transcript updates in real time.
+5. The run workbench hydrates from the execution summary and final artifact.
+6. The user can inspect volumes, history, optimization, or settings from the
+   same shell.
 
-### Execution States
+## Surface Map
 
-The workspace tracks execution through these states:
+| Surface | Route | Owns | Notes |
+| --- | --- | --- | --- |
+| Workbench | `/app/workspace` | `features/workspace/*` | Main execution and inspection surface |
+| Volumes | `/app/volumes` | `features/volumes/*` | Mounted Daytona volume browser |
+| History | `/app/history` | `features/history/*` | Session and conversation history |
+| Optimization | `/app/optimization` | `features/optimization/*` | GEPA prompt optimization |
+| Settings | `/app/settings` | `features/settings/*` | Dialog-first settings surface |
 
-| State | Description | UI Treatment |
-|-------|-------------|--------------|
-| `idle` | Ready for input | Composer enabled, empty state shown |
-| `bootstrapping` | Sandbox starting | Loading indicator, "Setting up workspace…" |
-| `running` | Execution in progress | Streaming trajectory, progress indicators |
-| `completed` | Task finished successfully | Final answer shown, composer ready |
-| `error` | Execution failed | Error message with details |
-| `needs_human_review` | HITL checkpoint | Review action buttons displayed |
-| `cancelled` | User stopped execution | Neutral completion state |
+## Layer Structure
 
-## Component Architecture
-
-### Layer Structure
-
-```
-src/
-├── routes/           # File-based routing (TanStack Router)
-├── features/         # Product surface entry points
-│   ├── workspace/    # Main workbench surface
-│   │   └── ui/       # Workspace UI components
-│   │       ├── transcript/       # Message list and rendering
-│   │       ├── assistant-content/ # Turn display components
-│   │       ├── composer/         # Input area controls
-│   │       ├── inspector/        # Side panel details
-│   │       └── workbench/        # Execution trace display
-│   ├── volumes/      # Durable storage browser
-│   ├── optimization/ # DSPy optimization UI
-│   ├── settings/     # Configuration screens
-│   └── layout/       # App chrome and shell
-├── components/       # Reusable UI primitives
-│   ├── ui/          # shadcn/Base UI components
-│   ├── ai-elements/ # AI-specific components (conversation, message)
-│   └── product/     # App-owned composition patterns
-└── lib/             # Business logic and integrations
-    ├── workspace/   # State stores and event adapters
-    └── rlm-api/     # REST and websocket clients
+```text
+src/frontend/src/
+├── routes/                # Thin TanStack Router wrappers
+├── features/
+│   ├── layout/            # Shell chrome, route sync, dialogs, sidebar, header
+│   ├── workspace/         # Workbench UI, transcript, inspector, run panel
+│   ├── volumes/           # Volume browser and file preview
+│   ├── history/           # Session list, detail drawer, replay
+│   ├── optimization/      # Optimization tabs and forms
+│   └── settings/          # Settings dialog and runtime forms
+├── lib/
+│   ├── workspace/         # Zustand stores, event adapters, hydration reducers
+│   └── rlm-api/           # REST and websocket clients
+├── stores/                # Shell/navigation state
+├── components/ui/         # Shared UI primitives
+├── components/ai-elements/ # AI Elements rendering primitives
+└── components/product/    # Reusable product composition
 ```
 
-### Key Component Boundaries
+## Workbench Behavior
 
-**Feature entry points** (`features/*`) are thin wrappers that compose implementation from `features/*/ui/*` and `lib/*`:
+The workbench is the only live execution surface.
 
-```tsx
-// features/workspace/workspace-screen.tsx
-export function WorkspaceScreen() {
-  const runtime = useWorkspace(); // from lib/workspace
-  return (
-    <div>
-      <WorkspaceMessageList {...} /> {/* from features/workspace/ui */}
-      <WorkspaceComposer {...} />
-    </div>
-  );
-}
-```
+Rules:
 
-**Implementation components** (`features/workspace/ui/*`) handle rendering and user interaction but don't own business logic:
+- `WorkspaceScreen` initializes `daytona_pilot` as the runtime mode.
+- `useWorkspace()` submits messages, streams websocket frames, handles HITL,
+  and manages local conversation loading.
+- `useChatStore` holds the active session id and streaming transcript.
+- `useRunWorkbenchStore` holds the execution panel state.
+- The workbench panel must hydrate from `execution_completed.summary` and
+  `final_artifact`, not from transcript scraping.
+- The passive execution stream exists only for execution summary and workbench
+  hydration.
 
-```tsx
-// features/workspace/ui/transcript/workspace-message-list.tsx
-export function WorkspaceMessageList({ messages, isTyping, ... }) {
-  // Pure rendering logic, receives props from parent
-}
-```
+## Canvas Behavior
 
-**State and adapters** (`lib/workspace/*`) own backend event mapping and state management:
+The shell canvas is route-aware.
 
-```tsx
-// lib/workspace/chat-store.ts - Zustand store for chat state
-// lib/workspace/backend-chat-event-adapter.ts - Maps WS frames to chat messages
-```
+- On Workbench, it acts as the inspector and run workbench.
+- On Volumes, it shows the file preview.
+- On Settings, Optimization, and History, it closes.
+- On mobile, the canvas becomes a bottom sheet.
+- On desktop, the canvas is the right-hand resizable panel.
 
-## State Management
+## What Is Out Of Scope
 
-### Primary Stores
+The current frontend does not treat these as product surfaces:
 
-| Store | Purpose | Location |
-|-------|---------|----------|
-| `useChatStore` | Chat messages, streaming state | `lib/workspace/chat-store.ts` |
-| `useWorkspaceUiStore` | UI state (inspector, selection) | `lib/workspace/workspace-ui-store.ts` |
-| `useRunWorkbenchStore` | Execution state, iterations | `lib/workspace/run-workbench-store.ts` |
-| `useArtifactStore` | Execution artifacts | `lib/workspace/artifact-store.ts` |
-| `useChatHistoryStore` | Persisted conversations | `lib/workspace/chat-history-store.ts` |
+- `taxonomy`
+- `skills`
+- `memory`
+- `analytics`
 
-### State Flow
-
-```
-WebSocket Frame
-    ↓
-applyWsFrameToMessages() — adapts frame to ChatMessage[]
-    ↓
-useChatStore.setMessages() — updates Zustand state
-    ↓
-WorkspaceMessageList — renders via React subscription
-```
-
-## Websocket Integration
-
-### Connection Flow
-
-1. `useWorkspace()` hook manages the connection lifecycle
-2. `streamChatOverWs()` opens connection and sends initial message
-3. `onFrame` callback receives streaming events
-4. Events are adapted via `applyWsFrameToMessages()`
-
-### Event Types
-
-Events from the backend websocket (`WsEventKind`):
-
-| Event | Purpose |
-|-------|---------|
-| `assistant_token` | Streaming text tokens |
-| `reasoning_step` | Model reasoning display |
-| `trajectory_step` | Execution trace step |
-| `tool_call` / `tool_result` | Tool invocations |
-| `status` | Progress updates |
-| `final` | Execution completed |
-| `error` | Execution failed |
-| `hitl_request` | Human review needed |
-
-### Adding Support for New Event Types
-
-1. Add the event kind to `WsEventKind` in `lib/rlm-api/ws-types.ts`
-2. Update `applyWsFrameToMessages()` in `lib/workspace/backend-chat-event-adapter.ts`
-3. Add rendering in `src/features/workspace/ui/transcript/trace-part-renderers.tsx`
-4. Update display item building in `lib/workspace/chat-display-items.ts` if needed
-
-## Component Patterns
-
-### Status Components
-
-Use the execution status pattern components for consistent state display:
-
-```tsx
-import { StatusBadge, StatusIndicator, StatusMessage } from "@/components/product/execution-status";
-
-<StatusBadge status="running" />
-<StatusIndicator status="completed" />
-<StatusMessage variant="warning" title="Sandbox Starting">
-  Your workspace is being prepared...
-</StatusMessage>
-```
-
-### Section Layout
-
-Use section layout components for consistent spacing and structure:
-
-```tsx
-import { Section, SectionHeader, SectionContent } from "@/components/product/section-layout";
-
-<Section spacing="default">
-  <SectionHeader title="Execution Trace" />
-  <SectionContent scroll>
-    {/* Scrollable content */}
-  </SectionContent>
-</Section>
-```
-
-### Empty States
-
-The empty state pattern shows contextual guidance:
-
-```tsx
-import { EmptyPanel } from "@/components/product/empty-panel";
-
-<EmptyPanel
-  title="No results yet"
-  description="Submit a task to see execution results"
-  icon={FileSearch}
-/>
-```
-
-## Styling Conventions
-
-### Design Tokens
-
-The frontend uses a layered token system:
-
-1. **Tailwind v4 baseline** — Core utility classes
-2. **shadcn/Base UI tokens** — Component-level tokens via CSS variables
-3. **App semantic extensions** — Product-specific tokens in `globals.css`
-
-Key tokens:
-
-```css
-/* Semantic colors */
---foreground          /* Primary text */
---muted-foreground    /* Secondary text */
---border              /* Default borders */
---border-subtle       /* Light borders */
-
-/* Status colors */
---destructive         /* Error states */
---primary             /* Interactive elements */
-
-/* Surfaces */
---background          /* Page background */
---card                /* Elevated surfaces */
---muted               /* Subtle backgrounds */
-```
-
-### Typography Utilities
-
-Use semantic typography utilities:
-
-```html
-<h1 class="typo-h1">Page Title</h1>
-<p class="typo-base">Body text</p>
-<span class="typo-caption">Small label</span>
-<code class="typo-mono">code</code>
-```
-
-### Layout Utilities
-
-```html
-<div class="max-w-content">Prose width content</div>
-<div class="max-w-container">Container width content</div>
-```
-
-## Responsive Behavior
-
-### Breakpoints
-
-The workspace adapts at these breakpoints:
-
-| Breakpoint | Behavior |
-|------------|----------|
-| Mobile (<768px) | Single column, bottom sheet canvas |
-| Tablet (768-1024px) | Side-by-side with collapsed sidebar |
-| Desktop (>1024px) | Full layout with expanded sidebar |
-
-### Mobile Adaptations
-
-- Composer moves to fixed bottom position
-- Inspector panel becomes a bottom sheet
-- Empty state copy adjusts for mobile
-- Touch targets meet 44px minimum
-
-## Testing
-
-### Test Structure
-
-Tests are colocated with their modules under `__tests__/`:
-
-```
-features/workspace/ui/transcript/__tests__/
-  workspace-message-list.ai-elements.test.tsx
-  workspace-chat-empty-state.test.tsx
-```
-
-### Key Test Patterns
-
-**Component rendering:**
-```tsx
-import { render, screen } from "@/test/test-utils";
-
-test("renders empty state", () => {
-  render(<WorkspaceChatEmptyState isMobile={false} onSuggestionClick={vi.fn()} />);
-  expect(screen.getByText(/What would you like to build/)).toBeInTheDocument();
-});
-```
-
-**State integration:**
-```tsx
-import { useChatStore } from "@/lib/workspace/chat-store";
-
-test("applies message from frame", () => {
-  const { result } = renderHook(() => useChatStore());
-  // Test store interactions
-});
-```
-
-## Out of Scope
-
-The frontend intentionally does **not**:
-
-- Implement recursive execution logic (belongs in `fleet_rlm.worker`)
-- Make direct Daytona API calls (abstracted by backend)
-- Store sensitive credentials (handled by backend)
-- Derive execution decisions from UI heuristics (follows backend state)
-
-The frontend is a **presentation and orchestration layer** for the backend-driven execution flow.
-
-## Common Tasks
-
-### Adding a new execution event visualization
-
-1. Define the render part type in `workspace-types.ts`
-2. Add frame→message mapping in `backend-chat-event-adapter.ts`
-3. Add rendering component in `trace-part-renderers.tsx`
-4. Update `buildChatDisplayItems()` if grouping logic changes
-5. Add tests for the new rendering
-
-### Updating empty state messaging
-
-Edit `workspace-chat-empty-state.tsx`:
-- Update suggestions array for new prompts
-- Modify copy in the component JSX
-
-### Adding a new status state
-
-1. Add the status to `RunStatus` type in `workspace-types.ts`
-2. Update `STATUS_ICONS` and `STATUS_LABELS` in `execution-status.tsx`
-3. Add variant styles in the CVA definitions
-4. Update any components that switch on status
-
-## Related Documentation
-
-- [Root AGENTS.md](../../AGENTS.md) — Repository-wide conventions
-- [Frontend AGENTS.md](../../src/frontend/AGENTS.md) — Frontend-specific rules
-- [Architecture Overview](../architecture.md) — System architecture
+New work should target `features/*`, `lib/*`, and the thin route wrappers.

--- a/docs/how-to-guides/developer-setup.md
+++ b/docs/how-to-guides/developer-setup.md
@@ -10,7 +10,7 @@ This guide walks through setting up a complete local development environment for
 | uv            | Latest  | Package and dependency management |
 | pnpm          | Latest  | Frontend development              |
 | Git           | 2.x     | Version control                   |
-| Modal Account | -       | Sandbox execution                 |
+| Daytona Account | -     | Sandbox execution                 |
 
 ## 1. Install Python
 
@@ -166,7 +166,7 @@ MLFLOW_EXPERIMENT=fleet-rlm
 POSTHOG_ENABLED=false
 ```
 
-> **Security:** Never commit your `.env` file. It is already in `.gitignore`. For team setups, use Modal secrets for shared API keys.
+> **Security:** Never commit your `.env` file. It is already in `.gitignore`. For team setups, use your normal secret-management flow instead of checking shared credentials into the repo.
 
 > **MLflow note:** The local MLflow default is `http://127.0.0.1:5001`, which
 > matches `make mlflow-server`. In local development, the API will auto-start that

--- a/docs/how-to-guides/frontend-development.md
+++ b/docs/how-to-guides/frontend-development.md
@@ -13,30 +13,8 @@ pnpm install --frozen-lockfile
 pnpm run dev
 ```
 
-The development server runs at `http://localhost:5173` and proxies
-`/api/v1` and `/health` to the backend at `http://localhost:8000`.
-
-## Repo-Aligned Commands
-
-All commands below run from `src/frontend/`:
-
-| Command | Description |
-| --- | --- |
-| `pnpm run dev` | Start the Vite+ development server |
-| `pnpm run build` | Build the production bundle |
-| `pnpm run preview` | Preview the production bundle locally |
-| `pnpm run type-check` | Run TypeScript type checks |
-| `pnpm run lint` | Run the frontend lint rules |
-| `pnpm run lint:robustness` | Run the repo-aligned frontend lint lane |
-| `pnpm run format` | Format frontend source files with Vite+ `vp fmt` (backed by Oxc/Oxfmt) |
-| `pnpm run format:check` | Check frontend formatting with `vp fmt --check` |
-| `pnpm run test:unit` | Run Vitest unit tests |
-| `pnpm run test:watch` | Run Vitest in watch mode |
-| `pnpm run test:coverage` | Run Vitest with coverage output |
-| `pnpm run test:e2e` | Run Playwright end-to-end tests |
-| `pnpm run api:sync` | Copy the root OpenAPI spec and regenerate TS types |
-| `pnpm run api:check` | Fail if `api:sync` would change tracked generated files |
-| `pnpm run check` | Run type-check, lint, unit tests, build, and e2e |
+The dev server runs at `http://localhost:5173` and proxies `/api/v1`,
+`/health`, and `/ready` to the backend at `http://localhost:8000`.
 
 ## Current Source Layout
 
@@ -44,37 +22,48 @@ Frontend source lives under `src/frontend/src/`.
 
 | Path | Purpose |
 | --- | --- |
-| `routes/` | File-based routes, redirects, auth pages, and `/404` handling |
-| `screens/` | Top-level product surfaces for workspace, volumes, settings, and shell |
-| `app/` | Behavior-heavy shell/workspace internals that should not live in route files |
-| `components/ui/` | Shared shadcn/Base UI primitives and thin local extensions |
-| `components/ai-elements/` | Transcript and chat-specific rendering primitives |
-| `lib/rlm-api/` | REST client, websocket client, config, and generated OpenAPI types |
-| `lib/workspace/` | Workspace-specific adapters, normalizers, and helper logic |
-| `stores/` | Shared Zustand state |
-| `styles/globals.css` | Tailwind v4 baseline tokens and app-wide styles |
+| `routes/` | Thin TanStack Router wrappers, redirects, auth pages, and not-found handling |
+| `features/layout/` | Shell chrome, route sync, sidebar, header, dialogs, canvas host |
+| `features/workspace/` | Workbench screen, transcript, inspector, run panel, composer |
+| `features/volumes/` | Mounted volume browser and preview flow |
+| `features/history/` | Session list, detail drawer, replay surfaces |
+| `features/optimization/` | Optimization tabs and forms |
+| `features/settings/` | Settings dialog/page and runtime settings forms |
+| `lib/workspace/` | Zustand stores, runtime adapters, hydration reducers, transcript shaping |
+| `lib/rlm-api/` | REST and websocket clients plus generated API types |
+| `stores/` | Shell/navigation state |
+| `components/ui/` | Shared shadcn/Base UI primitives |
+| `components/ai-elements/` | AI Elements rendering primitives |
+| `components/product/` | Reusable product composition built from the shared layers |
+| `app/` | App bootstrap and providers |
 
 ## Product Surface Rules
 
-- Supported frontend surfaces are `/app/workspace`, `/app/volumes`,
+- Supported surfaces are `/app/workspace`, `/app/volumes`, `/app/history`,
   `/app/optimization`, and `/app/settings`.
-- Retired `/app/taxonomy*`, `/app/skills*`, `/app/memory`, and
-  `/app/analytics` routes should fall through to `/404`.
-- Thin route wrappers under `routes/` should render screen modules instead of
-  owning page logic.
-- `workspace`, `volumes`, `optimization`, and `settings` behavior should stay
-  in `screens/`, `app/`, and `lib/` rather than reintroducing the older
-  `features/` layout.
+- Retired `taxonomy`, `skills`, `memory`, and `analytics` paths should fall
+  through to `/404`.
+- Route wrappers must stay thin and should not own page logic.
+- New work should target `features/*`, `lib/*`, or `components/product/*`, not
+  a resurrected screen layer.
 
-## Runtime and API Contract Rules
+## Runtime And API Contract Rules
 
-- `/api/v1/ws/execution` is the canonical conversational websocket stream.
-- `/api/v1/ws/execution/events` is the passive workbench stream.
-- Frontend workbench state should hydrate from
-  `execution_completed.summary`, not from legacy chat-final
-  payloads.
-- `daytona_pilot` is the public runtime mode and sends `execution_mode`,
-  `repo_url`, `repo_ref`, `context_paths`, and `batch_concurrency`.
+- `/api/v1/ws/execution` is the canonical conversational websocket.
+- `/api/v1/ws/execution/events` is the passive execution subscription stream.
+- The workbench should hydrate from `execution_completed.summary` and
+  `final_artifact`.
+- `daytona_pilot` is the public runtime label in the UI.
+- Runtime controls stay aligned with `execution_mode`, `repo_url`, `repo_ref`,
+  `context_paths`, and `batch_concurrency`.
+
+## Shell And Layout Rules
+
+- `RootLayout` owns the shell chrome and responsive split layout.
+- `RouteSync` keeps the URL and shell store aligned.
+- Volumes opens the canvas automatically.
+- Settings, Optimization, and History close the canvas.
+- Mobile uses the bottom sheet canvas and bottom tab bar.
 
 ## Environment
 
@@ -91,15 +80,14 @@ Optional overrides:
 - `VITE_PUBLIC_POSTHOG_API_KEY`
 - `VITE_PUBLIC_POSTHOG_HOST`
 
-If `VITE_FLEET_WS_URL` is unset, the frontend derives websocket URLs for
-`/api/v1/ws/execution` and `/api/v1/ws/execution/events` from
+If `VITE_FLEET_WS_URL` is unset, websocket URLs are derived from
 `VITE_FLEET_API_URL`.
 
 ## OpenAPI Sync Workflow
 
 The canonical HTTP contract lives at `openapi.yaml` in the repo root.
 
-If backend route, schema, or OpenAPI-facing doc metadata changes, regenerate the
+If backend route, schema, or OpenAPI-facing metadata changes, regenerate the
 root spec first:
 
 ```bash
@@ -122,14 +110,15 @@ Generated files:
 
 Do not edit generated files manually.
 
-## React and UI Conventions
+## React And UI Conventions
 
-- React 19 refs should use direct ref passing instead of introducing
-  `forwardRef` by default.
-- Prefer the shared shadcn/Base UI baseline over one-off wrapper components or
-  parallel token systems.
+- React 19 direct ref passing is preferred over introducing `forwardRef` by
+  default.
 - Keep global theme primitives in `src/styles/globals.css`.
+- Prefer the shared shadcn/Base UI baseline over one-off wrappers or parallel
+  token systems.
 - Keep `@/lib/utils` as the canonical `cn()` import path.
+- Preserve the current `features/*` ownership model when adding UI.
 
 ## Validation
 
@@ -149,5 +138,6 @@ For the broader repo gate:
 
 ```bash
 # from repo root
-make quality-gate
+make check
 ```
+

--- a/docs/how-to-guides/installation.md
+++ b/docs/how-to-guides/installation.md
@@ -164,7 +164,7 @@ The `.env.example` file contains all configurable environment variables. Key cat
 | `POSTHOG_ENABLED` | Enable PostHog analytics | `false`                    |
 | `POSTHOG_HOST`    | PostHog host URL         | `https://eu.i.posthog.com` |
 
-> **Security Note:** Never commit your `.env` file with real secrets. Use Modal's secret management for team setups.
+> **Security Note:** Never commit your `.env` file with real secrets. Use your normal team secret-management workflow instead of storing shared credentials in the repo.
 
 ## Frontend Development Commands
 

--- a/docs/how-to-guides/mlflow-workflows.md
+++ b/docs/how-to-guides/mlflow-workflows.md
@@ -119,7 +119,7 @@ curl -X POST http://127.0.0.1:8000/api/v1/traces/feedback \
     "client_request_id": "chat-abc123",
     "is_correct": false,
     "comment": "The answer skipped the root cause.",
-    "expected_response": "The root cause was an expired Modal secret."
+    "expected_response": "The root cause was an expired Daytona credential."
   }'
 ```
 

--- a/docs/how-to-guides/testing-strategy.md
+++ b/docs/how-to-guides/testing-strategy.md
@@ -17,6 +17,7 @@ fleet-rlm uses pytest markers to categorize tests by scope and runtime requireme
 | `e2e`         | End-to-end workflow smoke tests                | Seconds to minutes             |
 | `benchmark`   | Performance/throughput benchmark tests         | Variable                       |
 | `live_llm`    | Tests requiring live Daytona + configured LLM  | Variable, requires credentials |
+| `live_daytona` | Tests requiring an explicitly enabled live Daytona backend | Variable, requires credentials |
 
 ### Marker Usage
 
@@ -56,7 +57,7 @@ Live LLM tests require Daytona connectivity and configured LLM credentials:
 
 ```bash
 # Validate Daytona connectivity first
-uv run python scripts/validate_env.py daytona
+uv run fleet-rlm daytona-smoke --repo https://github.com/qredence/fleet-rlm.git --ref main
 
 # Run live LLM tests
 uv run pytest -q -m "live_llm"
@@ -193,11 +194,12 @@ pnpm run test:watch
 
 ```text
 src/frontend/src/
-├── app/                  # Shell and workspace internals
-├── routes/               # File-based routes and /404 handling
-├── screens/              # Top-level workspace, volumes, settings, and shell surfaces
-├── lib/                  # API, workspace adapters, and shared helpers
-├── stores/               # Shared Zustand state
+├── app/                  # Bootstrap and provider composition
+├── routes/               # File-based route tree
+├── features/             # Product-surface entrypoints and UI ownership
+├── components/           # ui/, ai-elements/, and product compositions
+├── lib/                  # API clients, workspace adapters, and shared helpers
+├── stores/               # Shared Zustand shell state
 └── ...
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,79 +1,48 @@
-# Fleet-RLM Documentation
+# Documentation Home
 
-Welcome to the `fleet-rlm` documentation. The docs are organized roughly around the [Diataxis framework](https://diataxis.fr/) and describe the maintained product: a Daytona-backed recursive DSPy workspace with a thin FastAPI/WebSocket transport and a narrow Agent Framework host around it.
+`fleet-rlm` is a Daytona-backed recursive DSPy workbench. The maintained product path is the live workspace runtime, the durable volume browser, the optimization surface, runtime settings and diagnostics, and the session history and replay view. Historical audits and migration notes are kept separate so the current docs stay readable.
 
-## Quick Links
+## Start Here
 
-| Category | Description |
-|----------|-------------|
-| [Adaptive RLM Product Spec](explanation/product-spec.md) | User-facing product definition and capability model |
-| [Frontend Feature Spec](reference/frontend-feature-spec.md) | Page-level information architecture and component contracts |
-| [Architecture](architecture.md) | Current architecture overview and layer ownership |
-| [Current Architecture and Transition Note](notes/current-architecture-transition.md) | Migration status and cleanup guidance for transitional layers |
-| [Codebase Map](reference/codebase-map.md) | Focused backend ownership map |
-| [Module Map](reference/module-map.md) | Current backend module relationships |
-| [Tutorials](tutorials/index.md) | Learning-oriented guides for getting started |
-| [How-to Guides](how-to-guides/index.md) | Task-oriented guides for specific goals |
-| [Reference](reference/index.md) | Information-oriented technical documentation |
-| [Explanation](explanation/index.md) | Understanding-oriented conceptual guides |
+- [README](README.md) for the top-level docs landing page
+- [Product Spec](explanation/product-spec.md) for the user-facing product contract
+- [Architecture Overview](architecture.md) for the current layer ownership model
+- [Reference Index](reference/index.md) for implementation-facing contracts
+- [Explanation Index](explanation/index.md) for conceptual docs
+- [Current Architecture and Transition Note](notes/current-architecture-transition.md) for the active migration boundary
 
-## Quick Start
+## Current Docs
 
-```bash
-uv init
-uv add fleet-rlm
-uv run fleet web
-```
-
-Then open `http://localhost:8000`.
-
-## Choose Your Path
-
-### Use the Product
-
-- [Installation Guide](how-to-guides/installation.md)
-- [Adaptive RLM Product Spec](explanation/product-spec.md)
-- [Runtime Settings](how-to-guides/runtime-settings.md)
-- [Troubleshooting](how-to-guides/troubleshooting.md)
-
-### Build Integrations
-
-- [HTTP and WebSocket API](reference/http-api.md)
-- [CLI Reference](reference/cli.md)
-- [MCP Server Integration](how-to-guides/using-mcp-server.md)
-
-### Understand the System
-
-- [Architecture Overview](architecture.md)
-- [Current Architecture and Transition Note](notes/current-architecture-transition.md)
-- [Frontend Feature Spec &amp; Information Architecture](reference/frontend-feature-spec.md)
+- [Tutorials](tutorials/index.md)
+- [How-to Guides](how-to-guides/index.md)
+- [Reference](reference/index.md)
+- [Explanation](explanation/index.md)
 - [Frontend Product Surface Guide](guides/frontend-product-surface.md)
-- [Backend Codebase Map](reference/codebase-map.md)
-- [Python Backend Module Map](reference/module-map.md)
-- [Backend/Frontend Wiring Analysis](wiring-analysis.md)
-- [Concepts](explanation/concepts.md)
-- [Historical Snapshots](historical/index.md)
-- [Phase-by-phase migration notes](historical/index.md#architecture-and-migration-history)
-
-### Product Specs
-
 - [Optimization Page Spec](specs/optimization-page.md)
+- [Wiring Analysis](wiring-analysis.md)
 
-### Contribute
+## Current Product Surfaces
 
-- [Contributing Guide](../CONTRIBUTING.md)
-- [Developer setup](how-to-guides/developer-setup.md)
-- [CLI reference](reference/cli.md)
+- [Workbench](explanation/product-spec.md)
+- [Volumes](explanation/product-spec.md)
+- [Optimization](explanation/product-spec.md)
+- [Settings](explanation/product-spec.md)
+- [History](reference/frontend-backend-integration.md)
 
-## Source-of-Truth Policy
+## Historical Notes
 
-When documentation conflicts with implementation, treat these as authoritative:
+- [Historical Snapshots](historical/index.md)
+- [Architecture and migration history](historical/index.md#architecture-and-migration-history)
 
-- **CLI truth**: `uv run fleet-rlm --help` and `uv run fleet --help`
-- **API truth**: `openapi.yaml`
-- **WebSocket truth**: `src/fleet_rlm/api/routers/ws/endpoint.py` and adjacent helpers in `src/fleet_rlm/api/routers/ws/`
-- **Runtime core truth**: `src/fleet_rlm/runtime/agent/chat_agent.py`, `src/fleet_rlm/runtime/agent/recursive_runtime.py`, `src/fleet_rlm/integrations/daytona/interpreter.py`, and `src/fleet_rlm/integrations/daytona/runtime.py`
+## Complete Table Of Contents
 
----
+- [SUMMARY.md](SUMMARY.md)
 
-For a complete table of contents, see [SUMMARY.md](SUMMARY.md).
+## Source of Truth
+
+When docs disagree with the code, trust the code and generated contracts:
+
+- backend routes and websocket behavior in `src/fleet_rlm/api/`
+- outer host policy in `src/fleet_rlm/agent_host/`
+- runtime and Daytona execution in `src/fleet_rlm/runtime/` and `src/fleet_rlm/integrations/daytona/`
+- frontend route and workspace behavior in `src/frontend/src/`

--- a/docs/notes/current-architecture-transition.md
+++ b/docs/notes/current-architecture-transition.md
@@ -1,64 +1,38 @@
 # Current Architecture and Transition Note
 
-This note captures the current architecture framing to use when updating docs or planning cleanup work.
+This note is historical context for readers who still encounter older migration-era language in the docs.
 
-## Current framing
+## Historical Context
 
-Describe the backend in this order:
+The backend used to be described with bridge-layer terminology during the migration to the current layout. Those labels are historical only and are no longer present in the current tree.
 
-1. **Thin FastAPI/WebSocket transport**
-2. **Narrow but real Agent Framework outer orchestration host**
-3. **Daytona-backed recursive DSPy worker/runtime core**
+- `orchestration_app/` is historical terminology for an old compatibility bridge.
+- `api/orchestration/` is historical terminology for old compatibility shims.
+- The current ownership story is `api/` -> `agent_host/` -> `worker/` -> `runtime/` -> `integrations/daytona/`.
+- Offline evaluation and optimization remain in `runtime/quality/`.
 
-Add these explicit qualifiers when needed:
+## Current Read Order
 
-- `agent_host/` is real, but intentionally narrow.
-- `orchestration_app/` is a transitional compatibility layer.
-- `api/orchestration/` contains compatibility shims.
-- `runtime/agent/` plus `integrations/daytona/` are the long-term core.
-- `runtime/quality/` is the offline evaluation/optimization layer.
+When you want the live architecture, read these files first:
 
-## Read order for contributors
+1. `src/fleet_rlm/api/main.py`
+2. `src/fleet_rlm/api/routers/ws/endpoint.py`
+3. `src/fleet_rlm/api/runtime_services/chat_runtime.py`
+4. `src/fleet_rlm/agent_host/workflow.py`
+5. `src/fleet_rlm/agent_host/terminal_flow.py`
+6. `src/fleet_rlm/worker/streaming.py`
+7. `src/fleet_rlm/runtime/factory.py`
+8. `src/fleet_rlm/runtime/agent/chat_agent.py`
+9. `src/fleet_rlm/integrations/daytona/interpreter.py`
+10. `src/fleet_rlm/integrations/daytona/runtime.py`
 
-When trying to understand the system, start here:
+## What the Current Tree Actually Means
 
-1. `src/fleet_rlm/runtime/agent/chat_agent.py`
-2. `src/fleet_rlm/runtime/agent/recursive_runtime.py`
-3. `src/fleet_rlm/integrations/daytona/interpreter.py`
-4. `src/fleet_rlm/integrations/daytona/runtime.py`
-5. `src/fleet_rlm/worker/*`
-6. `src/fleet_rlm/agent_host/workflow.py`
-7. `src/fleet_rlm/api/main.py`
-8. `src/fleet_rlm/api/routers/ws/*`
-9. `src/fleet_rlm/orchestration_app/*`
-10. `src/fleet_rlm/api/orchestration/*`
+- `api/` is transport-thin: auth, websocket lifecycle, runtime services, session/history, and event shaping.
+- `agent_host/` is a real hosted policy layer: workflow orchestration, HITL, terminal ordering, checkpoints, and startup-status handling.
+- `worker/`, `runtime/`, and `integrations/daytona/` hold the execution core and sandbox substrate.
+- `runtime/quality/` is offline only and should not be treated as part of the live websocket request path.
 
-## Cleanup goals for the first pass
+## Historical Cleanup Rule
 
-Keep the first pass about structure and discoverability only.
-
-### Targeted cleanup checklist
-
-- [ ] Reduce compatibility clutter in `src/fleet_rlm/api/orchestration/*`
-- [ ] Reduce wrapper clutter under `src/fleet_rlm/api/routers/ws/*`
-- [ ] Shrink `src/fleet_rlm/orchestration_app/*` toward only still-needed transition seams
-- [ ] Remove stale ownership notes and deleted-file references from docs
-- [ ] Keep one current architecture overview and one current transition note linked from the docs index
-
-### Out of scope for the first pass
-
-- [ ] No redesign
-- [ ] No broad refactor
-- [ ] No runtime behavior rewrite
-- [ ] No movement of cognition into orchestration
-- [ ] No movement of Daytona execution or memory semantics into transport or host state
-- [ ] No websocket/public contract changes disguised as cleanup
-
-## Documentation deliverables
-
-The stable doc set for this framing should be:
-
-- one current architecture overview (`docs/architecture.md`)
-- one focused codebase map (`docs/reference/codebase-map.md`)
-- one backend module map (`docs/reference/module-map.md`)
-- one migration-status / transitional-structure note (this file)
+If older notes or reviews still mention bridge packages, treat them as migration history. Do not use them as current ownership labels when updating docs or code.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -243,7 +243,7 @@ Both `fleet` and `fleet-rlm serve-api` support Hydra-style configuration overrid
 # Example: override runtime settings
 uv run fleet web dspy_lm_model=gpt-4
 
-# Example: override Modal settings
+# Example: override runtime settings
 uv run fleet volume_name=my-custom-volume
 ```
 

--- a/docs/reference/codebase-map.md
+++ b/docs/reference/codebase-map.md
@@ -1,33 +1,78 @@
 # Backend Codebase Map
 
-This document summarizes the current backend package layout with the runtime core first and the outer layers called out explicitly.
-
-## Current Ordering
-
-1. **Runtime core**: `src/fleet_rlm/worker/`, `src/fleet_rlm/runtime/`, `src/fleet_rlm/integrations/` (with `src/fleet_rlm/integrations/daytona/` as the execution substrate)
-2. **Outer orchestration host**: `src/fleet_rlm/agent_host/`
-3. **Thin transport shell**: `src/fleet_rlm/api/`
-4. **Transitional bridge layers**: `src/fleet_rlm/orchestration_app/`, `src/fleet_rlm/api/orchestration/`
-5. **Offline quality layer**: `src/fleet_rlm/runtime/quality/`
+This document summarizes the current backend package layout with the live runtime core first and the transport shell called out explicitly.
 
 ## Top-Level Areas
 
 | Path | Role | Notes |
 | --- | --- | --- |
-| `src/fleet_rlm/worker/` | worker boundary | task contracts and worker-side adapters feeding the shared runtime |
-| `src/fleet_rlm/runtime/` | recursive runtime core | chat agent, recursive runtime, execution helpers, content helpers, tools, runtime models, and quality workflows |
-| `src/fleet_rlm/integrations/` | external systems boundary | config, database, MCP, observability, and provider integrations, including the Daytona execution substrate |
-| `src/fleet_rlm/integrations/daytona/` | Daytona substrate | interpreter, runtime/session lifecycle, volume helpers, diagnostics, and provider bridge code |
-| `src/fleet_rlm/agent_host/` | outer orchestration host | Agent Framework workflow, hosted HITL/checkpoint policy, execution events, and startup/repl bridges |
-| `src/fleet_rlm/api/` | transport shell | FastAPI auth, routers, schemas, websocket transport, and API-side services |
-| `src/fleet_rlm/orchestration_app/` | transitional bridge | compatibility orchestration seams retained during host migration |
-| `src/fleet_rlm/api/orchestration/` | compatibility shims | API-facing adapters that preserve older orchestration entrypoints |
-| `src/fleet_rlm/cli/` | operator surface | Typer commands, runner assembly, and terminal UX |
-| `src/fleet_rlm/scaffold/` | developer tooling | assets installed by `fleet-rlm init` |
-| `src/fleet_rlm/ui/` | packaged assets | built frontend artifacts for wheel installs |
-| `src/fleet_rlm/utils/` | small shared helpers | regex and other lightweight utility helpers |
+| `src/fleet_rlm/worker/` | worker boundary | task contracts and the stream adapter that hands work into the runtime agent |
+| `src/fleet_rlm/runtime/` | runtime core | shared chat logic, recursive execution, execution helpers, runtime models, tools, content helpers, and offline quality |
+| `src/fleet_rlm/integrations/daytona/` | Daytona substrate | interpreter, runtime/session lifecycle, workspace helpers, diagnostics, and volume access |
+| `src/fleet_rlm/agent_host/` | hosted policy layer | Agent Framework workflow, HITL, checkpointing, terminal ordering, and startup/repl bridges |
+| `src/fleet_rlm/api/` | transport shell | FastAPI app factory, auth, routers, schemas, websocket transport, runtime services, and event shaping |
+| `src/fleet_rlm/cli/` | operator surface | `fleet` / `fleet-rlm` entrypoints, command registration, and terminal UX |
+| `src/fleet_rlm/scaffold/` | packaged guidance | init assets, agent prompts, skills, hooks, and team templates |
+| `src/fleet_rlm/ui/` | packaged UI assets | built frontend artifacts for installed distributions |
+| `src/fleet_rlm/utils/` | shared helpers | small reusable utilities |
 
-## Primary Dependency Boundaries
+## Layer Map
+
+```mermaid
+graph TB
+    CLI["cli/"] --> API
+    CLI --> RUNTIME
+    CLI --> INTEGRATIONS
+    CLI --> SCAFFOLD
+
+    API["api/"] --> HOST["agent_host/"]
+    API --> RUNTIME["runtime/"]
+    API --> INTEGRATIONS["integrations/"]
+    API --> UI["ui/"]
+
+    HOST --> WORKER["worker/"]
+    WORKER --> RUNTIME
+    RUNTIME --> DAYTONA["integrations/daytona/"]
+    RUNTIME --> QUALITY["runtime/quality/"]
+```
+
+## Current Dependency Boundaries
+
+### `src/fleet_rlm/api/`
+
+- Incoming:
+  - CLI server entrypoints
+  - frontend HTTP and websocket clients
+  - tests
+- Outgoing:
+  - `src/fleet_rlm/agent_host/*`
+  - `src/fleet_rlm/runtime/*`
+  - `src/fleet_rlm/integrations/*`
+
+Key files:
+
+- `api/main.py` owns app factory, lifespan, route registration, and SPA mounting
+- `api/bootstrap.py` handles startup wiring, critical state, and optional warmup
+- `api/routers/ws/endpoint.py` owns the two websocket surfaces
+- `api/runtime_services/chat_runtime.py` prepares execution turns and runtime context
+- `api/runtime_services/chat_persistence.py` writes turn/session lifecycle data
+- `api/events/events.py` shapes execution-event payloads for passive subscribers
+
+### `src/fleet_rlm/agent_host/`
+
+- Incoming:
+  - `api/routers/ws/*`
+  - tests
+- Outgoing:
+  - `src/fleet_rlm/worker/*`
+
+Key files:
+
+- `agent_host/workflow.py` is the hosted Agent Framework workflow around the worker seam
+- `agent_host/hitl_flow.py` owns HITL checkpointing policy
+- `agent_host/terminal_flow.py` owns terminal ordering/completion policy
+- `agent_host/sessions.py` owns session continuation and restore helpers
+- `agent_host/execution_events.py` normalizes execution events for the host layer
 
 ### `src/fleet_rlm/worker/`, `src/fleet_rlm/runtime/`, and `src/fleet_rlm/integrations/daytona/`
 
@@ -38,61 +83,17 @@ This document summarizes the current backend package layout with the runtime cor
   - `integrations/mcp/server.py`
 - Outgoing:
   - `src/fleet_rlm/integrations/database/*`
-  - external Daytona SDK / provider systems
+  - external Daytona SDK and provider systems
 
-Key notes:
+Key files:
 
-- `runtime/agent/chat_agent.py` and `runtime/agent/recursive_runtime.py` are the main cognition loop.
-- `integrations/daytona/interpreter.py` and `integrations/daytona/runtime.py` are the execution and durable-memory substrate.
-- `runtime/models/builders.py` and `runtime/models/registry.py` are the runtime model/build registry surface.
-- `runtime/quality/*` is the offline DSPy evaluation and optimization layer.
-
-### `src/fleet_rlm/agent_host/`
-
-- Incoming:
-  - `api/routers/ws/*`
-  - tests
-- Outgoing:
-  - `src/fleet_rlm/orchestration_app/*`
-  - `src/fleet_rlm/worker/*`
-
-Key notes:
-
-- `agent_host/workflow.py` is host policy around the worker seam, not the core engine.
-- `agent_host/` is intentionally narrow: it should host policy, checkpoints, HITL, and execution-event coordination without becoming a second runtime.
-
-### `src/fleet_rlm/api/`
-
-- Incoming:
-  - CLI server entrypoints
-  - tests
-  - frontend HTTP/WebSocket clients
-- Outgoing:
-  - `src/fleet_rlm/agent_host/*`
-  - `src/fleet_rlm/runtime/*`
-  - `src/fleet_rlm/integrations/*`
-
-Key notes:
-
-- `api/main.py` owns app factory, lifespan, and SPA asset mounting.
-- `api/bootstrap.py` handles runtime bootstrap, critical startup, and optional warmup scheduling.
-- `api/routers/ws/*` should stay transport-thin: socket lifecycle, auth-derived identity, session extraction, event shaping, and envelope delivery.
-- `api/runtime_services/*` should stay service-thin: settings, diagnostics, volume browsing, and chat/runtime preparation.
-
-### `src/fleet_rlm/orchestration_app/` and `src/fleet_rlm/api/orchestration/`
-
-- Incoming:
-  - `agent_host/*`
-  - `api/routers/ws/*`
-- Outgoing:
-  - `src/fleet_rlm/worker/*`
-  - `src/fleet_rlm/runtime/*`
-
-Key notes:
-
-- These are transition seams, not the long-term center of gravity.
-- Prefer shrinking these packages toward only the still-needed compatibility paths.
-- Avoid adding new product logic here unless the work is explicitly about the migration seam itself.
+- `worker/streaming.py` is the boundary that streams a prepared request through the runtime agent
+- `runtime/factory.py` builds the canonical Daytona-backed chat agent
+- `runtime/agent/chat_agent.py` and `runtime/agent/recursive_runtime.py` contain the main cognition loop
+- `runtime/execution/*` contains execution helpers and streaming context
+- `runtime/models/*` contains runtime model assembly and registry code
+- `runtime/quality/*` is the offline evaluation and optimization layer
+- `integrations/daytona/interpreter.py` and `integrations/daytona/runtime.py` are the sandbox and durable-workspace substrate
 
 ### `src/fleet_rlm/cli/`
 
@@ -105,43 +106,23 @@ Key notes:
   - `integrations/*`
   - `scaffold/*`
 
-Key notes:
+Key files:
 
-- `fleet web` delegates into `fleet-rlm serve-api`.
-- Terminal UX belongs here, not in API or runtime transport code.
+- `cli/main.py` is the lightweight `fleet` launcher
+- `cli/fleet_cli.py` defines the `fleet-rlm` surface
+- `cli/runners.py` assembles shared runtime helpers
+- `cli/runtime_factory.py` remains a compatibility re-export only
 
-## Cross-Cutting Runtime Boundaries
+## Read First by Task
 
-These boundaries must stay aligned when making non-trivial backend changes:
+| Task | Read first |
+| --- | --- |
+| Websocket or runtime contract change | `api/main.py`, `api/routers/ws/endpoint.py`, `api/runtime_services/chat_runtime.py`, `agent_host/workflow.py`, `worker/streaming.py` |
+| Session/history change | `api/routers/sessions.py`, `integrations/local_store.py`, `api/runtime_services/chat_persistence.py` |
+| Runtime settings or diagnostics | `api/routers/runtime.py`, `api/runtime_services/settings.py`, `api/runtime_services/diagnostics.py` |
+| Daytona execution change | `runtime/factory.py`, `runtime/agent/chat_agent.py`, `integrations/daytona/interpreter.py`, `integrations/daytona/runtime.py` |
+| Offline optimization change | `runtime/quality/module_registry.py`, `runtime/quality/optimization_runner.py` |
 
-1. Websocket contract
-   `api/routers/ws/*`, `api/events/*`, `agent_host/*`, `runtime/execution/*`, `src/frontend/src/lib/rlm-api/*`, and the workspace stores/screens.
-2. Daytona execution contract
-   `api/schemas/core.py`, `api/routers/ws/types.py`, `worker/*`, `runtime/agent/*`, `integrations/daytona/*`, and the frontend runtime settings flow.
-3. Persistence and trace shaping
-   `integrations/database/*`, `api/events/*`, and `/api/v1/sessions/state`.
-4. CLI/runtime assembly
-   `cli/fleet_cli.py`, `cli/commands/serve_cmds.py`, `api/main.py`, and `integrations/mcp/server.py`.
+## Historical Note
 
-## Discoverability Hotspots
-
-The main complexity clusters are now:
-
-1. `runtime/agent/*` and `integrations/daytona/*`
-   The core reasoning and execution substrate live here.
-2. `agent_host/*`
-   Hosted policy is narrow, but it is real and should stay explicit in docs.
-3. `api/routers/ws/*`
-   The transport layer is thin by intent, but websocket changes still cascade into frontend workbench rendering.
-4. `orchestration_app/*` and `api/orchestration/*`
-   These are migration-heavy seams that benefit from continued cleanup and clearer ownership notes.
-
-## Verification
-
-The current map was checked against the source tree with:
-
-```bash
-# from repo root
-find src/fleet_rlm -maxdepth 2 -type d | sort
-rg --files src/fleet_rlm
-```
+Older docs may still refer to bridge packages that are no longer present in the tree. Treat those references as historical context only; do not use them as current ownership labels.

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -110,7 +110,7 @@ Associates users with tenants and defines their role.
 
 #### SandboxSession
 
-Represents a sandbox execution environment session (Modal, Daytona, etc.).
+Represents a sandbox execution environment session tracked by the persistence layer.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/docs/reference/frontend-architecture.md
+++ b/docs/reference/frontend-architecture.md
@@ -1,107 +1,153 @@
 # Frontend Architecture
 
-This document describes the maintained architecture of the frontend under
+This document describes the maintained frontend architecture under
 `src/frontend/src/`.
 
-The frontend is a React 19 + TypeScript + Vite app using TanStack Router for
-routing, TanStack Query for backend-backed state, and Zustand for client-side
-session/UI state.
+The frontend is a React 19 + TypeScript + TanStack Router + TanStack Query +
+Zustand application. The current codebase is organized around route files,
+feature modules, and shared `lib/` state adapters.
 
-## Current Directory Structure
+## Architecture Stack
+
+```mermaid
+flowchart TB
+  A["routes/"] --> B["features/layout/"]
+  A --> C["features/workspace/"]
+  A --> D["features/volumes/"]
+  A --> E["features/history/"]
+  A --> F["features/optimization/"]
+  A --> G["features/settings/"]
+
+  C --> H["lib/workspace/"]
+  C --> I["lib/rlm-api/"]
+  D --> I
+  F --> I
+  G --> I
+
+  B --> J["stores/navigation-store"]
+  C --> J
+```
+
+## Current Source Ownership
 
 ```text
 src/frontend/src/
-├── app/                         # App bootstrap and root composition
-├── routes/                      # File-based TanStack Router surfaces
-├── screens/                     # Product slices and route-level screen modules
-│   ├── shell/                   # App shell, navigation, auth/error screens
-│   ├── workspace/               # Chat, transcript, workbench, inspector, artifacts
-│   ├── volumes/                 # Volumes browser and file preview flows
-│   └── settings/                # Runtime and app settings
-├── components/
-│   ├── ui/                      # Shared UI primitives
-│   ├── prompt-kit/              # Prompt/message rendering components
-│   └── shared/                  # Shared app-specific utilities/components
+├── routes/              # TanStack Router file tree and not-found/login/logout/signup routes
+├── features/
+│   ├── layout/          # Shell chrome, route sync, sidebar, header, dialogs, canvas host
+│   ├── workspace/       # Chat-first execution workbench, transcript, inspector, run panel
+│   ├── volumes/         # Mounted Daytona volume browser and file preview flow
+│   ├── history/         # Session history list/detail and replay views
+│   ├── optimization/    # GEPA prompt optimization UI
+│   └── settings/        # Settings dialog/page and runtime settings forms
 ├── lib/
-│   └── rlm-api/                 # REST/WebSocket client contract and generated API types
-├── stores/                      # Cross-app Zustand stores
-└── styles.css                   # Theme tokens and global styles
+│   ├── workspace/       # Zustand stores, adapters, runtime hydration, transcript shaping
+│   └── rlm-api/         # REST and websocket clients plus generated API types
+├── stores/              # Shell/navigation state shared across the app
+├── components/ui/       # shadcn/Base UI primitives and thin local extensions
+├── components/ai-elements/  # AI Elements rendering primitives
+├── components/product/  # App-owned reusable composition built from registry layers
+└── app/                 # App bootstrap/providers
 ```
 
-## Supported Product Surfaces
+Route wrappers should point at `features/*` modules directly.
 
-The live frontend shell supports only:
+## Route Tree
 
-- `/app/workspace`
-- `/app/volumes`
-- `/app/optimization`
-- `/app/settings`
+The live route tree is intentionally small and explicit:
 
-Retired `taxonomy`, `skills`, `memory`, and `analytics` routes are no longer
-supported compatibility entrypoints; unknown legacy paths now fall through to
-the not-found flow.
+- `/` redirects to `/app/workspace`
+- `/app` mounts the shell layout
+- `/app/workspace` is the main workbench
+- `/app/volumes` is the mounted storage browser
+- `/app/history` is the session history surface
+- `/app/optimization` is the optimization surface
+- `/app/settings` is the settings dialog/page fallback
+- `/login`, `/logout`, `/signup`, and `/404` remain standalone routes
+- `src/routes/$.tsx` is the catchall for unsupported paths
 
-## Routing and Screen Composition
+The shell route files are thin wrappers only:
 
-- `src/router.tsx` owns the router instance.
-- `src/routes/*` contains the file-based route tree.
-- `src/routeTree.gen.ts` is generated and should not be edited by hand.
-- Thin route wrappers should render screen modules from `src/screens/*` rather than
-  introducing page-layer duplication.
+- `src/routes/app.tsx` mounts `RootLayout`
+- `src/routes/app/workspace.tsx` lazy-loads `features/workspace/workspace-screen`
+- `src/routes/app/volumes.tsx` lazy-loads `features/volumes/volumes-screen`
+- `src/routes/app/history.tsx` lazy-loads `features/history/history-screen`
+- `src/routes/app/optimization.tsx` lazy-loads `features/optimization/optimization-screen`
+- `src/routes/app/settings.tsx` lazy-loads `features/settings/settings-screen`
 
-The main frontend slices are:
+## Shell And Layout Behavior
 
-- `src/screens/workspace/` for the dominant chat/runtime/workbench surface
-- `src/screens/volumes/` for volumes browsing
-- `src/screens/settings/` for runtime/app settings
-- `src/screens/shell/` for shell chrome, navigation, and standalone auth/error screens
+`RootLayout` in `features/layout/root-layout.tsx` owns:
 
-## State and Runtime Contract
+- `AppProviders`
+- the sidebar, header, and route outlet
+- the desktop resizable split between content and canvas
+- the mobile bottom sheet canvas
+- login and settings dialogs
+- the command palette
+- the toast host
 
-- TanStack Query handles backend-backed reads and settings/status queries.
-- Zustand holds local session, navigation, transcript, workbench, and shell state.
-- `src/screens/workspace/model/chat-store.ts` remains part of the live streaming
-  contract with the backend.
-- `src/screens/workspace/model/run-workbench-store.ts` and
-  `src/screens/workspace/model/run-workbench-adapter.ts` own workbench hydration.
-- `src/screens/workspace/model/backend-chat-event-adapter.ts` reduces chat frames
-  into transcript state.
-- `src/screens/workspace/model/backend-artifact-event-adapter.ts` reduces execution
-  steps into the artifact/graph view.
+`RouteSync` is the URL-to-state bridge. It keeps the shell state in sync with
+the current route, and it clears the selected volume file when leaving Volumes.
+The reverse direction is handled by navigation helpers and route-triggered
+actions.
 
-Runtime expectations:
+Important shell behavior:
 
-- `/api/v1/ws/execution` is the canonical conversational websocket stream.
-- `/api/v1/ws/execution/events` is the passive execution/workbench stream.
-- `daytona_pilot` is the public runtime path and sends `execution_mode`, `repo_url`, `repo_ref`,
-  `context_paths`, and `batch_concurrency`.
-- Frontend workbench state should hydrate from `execution_completed.summary`, not
-  from legacy chat-final scraping.
+- Workbench keeps the inspector/canvas available.
+- Volumes opens the canvas automatically so the file preview stays adjacent to
+  the browser.
+- Optimization, History, and Settings close the canvas.
+- Mobile and desktop share the same route ownership, but the canvas is rendered
+  as a bottom sheet on mobile.
 
-## Backend Integration
+## State And Runtime Model
 
-- `src/lib/rlm-api/client.ts` owns REST calls.
-- `src/lib/rlm-api/wsClient.ts` owns chat/execution WebSocket setup.
-- `src/lib/rlm-api/generated/openapi.ts` is generated from `openapi.yaml`.
-- `src/lib/rlm-api/config.ts` derives REST/WS URLs from frontend env vars.
+The frontend uses three main state layers:
 
-The frontend and backend contract is documented in
-`docs/reference/frontend-backend-integration.md`. Treat that document and
-`src/frontend/AGENTS.md` as the primary references when changing runtime labels,
-request shapes, or websocket payload expectations.
+1. TanStack Router for route selection and route params.
+2. Zustand for local session, navigation, shell, transcript, and workbench
+   state.
+3. TanStack Query for backend-backed reads, settings, and status queries.
 
-## Validation
+Key stores and adapters:
 
-From `src/frontend/`:
+- `src/stores/navigation-store.ts` owns active nav and canvas state.
+- `src/features/workspace/use-workspace.ts` owns workspace session history,
+  backend streaming, and runtime orchestration.
+- `src/lib/workspace/chat-store.ts` owns the live transcript and session id.
+- `src/lib/workspace/run-workbench-store.ts` owns execution summary state and
+  artifact hydration.
+- `src/lib/workspace/backend-chat-event-adapter.ts` turns websocket chat frames
+  into transcript rows.
+- `src/lib/workspace/backend-artifact-event-adapter.ts` turns execution steps
+  into artifact graph state.
+- `src/lib/workspace/run-workbench-hydration.ts` normalizes execution summaries
+  and final artifacts into the canonical run panel state.
+
+## Frontend File Ownership Rules
+
+- Keep route files thin. They should only connect TanStack Router to the owning
+  feature module.
+- Keep shell behavior in `features/layout/*`.
+- Keep workbench logic in `features/workspace/*` and `lib/workspace/*`.
+- Keep mounted-storage behavior in `features/volumes/*`.
+- Keep session history in `features/history/*`.
+- Keep optimization and settings logic in their own feature trees.
+- Keep websocket and REST transport details in `lib/rlm-api/*`.
+- Keep generated API files and router output out of hand-edited docs and code.
+
+## Validation And Change Discipline
+
+When frontend route, shell, runtime, or API contract changes, validate against
+the current contracts rather than the old screen-based architecture.
+
+Useful checks from `src/frontend/`:
 
 - `pnpm install --frozen-lockfile`
 - `pnpm run api:check`
 - `pnpm run type-check`
-- `pnpm run lint`
+- `pnpm run lint:robustness`
 - `pnpm run test:unit`
 - `pnpm run build`
 - `pnpm run check`
-
-If browser-level behavior changed, also run:
-
-- `pnpm run test:e2e`

--- a/docs/reference/frontend-backend-integration.md
+++ b/docs/reference/frontend-backend-integration.md
@@ -1,306 +1,213 @@
-# Frontend ↔ Backend Integration
+# Frontend Back-end Integration
 
-This document captures the current integration contract between:
+This document captures the current integration contract between the frontend
+SPA and the backend API.
 
-- Frontend SPA: `src/frontend`
-- Backend API: `src/fleet_rlm/api`
+The important rule is simple: the frontend talks to the backend through a
+small REST surface, a conversational websocket, and a separate passive
+execution subscription websocket. There is no SSE path in the current frontend
+contract.
 
-## Supported Frontend Product Surfaces
+## Supported Product Surfaces
 
-The live frontend shell supports only:
+The live shell supports:
 
 - `/app/workspace`
 - `/app/volumes`
+- `/app/history`
 - `/app/optimization`
 - `/app/settings`
 
-Retired `/app/taxonomy*`, `/app/skills*`, `/app/memory`, and `/app/analytics`
-paths are no longer compatibility entrypoints; the frontend should route them
-through the not-found flow instead of redirecting them into active product
-surfaces.
+Legacy `taxonomy`, `skills`, `memory`, and `analytics` routes are not supported
+entrypoints.
 
-## API Base and Routing
+## REST Surfaces Used By The Frontend
 
-Backend serves:
+The frontend consumes the following backend surfaces:
 
-- Health: `/health`, `/ready`
-- Versioned API: `/api/v1/*`
-- WebSockets: `/api/v1/ws/execution`, `/api/v1/ws/execution/events`
-
-## Backend Surfaces Used by Frontend
-
-Primary interactive/chat surfaces:
-
-- Canonical: `WS /api/v1/ws/execution`
-- Passive execution subscriptions: `WS /api/v1/ws/execution/events`
-
-Runtime setup surfaces:
-
+- `GET /health`
+- `GET /ready`
 - `GET /api/v1/auth/me`
 - `GET /api/v1/runtime/settings`
-- `PATCH /api/v1/runtime/settings` (local-only writes)
+- `PATCH /api/v1/runtime/settings`
 - `POST /api/v1/runtime/tests/lm`
 - `POST /api/v1/runtime/tests/daytona`
 - `GET /api/v1/runtime/status`
+- `GET /api/v1/sessions/state`
+- `GET /api/v1/sessions`
+- `GET /api/v1/sessions/{id}`
+- `GET /api/v1/sessions/{id}/turns`
+- `DELETE /api/v1/sessions/{id}`
+- `POST /api/v1/traces/feedback`
 
-Runtime settings behavior:
+The history surface uses the sessions endpoints. The settings surface uses the
+runtime settings and runtime status endpoints. The workspace surface uses
+`/api/v1/auth/me` and runtime status to gate the composer and warnings.
 
-- `PATCH /api/v1/runtime/settings` writes are local-only (`APP_ENV=local`).
-- frontend runtime secret inputs are write-only; secrets are sent only when explicitly rotated or explicitly cleared.
-- runtime model changes are hot-applied in-process and can be verified via:
-  - `GET /api/v1/runtime/status`
-  - `active_models.planner`
-  - `active_models.delegate`
-  - `active_models.delegate_small`
-- `execution_mode` remains part of the Daytona-backed request state.
-- Daytona-specific source controls are `repo_url`, `repo_ref`,
-  `context_paths`, and `batch_concurrency`.
+## Websocket Split
 
-Daytona SDK and volume behavior:
+The client derives two websocket URLs from the API base:
 
-- The backend Daytona integration is implemented on the official Daytona Python SDK.
-- `DAYTONA_TARGET` is treated as Daytona SDK config only; it is not used as a workspace id,
-  sandbox id, or persistent volume name.
-- The Daytona Volumes page path browses a workspace-scoped persistent Daytona volume whose name is
-  derived from the authenticated workspace/tenant claim.
-- That persistent volume is attached to temporary Daytona sandboxes through the Python SDK
-  `volume.get(..., create=True)` + `VolumeMount(...)` flow.
+- `wsUrl` -> `/api/v1/ws/execution`
+- `wsExecutionUrl` -> `/api/v1/ws/execution/events`
 
-Deprecated/planned surfaces removed from backend:
-
-- `/api/v1/chat`
-- `/api/v1/tasks*`
-- `/api/v1/sessions*` CRUD (state summary endpoint remains)
-- `/api/v1/taxonomy*`
-- `/api/v1/analytics*`
-- `/api/v1/search`
-- `/api/v1/memory*`
-- `/api/v1/sandbox*`
-
-## Auth Contract
-
-- Frontend SPA auth uses Microsoft Entra via MSAL Browser.
-- Browser token storage uses the canonical `fleet-rlm:access-token` key only.
-  The legacy `fleet_access_token` localStorage migration path is no longer
-  supported.
-- Default frontend authority is `https://login.microsoftonline.com/organizations`.
-- Frontend login/logout callback path is `/login`.
-- The SPA requests `api://<api-app-client-id>/access_as_user`.
-- The same acquired access token is reused for:
-  - `Authorization: Bearer ...` on HTTP requests
-  - `access_token` bootstrap on websocket clients where the server supports query-token compatibility; prefer this only when a header cannot be forwarded
-- `GET /api/v1/auth/me` is the frontend’s canonical identity bootstrap endpoint.
-- In Entra mode, backend tenant admission is enforced against the Neon `tenants` table before runtime persistence starts.
-
-## WebSocket Behavior
+`VITE_FLEET_WS_URL` can override the base websocket host. If it is unset, the
+frontend derives both websocket URLs from `VITE_FLEET_API_URL`.
 
 ### `/api/v1/ws/execution`
 
-- Accepts `message`, `cancel`, and `command` payloads.
-- Emits `event`, `command_result`, and `error` envelopes.
-- Canonical purpose: conversational turn streaming.
-- Auth claims are canonical tenant/user authority.
-- `session_id` remains the authoritative client-controlled selector for chat-session restore/continue on message and command payloads.
-- `workspace_id` and `user_id` are unsupported on websocket payloads and should be rejected immediately.
-- Query `session_id` is intentionally unsupported on this route.
-- `daytona_pilot` is the public runtime label for the shared workbench runtime.
-- Daytona `message` frames may also carry `repo_url`, `repo_ref`,
-  `context_paths`, and `batch_concurrency`.
-- Daytona requests reject request-side `max_depth`, and `repo_ref` requires
-  `repo_url`.
-- Canonical event kinds:
-  - `assistant_token`
-  - `reasoning_step`
-  - `trajectory_step`
-  - `status`
-  - `warning`
-  - `tool_call`
-  - `tool_result`
-  - `plan_update`
-  - `rlm_executing`
-  - `memory_update`
-  - `hitl_request`
-  - `hitl_resolved`
-  - `command_ack`
-  - `command_reject`
-  - terminal: `final`, `cancelled`, `error`
-- Every chat event payload should carry normalized runtime metadata under `payload.runtime` when
-  runtime state is known. The stable keys are:
-  - `execution_mode`
-  - `depth`
-  - `max_depth`
-  - `execution_profile`
-  - `sandbox_active`
-  - `sandbox_id`
-  - `effective_max_iters`
-  - optional `volume_name`
-  - optional `run_id`
-- For Daytona, `payload.runtime.volume_name` refers to the workspace-scoped persistent Daytona
-  volume when that volume is in use for the run.
-- `final` is transcript-oriented. It may include the final assistant text, reasoning summary,
-  citations/sources, attachments, and terminal runtime metadata, but it is no longer the canonical
-  workbench hydration source for Daytona.
-- During the current compatibility window, chat-final payloads may still include legacy
-  `run_result` / `final_artifact` data.
-- Frontend workbench state may use chat-final only to backfill missing `summary` and
-  `final_artifact` after the turn; it must not hydrate rich analyst sections from chat-final.
+This is the conversational websocket. It handles:
 
-### Chat Trace Render Contract
+- `message`
+- `cancel`
+- `command`
 
-Frontend chat trace rendering uses AI Elements components with a live-first
-chronological policy:
+The frontend sends the first user turn here, including:
 
-- primary trace order:
-  - websocket arrival order for live events
-  - typical sequence: `Reasoning` -> `Tool`/`Sandbox` -> `Reasoning` -> ...
-- primary row mapping:
-  - `reasoning_step` -> `Reasoning`
-  - `tool_call` / `tool_result` -> `Tool` (or `Sandbox` for REPL-like payloads)
-  - `plan_update` / `rlm_executing` / `memory_update` -> `Task`
-  - `status` -> low-emphasis status note row
-- secondary summaries:
-  - `ChainOfThought` and `Queue` are summary surfaces only (non-primary)
-  - summaries never replace or reorder primary chronological rows
+- `content`
+- `trace`
+- `trace_mode`
+- `execution_mode`
+- `repo_url`
+- `repo_ref`
+- `context_paths`
+- `batch_concurrency`
+- `analytics_enabled`
+- `session_id`
 
-Trajectory payload handling:
+Important rules:
 
-- trajectory data is fallback/summary-oriented
-- trajectory-derived interleaving is only used when live reasoning/tool events
-  are absent for the turn
+- `session_id` is carried on the message and command payloads.
+- `workspace_id` and `user_id` are not supported on websocket payloads.
+- Query-string `session_id` is intentionally not part of this route.
+- `resolve_hitl` is the command currently used by the workspace HITL flow.
 
-### `/api/v1/ws/execution`
+Common event kinds on this stream:
 
-- Dedicated execution/workbench stream for artifact, step, and run-summary visualization.
-- Filters by auth-derived identity plus query `session_id`.
-- `workspace_id` and `user_id` query params are unsupported and should be rejected immediately.
-- Emits `execution_started`, `execution_step`, `execution_completed`.
-- `execution_completed.summary` is the canonical canvas/workbench summary for the Daytona-backed
-  runtime. Frontend workbench state should hydrate from this summary rather than scraping data from
-  transcript-final payloads.
-- `execution_step.step` now carries additive actor metadata:
-  - `depth` (optional)
-  - `actor_kind` (`root_rlm | sub_agent | delegate | unknown`, optional)
-  - `actor_id` (optional)
-  - `lane_key` (optional)
-- Minimum required top-level fields:
-  - `run_id`
-  - `task`
-  - `final_artifact`
-  - `summary`
-- `summary` should carry the final termination/error/warnings/duration metadata the workbench needs.
-- Richer completion sections remain allowed but optional in this phase:
-  - `status`
-  - `termination_reason`
-  - `duration_ms`
-  - `iterations`
-  - `callbacks`
-  - `prompt_handles` / `prompts`
-  - `context_sources`
-  - `sources`
-  - `attachments`
-  - `warnings`
-- `execution_step.step.type` remains runtime-agnostic with the current `llm | tool | repl | memory
-  | output` lane model.
-- `execution_step.step.timestamp` is emitted as numeric Unix epoch seconds by the backend; the frontend may normalize it for display, but should not require ISO strings on the wire.
+- `assistant_token`
+- `reasoning_step`
+- `trajectory_step`
+- `status`
+- `warning`
+- `tool_call`
+- `tool_result`
+- `plan_update`
+- `rlm_executing`
+- `memory_update`
+- `hitl_request`
+- `hitl_resolved`
+- `command_ack`
+- `command_reject`
+- `final`
+- `cancelled`
+- `error`
 
 ### `/api/v1/ws/execution/events`
 
-- Dedicated passive execution/workbench subscription stream.
-- Requires query `session_id`.
-- Accepts no message, cancel, or command frames.
-- Emits `execution_started`, `execution_step`, and `execution_completed`.
+This is the passive execution subscription stream.
 
-### Unified Workspace Canvas Contract
+Important rules:
 
-- Frontend transcript state and workbench state should reduce into a canonical per-turn record keyed
-  by assistant turn / session / run identity.
-- The chat transcript remains compact:
-  - user message
-  - assistant streaming/final answer
-  - lightweight trace/status/tool summaries
-- The canvas is the primary place for verbose execution detail:
-  - `Answer`
-  - `Reasoning`
-  - `Plan / Trajectory`
-  - `Tools / Execution`
-  - `Evidence`
-  - `Artifacts`
-- Daytona-specific iteration/callback/prompt detail is additive inside the canvas. It is not the
-  primary cross-runtime reasoning model.
-- Daytona live trace should expose the guide-relevant milestones in realtime:
-  iteration start, planner/reasoning preview, extracted code preview, sandbox observation, recursive
-  child spawn / child synthesis, and terminal completion or failure.
-- Daytona sandbox/debug transcript cards are driven by `status` frames whose payload carries
-  `phase="sandbox_output"` plus stream text metadata. Treat that wire shape as part of the
-  transcript rendering contract while it remains in use.
+- `session_id` is required as a query parameter.
+- The stream is subscription-only.
+- It does not accept `message`, `cancel`, or `command` frames.
+- It emits execution lifecycle frames for the workbench canvas.
 
-### Execution Graph Semantics
+## Runtime And Workbench Contract
 
-Artifact graph rendering maps execution steps into actor swimlanes:
+The workspace runtime is Daytona-backed and the UI treats `daytona_pilot` as
+the public runtime label.
 
-- `Root RLM` lane: root planner/orchestrator execution.
-- `Sub-agent` lanes: recursive/delegated agent depth contexts.
-- `Delegate` lanes: delegate profile execution contexts.
-- `Unknown` lane: fallback when actor hints are unavailable.
+The frontend keeps the following runtime controls aligned with backend requests:
 
-Ordering and edge rules:
+- `execution_mode`
+- `repo_url`
+- `repo_ref`
+- `context_paths`
+- `batch_concurrency`
 
-- Step order is deterministic by `sequence`, with `(timestamp, id)` as fallback.
-- Parent-child edges are causal (primary).
-- Chronological edges are dashed temporal hints (secondary).
+The backend enriches frames with runtime context. The frontend treats these keys
+as stable when present:
 
-Content policy:
+- `depth`
+- `max_depth`
+- `execution_profile`
+- `sandbox_active`
+- `effective_max_iters`
+- `volume_name`
+- `execution_mode`
+- `runtime_mode`
+- `sandbox_id`
+- `workspace_path`
+- `sandbox_transition`
 
-- Graph, Timeline, and Preview surfaces do not intentionally truncate artifact
-  text content.
-- Large payloads may be shown in scrollable regions, but full text remains
-  accessible in-place.
+### Transcript Stream
 
-## Environment Variables
+`/api/v1/ws/execution` feeds the live transcript.
 
-Frontend connectivity is typically driven by:
+The frontend reduces frames into:
 
-- `VITE_FLEET_API_URL`
-- `VITE_FLEET_WS_URL`
-- `VITE_FLEET_TRACE`
+- user and assistant messages
+- reasoning and trajectory rows
+- tool and sandbox cards
+- HITL / clarification cards
+- summary rows and warnings
 
-Execution stream payload-size controls (backend):
+The adapter stack is:
 
-- `WS_EXECUTION_MAX_TEXT_CHARS` (default `65536`)
-- `WS_EXECUTION_MAX_COLLECTION_ITEMS` (default `500`)
-- `WS_EXECUTION_MAX_RECURSION_DEPTH` (default `12`)
+1. `ws-frame-parser.ts` normalizes raw websocket frames.
+2. `backend-chat-event-adapter.ts` turns chat frames into transcript rows.
+3. `backend-artifact-event-adapter.ts` turns execution steps into artifact rows.
+4. `chat-display-items.ts` groups rows into assistant turns.
 
-## Validation Checklist
+### Workbench Hydration
 
-From repo root:
+The workbench panel is summary-driven.
 
-```bash
-uv run fleet-rlm serve-api --port 8000
-uv run python scripts/openapi_tools.py generate
-rg -n "^  /" openapi.yaml
-rg -n "@router.websocket" src/fleet_rlm/api/routers/ws/endpoint.py
-```
+The canonical hydration path is:
 
-From `src/frontend` (optional frontend validation):
+1. `ws-frame-parser.ts` converts `execution_completed` frames into a normalized
+   event envelope.
+2. `run-workbench-hydration.ts` merges `summary`, `final_artifact`, run
+   metadata, prompts, iterations, callbacks, sources, and attachments into the
+   workbench state.
+3. `run-workbench-store.ts` keeps the canonical run panel state in Zustand.
 
-```bash
-pnpm install --frozen-lockfile
-pnpm run api:check
-pnpm run type-check
-pnpm run lint:robustness
-pnpm run test:unit
-pnpm run build
-```
+Rules:
 
-## Change Policy
+- `execution_completed.summary` is the primary completion source.
+- `final_artifact` is the primary artifact source.
+- Chat-final `run_result` is only a narrow compatibility backfill path.
+- The workbench should not depend on transcript scraping for its canonical
+  completion state.
 
-If backend routes or payload shapes change, update this file in the same PR as the code change.
+## Session And History Contract
 
-## Frontend API Layer Policy
+The history surface uses both backend sessions and local conversation state.
 
-- Canonical backend contracts for runtime/chat/auth should use `src/frontend/src/lib/rlm-api/*`.
-- Legacy `src/frontend/src/lib/api` auth/chat endpoint helpers have been removed. Do not reintroduce auth/chat contracts in that layer.
-- Canonical frontend feature ownership now lives in:
-  - `src/frontend/src/screens/workspace/*` for the live chat/runtime surface
-  - `src/frontend/src/screens/volumes/*` for the volumes browser
-  - `src/frontend/src/screens/shell/*` for composed shell navigation widgets
+Backend session data supports:
+
+- session list
+- session detail
+- session turns
+- session deletion
+
+The local conversation store remains a UI-level feature for saved workspace
+sessions and does not replace the backend session history.
+
+## Settings Contract
+
+Runtime settings writes are local-only in the current frontend contract.
+
+The settings feature treats these operations as current:
+
+- read current runtime settings
+- save runtime settings
+- test LM connectivity
+- test Daytona connectivity
+- refresh runtime status
+
+The runtime and LiteLLM forms use the backend runtime settings API. The
+optimization section reuses the optimization feature form rather than duplicating
+its own settings implementation.
+

--- a/docs/reference/frontend-feature-spec.md
+++ b/docs/reference/frontend-feature-spec.md
@@ -1,629 +1,152 @@
-# Frontend Feature Spec &amp; Information Architecture
+# Frontend Feature Spec
 
-> **Audience**: Engineers and AI agents working on the fleet-rlm frontend.
-> **Status**: Normative spec for current and near-term surfaces.
-> **Companion docs**: [Frontend Product Surface Guide](../guides/frontend-product-surface.md) · [Architecture](../architecture.md) · [Wiring Analysis](../wiring-analysis.md)
-
----
+> Audience: engineers and AI agents working on the Fleet RLM frontend.
+> Status: normative spec for the current frontend surfaces.
 
 ## Guiding Principle
 
-> **The UI should expose the recursive worker clearly, without exposing the architecture messily.**
+The UI should expose the recursive worker clearly without exposing the
+transport or layout machinery.
 
-Users should feel:
+Users should feel that they can:
 
-- "I can ask the system to do work"
-- "I can see what it's doing"
-- "I can inspect memory/artifacts when needed"
-- "I can tune how it runs"
-- "I can resume or review work later"
+- submit a task
+- watch the system work
+- inspect outputs and artifacts
+- tune execution settings
+- revisit prior work
 
-Users should **not** feel:
+Users should not feel that they are staring at a transport protocol viewer or a
+legacy screen shell.
 
-- "I am staring at a transport protocol viewer."
+## Product Surfaces
 
----
+| Route | Surface | Owning feature module | Purpose |
+| --- | --- | --- | --- |
+| `/app/workspace` | Workbench | `features/workspace/workspace-screen.tsx` | Primary task execution surface |
+| `/app/volumes` | Volumes | `features/volumes/volumes-screen.tsx` | Mounted Daytona volume browser |
+| `/app/history` | History | `features/history/history-screen.tsx` | Session and conversation history |
+| `/app/optimization` | Optimization | `features/optimization/optimization-screen.tsx` | GEPA prompt optimization |
+| `/app/settings` | Settings | `features/settings/settings-screen.tsx` | Runtime and app settings |
 
-## Core User Journeys
+## Workbench Spec
 
-| Journey | Primary page | Supporting surfaces |
-|---------|-------------|---------------------|
-| Start a task | Workbench | Composer, mode selector |
-| Monitor progress | Workbench | Execution stream, status badge, inspector |
-| Inspect outputs/artifacts | Workbench inspector | Run workbench panel, artifact cards |
-| Handle escalation / human review | Workbench | HITL card inline, review panel |
-| Revisit prior work | Sidebar session list | Workbench (loaded conversation) |
-| Manage volumes/memory | Volumes | Volume browser, file detail panel |
-| Adjust execution settings | Settings dialog | Runtime, appearance, optimization sections |
-| Optimize prompts | Optimization | GEPA form |
+The workbench is the primary live surface. It is chat-first, but it is not just
+a chat box.
 
----
+### Ownership
 
-## Navigation Model
+- `WorkspaceScreen` owns runtime bootstrap, placeholder behavior, session
+  persistence, and the execution mode selector.
+- `useWorkspace()` owns streaming, cancel, HITL resolution, and conversation
+  loading.
+- `useChatStore` owns live transcript state.
+- `useRunWorkbenchStore` owns execution summaries, artifacts, iterations,
+  callbacks, and completion metadata.
 
-### Current Navigation
+### Regions
 
-| Item | Route | NavItem | Purpose |
-|------|-------|---------|---------|
-| **Workbench** | `/app/workspace` | `workspace` | Primary task execution surface |
-| **Volumes** | `/app/volumes` | `volumes` | Durable memory/storage browser |
-| **Optimization** | `/app/optimization` | `optimization` | GEPA prompt optimization |
-| **Settings** | Dialog (or `/app/settings`) | `settings` | Configuration and preferences |
+| Region | Purpose | Main modules |
+| --- | --- | --- |
+| Header | Page identity, sidebar toggle, canvas toggle | `features/layout/header.tsx` |
+| Transcript | Live user/assistant/trace rendering | `features/workspace/ui/transcript/*` |
+| Composer | Submit, stop, execution mode, attachments | `features/workspace/ui/workspace-composer.tsx` |
+| Canvas / Inspector | Turn details, graph, execution panel, run panel | `features/workspace/workspace-canvas-panel.tsx` and `features/workspace/ui/*` |
+| HITL | Human review / approval | `features/workspace/ui/hitl-approval-modal.tsx` |
+| Session sidebar | Local conversation history and session actions | `features/workspace/ui/session-sidebar.tsx` |
 
-### Session List
+### Workbench States
 
-The sidebar "Chats" section serves as the session/run history surface. Conversations are stored in `useChatHistoryStore` (localStorage-backed) and sorted by `updatedAt`.
+| State | Behavior |
+| --- | --- |
+| `idle` | Composer enabled, empty state visible |
+| `understanding` | Request is being prepared |
+| `running` | Live transcript and workbench updates stream in |
+| `needs_human_review` | HITL card blocks continuation until resolved |
+| `complete` | Final answer and summary are visible |
+| `error` | Failure state with retry affordance |
+| `cancelled` | Neutral termination state |
 
-### Future Navigation (out of scope, documented for planning)
+### Transcript Model
 
-| Item | Purpose | Prerequisite |
-|------|---------|-------------|
-| Runs / History | Dedicated run browser with filters | Backend `/api/v1/sessions` list endpoint |
-| Artifacts | Standalone artifact browser | Backend artifact listing endpoint |
-| Approvals | Dedicated HITL queue | Backend approval queue endpoint |
-| Debug / Traces | Execution trace browser | Backend trace export |
+The transcript is built from normalized backend frames and grouped into
+assistant turns.
 
----
+Key render categories:
 
-## Page Specifications
+- user message
+- assistant answer
+- reasoning
+- trajectory
+- tool call and tool result
+- sandbox output
+- status note
+- HITL request / resolution
+- clarification request
+- plan update / RLM execution / memory update
 
----
+The transcript is summary-friendly, but the canonical completion state belongs
+in the workbench panel.
 
-### 1. Workbench Page
+## Volumes Spec
 
-**Route**: `/app/workspace`
-**Feature module**: `features/workspace/workspace-screen.tsx`
-**Purpose**: The place where a user submits a task, sees live execution, reads results, follows recursive progress, and handles escalation.
+The Volumes surface is a browser for the mounted Daytona volume tree.
 
-#### Primary User Actions
+Rules:
 
-| Action | Component | Backend dependency |
-|--------|-----------|-------------------|
-| Submit a task | `WorkspaceComposer` | `POST /api/v1/ws/execution` (websocket) |
-| Monitor live execution | `WorkspaceMessageList` | Streaming WS frames |
-| Stop execution | Composer stop button | `stopStreaming()` closes WS |
-| Handle HITL checkpoint | HITL card actions | `resolve_hitl` WS command |
-| Inspect run details | Inspector side panel | `useRunWorkbenchStore` state |
-| Switch execution mode | Composer mode selector | `executionMode` WS param |
-| Load prior conversation | Sidebar session click | `useChatHistoryStore` |
-| Start new session | Sidebar "New session" | `resetSession()` |
+- selecting a file opens the shell canvas
+- leaving the Volumes route clears the selected file
+- the canvas is a preview/detail area, not the primary browser
+- the volume tree should be treated as mounted durable storage, not the live
+  workspace session
 
-#### Regions
+## History Spec
 
-##### A. Header / Context Bar
+History is a first-class routed surface, not a sidebar-only concept.
 
-The global `LayoutHeader` provides:
+Rules:
 
-- Current page identity (Workbench)
-- Sidebar toggle
-- Canvas panel toggle
-- Session status via sidebar navigation
+- it lists backend sessions and local conversations
+- it can open a detail drawer without leaving the shell
+- it supports replay/inspection of prior work
+- it is separate from the live workbench turn flow
 
-**Should answer**: "Where am I, what context is active?"
+## Optimization Spec
 
-##### B. Main Execution Stream
+The optimization surface is a standalone product area.
 
-The heart of the page: `WorkspaceMessageList`.
+Rules:
 
-Renders distinct content blocks mapped from `ChatDisplayItem`:
+- it exposes modules, datasets, runs, and compare tabs
+- it does not participate in the live workspace websocket turn
+- it should reuse shared optimization form logic rather than duplicating config
 
-| Block type | `ChatMessage.type` / render part | Visual treatment |
-|------------|----------------------------------|-----------------|
-| **User message** | `user` | Right-aligned card with task text |
-| **Assistant answer** | `assistant` | Left-aligned card with markdown content |
-| **Reasoning** | `trace` → `reasoning` part | Collapsible inline reasoning block |
-| **Chain of thought** | `trace` → `chain_of_thought` part | Step timeline with status indicators |
-| **Tool call** | `trace` → `tool` part | Collapsible tool invocation card |
-| **Sandbox execution** | `trace` → `sandbox` part | Code block with output |
-| **Status note** | `trace` → `status_note` part | Inline status message |
-| **Queue / task progress** | `trace` → `queue` / `task` parts | Checklist progress |
-| **HITL checkpoint** | `hitl` | Highlighted review card with action buttons |
-| **Clarification request** | `clarification` | Question card with option buttons |
-| **Confirmation** | `trace` → `confirmation` part | Approve/reject action card |
-| **Error** | WS error frame | Error alert with retry affordance |
-
-Content blocks are grouped into **assistant turns** via `buildChatDisplayItems()`, which merges adjacent trace messages, tool sessions, and reasoning into logical turn units.
-
-**Content tone**: Action-oriented, calm, informative. Show "Running analysis…" not "Dispatching recursive decomposition module".
-
-##### C. Composer / Task Input Area
-
-The `WorkspaceComposer` at the bottom:
-
-- Main text input with contextual placeholder
-- Execution mode selector (auto/workspace/etc.)
-- Send/stop button with streaming state
-- Attachment support (currently text-only)
+## Settings Spec
 
-**Should feel like a task launcher**, not just a chat textbox.
+Settings can open as a dialog or as the routed fallback page.
 
-Placeholder text varies by state:
+Supported sections:
 
-| State | Placeholder |
-|-------|------------|
-| No backend | "Backend not configured — check Settings → Runtime" |
-| Idle, no messages | "Describe what you'd like to build or accomplish…" |
-| Idle, has messages | "Continue the conversation or start a new task…" |
-| Active | "Ask a follow-up question or provide more context…" |
+- `appearance`
+- `telemetry`
+- `litellm`
+- `runtime`
+- `optimization`
 
-##### D. Inspector / Context Panel (Canvas)
+Rules:
 
-The collapsible right-side panel (`LayoutSidepanel` → `WorkspaceCanvasPanel`):
+- the dialog is the primary entrypoint
+- the routed page is a fallback and compatibility surface
+- runtime settings and connectivity checks live in the settings feature tree
+- optimization settings reuse the optimization form from the optimization
+  feature
 
-| Tab | Content | Component |
-|-----|---------|-----------|
-| **Execution** | Run status, iterations, callbacks, context sources | `RunWorkbench` |
-| **Trajectory** | Turn-level reasoning and step details | `MessageInspectorPanel` |
-| **Evidence** | Sources, citations, attachments | Inspector evidence tab |
-| **Graph** | Artifact dependency graph | `ArtifactGraph` |
+## Navigation And Shell Rules
 
-##### E. Terminal Action State
+- `RootLayout` owns the shell chrome.
+- `RouteSync` keeps the URL and navigation store aligned.
+- `NavigationStore` is the client-side shell state for active nav and canvas
+  visibility.
+- `layout` owns the shell UX; product surfaces own their own internal logic.
+- route files stay thin and should not acquire page-level business logic.
 
-When a run completes, the composer re-enables for follow-up. The run workbench panel shows:
-
-- Final artifact summary
-- Iteration history
-- Duration and sandbox count
-- Error details (if failed)
-- Human review details (if escalated)
-
-#### UI States
-
-| State | `RunStatus` | Visual behavior |
-|-------|-------------|----------------|
-| **Idle** | `idle` | Empty state with suggestions, composer enabled |
-| **Starting** | `bootstrapping` | Loading shimmer "Setting up your workspace…", composer disabled |
-| **Running** | `running` | Streaming execution blocks, stop button visible |
-| **Waiting for review** | `needs_human_review` | HITL card highlighted, action buttons enabled |
-| **Completed** | `completed` | Final answer visible, composer re-enabled |
-| **Failed** | `error` | Error message with details, composer re-enabled |
-| **Cancelled** | `cancelled` | Neutral termination state, composer re-enabled |
-| **Cancelling** | `cancelling` | Spinner, "Stopping…" label |
-
-#### Backend Dependencies
-
-| Dependency | Endpoint / mechanism |
-|------------|---------------------|
-| Execution stream | `/api/v1/ws/execution` (websocket) |
-| Execution events | `/api/v1/ws/execution/events` (SSE) |
-| Session state | `GET /api/v1/sessions/state` |
-| Auth | `GET /api/v1/auth/me` |
-| Runtime status | `GET /api/v1/runtime/status` |
-| HITL resolution | `resolve_hitl` WS command |
-| Trace feedback | `POST /api/v1/traces/feedback` |
-
-#### Out of Scope for Workbench
-
-- Direct Daytona API calls (abstracted by backend)
-- Recursive worker decision logic (belongs in `fleet_rlm.worker`)
-- Volume management (Volumes page)
-- Prompt optimization (Optimization page)
-
----
-
-### 2. Settings Dialog
-
-**Route**: Dialog overlay (or `/app/settings`)
-**Feature module**: `features/settings/settings-screen.tsx`
-**Purpose**: Control defaults and user preferences for how the system runs.
-
-#### Sections
-
-| Section | Key | Icon | Purpose |
-|---------|-----|------|---------|
-| **Appearance** | `appearance` | Paintbrush | Theme, density, scroll behavior |
-| **Telemetry** | `telemetry` | Bell | Privacy and analytics preferences |
-| **LiteLLM** | `litellm` | Bot | Model provider, endpoint, API key |
-| **Runtime** | `runtime` | Cpu | Daytona credentials, connectivity |
-| **Optimization** | `optimization` | Sparkles | GEPA configuration and execution |
-
-#### Content Guidance by Section
-
-**Appearance** — UI preferences:
-
-- Theme (light/dark/system)
-- Density (compact/comfortable) — future
-- Show detailed execution events — future
-- Developer mode — future
-
-**Telemetry** — Privacy:
-
-- Analytics opt-in/out
-- PostHog integration toggle
-
-**LiteLLM** — Model configuration:
-
-- Provider base URL
-- API key
-- Planner model selection
-- Delegate model selection — future
-
-Copy should explain tradeoffs:
-
-- "Faster models reduce latency but may produce lower-quality reasoning"
-- "The planner model handles task decomposition and strategy"
-
-**Runtime** — Sandbox connectivity:
-
-- Daytona API key
-- Daytona server URL
-- Connection test
-- Runtime status display
-
-Copy should clarify what "runtime" means:
-
-- "Connect to a Daytona sandbox for secure isolated code execution"
-- "Your code runs in a persistent workspace with durable storage"
-
-**Optimization** — GEPA:
-
-- Metric selection
-- Optimization parameters
-- Run controls
-
-#### Behavior Principles
-
-- Searchable or clearly sectioned
-- Good defaults
-- Explanatory copy for each field
-- Restore defaults button — future
-- Save/cancel semantics
-- Avoid exposing raw internal jargon unless in advanced mode
-
-#### Backend Dependencies
-
-| Dependency | Endpoint |
-|------------|----------|
-| Runtime settings | `GET/PATCH /api/v1/runtime/settings` |
-| Runtime status | `GET /api/v1/runtime/status` |
-| Optimization | `POST /api/v1/optimization/run`, `GET /api/v1/optimization/status` |
-
----
-
-### 3. Volumes Page
-
-**Route**: `/app/volumes`
-**Feature module**: `features/volumes/volumes-screen.tsx`
-**Purpose**: Let users understand and manage durable workspace/memory containers.
-
-Volumes are not just storage — they are **part of the durable memory model**. The UI should help users understand: "What durable information does this agent retain here?"
-
-#### Primary User Actions
-
-| Action | Component | Backend dependency |
-|--------|-----------|-------------------|
-| Browse volume tree | `VolumesBrowser` | `GET /api/v1/runtime/volumes` |
-| Search files | Search input | Client-side `filterFs()` |
-| Inspect file content | Canvas detail panel | Client-side from volume tree |
-| Expand/collapse tree | Expand/Collapse buttons | Client-side state |
-| Refresh | Refresh button | Re-fetch volume tree |
-
-#### Volume Tree Structure
-
-The volume browser renders a hierarchical tree of `FsNode` items:
-
-| Node type | Visual treatment |
-|-----------|-----------------|
-| Volume root | `HardDrive` icon, label style, file count badge |
-| Directory | Folder/FolderOpen icon, expandable |
-| File | Type-specific icon (`.py`, `.md`, `.json`, etc.), size display |
-
-Durable mounted-volume roots follow the pattern: `memory/`, `artifacts/`, `buffers/`, `meta/`.
-
-#### UI States
-
-| State | Visual behavior |
-|-------|----------------|
-| Loading | Centered spinner, "Loading durable volume tree…" |
-| Empty | "No files found in the durable volume." |
-| Degraded | Warning alert explaining volume endpoint is unavailable |
-| Populated | Tree view with expand/collapse, search, file count |
-
-#### File Detail Panel (Canvas)
-
-When a file is selected, the canvas panel opens with:
-
-- File name and path
-- File size and modification date
-- Content preview (for supported types)
-
-#### Content Guidance
-
-Copy should explain persistence:
-
-- "Browse the Daytona mounted durable volume for this workspace"
-- "Files here persist across sessions and execution runs"
-- What is stored (memory files, artifacts, patches, generated outputs, logs, session metadata)
-- What is safe to remove
-- What is reused across runs
-
-#### Volume Safety
-
-Because this page touches durable state, future destructive actions should:
-
-- Be explicit with confirmation dialogs
-- Show impact clearly
-- Support archive before delete if possible
-
-#### Backend Dependencies
-
-| Dependency | Endpoint |
-|------------|----------|
-| Volume tree | `GET /api/v1/runtime/volumes` (or Daytona direct) |
-| File content | Volume content endpoints |
-| Runtime status | `GET /api/v1/runtime/status` |
-
-#### Out of Scope
-
-- Volume creation/deletion (future)
-- Volume import/export (future)
-- Memory/knowledge graph view (future)
-
----
-
-### 4. Optimization Page
-
-**Route**: `/app/optimization`
-**Feature module**: `features/optimization/optimization-screen.tsx`
-**Purpose**: Configure and run GEPA prompt optimization.
-
-#### Primary User Actions
-
-| Action | Component | Backend dependency |
-|--------|-----------|-------------------|
-| Configure optimization | `OptimizationForm` | `POST /api/v1/optimization/run` |
-| Check status | Status display | `GET /api/v1/optimization/status` |
-
-#### Backend Dependencies
-
-| Dependency | Endpoint |
-|------------|----------|
-| Run optimization | `POST /api/v1/optimization/run` |
-| Check status | `GET /api/v1/optimization/status` |
-
----
-
-### 5. Session List (Sidebar)
-
-**Location**: `LayoutSidebar` → "Chats" group
-**Purpose**: Review, resume, and inspect past work.
-
-#### Current State
-
-- Conversations stored in `useChatHistoryStore` (localStorage)
-- Sorted by `updatedAt` descending
-- Title derived from first user message
-- Delete action per conversation
-- Load conversation restores messages, phase, and turn artifacts
-
-#### Content
-
-Each session entry shows:
-
-- Title (truncated)
-- Delete action (hover reveal)
-
-#### Future Enhancements (documented for planning)
-
-A dedicated Runs/History page would add:
-
-- Run/session list with status badges
-- Task summary
-- Workspace/volume used
-- Key outputs
-- Escalation status
-- Filters: running, completed, failed, needs review, by workspace, by volume
-
----
-
-## Normalized UI State Model
-
-All pages share a consistent execution state model via `RunStatus`:
-
-```typescript
-type RunStatus =
-  | "idle"           // Ready for input
-  | "bootstrapping"  // Sandbox starting
-  | "running"        // Execution in progress
-  | "completed"      // Finished successfully
-  | "error"          // Execution failed
-  | "needs_human_review"  // HITL checkpoint
-  | "cancelled"      // User stopped execution
-  | "cancelling";    // Stop in progress
-```
-
-This prevents each page from inventing its own interpretation. Status is managed by `useRunWorkbenchStore` and displayed via shared `StatusBadge` and `StatusIndicator` components.
-
----
-
-## Shared Component System
-
-### Existing Pattern Components
-
-| Component | Module | Purpose |
-|-----------|--------|---------|
-| `StatusBadge` | `components/patterns/execution-status.tsx` | Colored status pill with icon |
-| `StatusIndicator` | `components/patterns/execution-status.tsx` | Small status dot |
-| `StatusMessage` | `components/patterns/execution-status.tsx` | Status alert box |
-| `ExecutionProgress` | `components/patterns/execution-status.tsx` | Progress bar |
-| `Section` | `components/patterns/section-layout.tsx` | Consistent section wrapper |
-| `SectionHeader` | `components/patterns/section-layout.tsx` | Section title + action |
-| `SectionCard` | `components/patterns/section-layout.tsx` | Bordered content card |
-| `EmptyPanel` | `components/patterns/empty-panel.tsx` | Empty state display |
-
-### Existing AI Element Components
-
-| Component | Module | Purpose |
-|-----------|--------|---------|
-| `Conversation` | `components/ai-elements/conversation` | Chat container |
-| `Message` | `components/ai-elements/message` | Individual message block |
-| `Reasoning` | `components/ai-elements/reasoning` | Collapsible reasoning |
-| `Suggestion` | `components/ai-elements/suggestion` | Quick-action chip |
-| `Tool` | `components/ai-elements/tool` | Tool call display |
-| `Sources` | `components/ai-elements/sources` | Source list |
-| `Task` | `components/ai-elements/task` | Task checklist |
-| `InlineCitation` | `components/ai-elements/inline-citation` | Citation card |
-
-### Workspace-Specific Components
-
-| Component | Module | Purpose |
-|-----------|--------|---------|
-| `WorkspaceComposer` | `features/workspace/ui/workspace-composer.tsx` | Task input area |
-| `WorkspaceMessageList` | `features/workspace/ui/transcript/workspace-message-list.tsx` | Execution stream |
-| `RunWorkbench` | `features/workspace/ui/workbench/run-workbench.tsx` | Execution detail panel |
-| `MessageInspectorPanel` | `features/workspace/ui/inspector/message-inspector-panel.tsx` | Turn inspector |
-| `ArtifactGraph` | `features/workspace/ui/inspector/artifact-graph.tsx` | Step dependency graph |
-| `ClarificationCard` | `features/workspace/ui/clarification-card.tsx` | Clarification prompt |
-| `ChainOfThought` | `features/workspace/ui/chain-of-thought.tsx` | Step timeline |
-| `Sandbox` | `features/workspace/ui/sandbox.tsx` | Code execution display |
-
-### Recommended Future Components
-
-| Component | Purpose |
-|-----------|---------|
-| `RunHeader` | Compact run metadata bar (status, duration, sandbox info) |
-| `ResultCard` | Terminal answer card with copy/export actions |
-| `ArtifactList` | Browsable list of produced artifacts |
-| `ReviewRequiredCard` | Explicit HITL card with reason and actions |
-| `SessionListItem` | Richer session entry with status badge and metadata |
-| `VolumeCard` | Volume summary card with storage stats |
-
----
-
-## Content & Copy Guidance
-
-### Workbench Copy Style
-
-Should feel action-oriented, calm, informative:
-
-| ✅ Good | ❌ Avoid |
-|---------|----------|
-| "Running analysis in workspace…" | "Dispatching recursive decomposition module" |
-| "Review needed before continuing" | "HITL checkpoint reached at depth 3" |
-| "Repair attempt completed" | "ReAct loop iteration 4 finalized" |
-| "Final result ready" | "Terminal frame received, run_status=completed" |
-| "Setting up your workspace…" | "Bootstrapping Daytona sandbox instance" |
-
-### Settings Copy Style
-
-Should explain tradeoffs:
-
-- Speed vs depth: "Faster models reduce latency but may produce lower-quality reasoning"
-- Autonomy vs approval: "Require confirmation before modifying files"
-- Concise vs detailed: "Show detailed execution events in the timeline"
-
-### Volume Copy Style
-
-Should explain persistence:
-
-- "Files here persist across sessions and execution runs"
-- "The memory directory stores learned context for future tasks"
-- "Artifacts contain outputs generated during execution"
-
----
-
-## State Management Architecture
-
-### Store Boundaries
-
-```
-┌─────────────────────────────────────────────────┐
-│ Global Stores                                    │
-│  useNavigationStore    — shell nav + canvas       │
-│  useThemeStore         — theme preference          │
-│  useTokenStore         — auth tokens               │
-└─────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────┐
-│ Workspace Stores                                 │
-│  useChatStore          — messages, streaming       │
-│  useWorkspaceUiStore   — inspector, selection      │
-│  useRunWorkbenchStore  — execution state            │
-│  useArtifactStore      — execution artifacts        │
-│  useChatHistoryStore   — persisted conversations   │
-└─────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────┐
-│ Volumes Store                                    │
-│  useVolumesSelectionStore — selected file state    │
-└─────────────────────────────────────────────────┘
-```
-
-### State Flow: WebSocket → UI
-
-```
-Backend Worker (fleet_rlm.worker)
-    ↓ produces events
-Agent Host (fleet_rlm.agent_host)
-    ↓ streams via websocket
-FastAPI WS Endpoint (/api/v1/ws/execution)
-    ↓
-Frontend WS Client (lib/rlm-api/ws-client.ts)
-    ↓
-Frame Parser (lib/rlm-api/ws-frame-parser.ts)
-    ↓
-Chat Event Adapter (lib/workspace/backend-chat-event-adapter.ts)
-    ↓ maps to ChatMessage[]
-Chat Store (lib/workspace/chat-store.ts)
-    ↓
-Display Item Builder (lib/workspace/chat-display-items.ts)
-    ↓ groups into AssistantTurnDisplayItem[]
-Workspace Message List (app/workspace/transcript/)
-    ↓ renders
-Trace Part Renderers (app/workspace/transcript/trace-part-renderers.tsx)
-```
-
----
-
-## Backend Boundary Rules
-
-The frontend must **not**:
-
-1. Duplicate recursive worker decision logic
-2. Re-derive backend semantics from ad hoc heuristics
-3. Make direct Daytona API calls
-4. Store sensitive credentials
-5. Let styling work drive protocol churn
-
-The frontend **should**:
-
-1. Consume the backend contract cleanly
-2. Map backend states to UI states using the normalized `RunStatus` model
-3. Render backend events through the adapter → store → renderer pipeline
-4. Keep transport concerns in `lib/rlm-api/`
-5. Keep state management in `lib/workspace/`
-6. Keep rendering in `app/workspace/`
-
----
-
-## Recommended Implementation Priorities
-
-### Must-Have (current phase)
-
-- [x] Workbench page polished and correctly wired
-- [x] Settings dialog structured by section
-- [x] Volume page browsable and understandable
-- [x] Session history usable via sidebar
-- [x] Human review surfaced clearly via HITL cards
-- [x] Shared pattern components (`StatusBadge`, `Section`, `EmptyPanel`)
-- [x] Frontend architecture guide
-
-### Next Phase
-
-- [ ] Richer session list with status badges and metadata
-- [ ] Terminal action buttons (continue, refine, repair, export)
-- [ ] Run header component with execution summary
-- [ ] Result card with copy/export actions
-- [ ] Artifact list component
-- [ ] Settings "Advanced" mode toggle
-- [ ] Volume detail panel improvements (memory organization view)
-- [ ] Dedicated Runs/History page
-
-### Future
-
-- [ ] Artifacts page or drawer
-- [ ] Trace/debug page
-- [ ] Multi-pane power-user layout
-- [ ] Advanced preferences (recursion depth, repair limits, verification toggles)
-- [ ] Approval queue page
-- [ ] Admin/debug dashboard

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -644,7 +644,7 @@ Sent when an error occurs that doesn't fit the event stream model.
 | `planner_missing` | No planner LLM configured |
 | `llm_timeout` | LLM call timed out |
 | `llm_rate_limited` | Rate limit from LLM provider |
-| `sandbox_unavailable` | Modal sandbox unreachable |
+| `sandbox_unavailable` | Daytona sandbox unavailable |
 | `auth_failed` | Authentication failed |
 | `auth_provider_missing` | Auth required but no provider |
 | `internal_error` | Unhandled exception |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,35 +1,43 @@
 # Reference
 
-Authoritative contracts, interfaces, and implementation-facing facts.
+Implementation-facing contracts, interfaces, and current-state facts.
 
-## Interfaces
+## Current Interfaces
 
 - [CLI Commands](cli.md)
 - [HTTP and WebSocket API](http-api.md)
 - [Python API](python-api.md)
 - [Source Layout](source-layout.md)
 - [Frontend Architecture](frontend-architecture.md)
-- [Frontend Feature Spec &amp; Information Architecture](frontend-feature-spec.md)
-- [Frontend ↔ Backend Integration](frontend-backend-integration.md)
+- [Frontend Feature Spec](frontend-feature-spec.md)
+- [Frontend Backend Integration](frontend-backend-integration.md)
 
-## Platform and Runtime
+## Runtime and Platform
 
 - [Auth Modes](auth.md)
 - [Database Architecture](database.md)
 - [Sandbox File System](sandbox-fs.md)
+- [Daytona Runtime Architecture](daytona-runtime-architecture.md)
+
+## Current Maps
+
+- [Codebase Map](codebase-map.md)
+  Current ownership map for `src/fleet_rlm`, including runtime surfaces, support packages, and transition hotspots.
+- [Module Map](module-map.md)
+  Package-level module relationships and runtime exports.
 
 ## Architecture Decision Records
 
 - [ADR Index](adr/README.md)
-  Architecture Decision Records documenting key design choices.
+  Architecture Decision Records documenting durable design choices.
 - [ADR-001: RLM Runtime Architecture](adr/001-rlm-runtime-architecture.md)
-  dspy.RLM as the core reasoning engine with ReAct orchestration.
+  DSPy `RLM` as the core reasoning engine with ReAct orchestration.
 - [ADR-003: Neon/Postgres with RLS](adr/003-neon-postgres-rls-persistence.md)
   Serverless PostgreSQL with Row-Level Security for multi-tenant persistence.
 - [ADR-004: Dual Auth Modes](adr/004-dual-auth-modes.md)
   Development and Entra authentication modes.
 
-## Internal Maps
+## Historical Reference Material
 
-- [Codebase Map and Simplification Audit](codebase-map.md)
-  Current full-package architecture map for `src/fleet_rlm`, including runtime surfaces, support packages, and refactor hotspots.
+- [Release Notes 0.4.99](release-notes-0.4.99.md)
+- [Release Notes 0.4.94](release-notes-0.4.94.md)

--- a/docs/reference/module-map.md
+++ b/docs/reference/module-map.md
@@ -6,36 +6,21 @@ This document maps the current module relationships within `src/fleet_rlm/` with
 
 ```mermaid
 graph TB
-    CLI["cli/"]
-    API["api/"]
-    HOST["agent_host/"]
-    BRIDGE["orchestration_app/ + api/orchestration/"]
-    WORKER["worker/"]
-    RUNTIME["runtime/"]
-    DAYTONA["integrations/daytona/"]
-    INTEGRATIONS["integrations/"]
-    QUALITY["runtime/quality/"]
-    SCAFFOLD["scaffold/"]
-    UI["ui/dist"]
+    CLI["cli/"] --> API["api/"]
+    CLI --> WORKER["worker/"]
+    CLI --> RUNTIME["runtime/"]
+    CLI --> INTEGRATIONS["integrations/"]
+    CLI --> SCAFFOLD["scaffold/"]
 
-    CLI --> API
-    CLI --> WORKER
-    CLI --> RUNTIME
-    CLI --> INTEGRATIONS
-    CLI --> SCAFFOLD
-
-    API --> HOST
+    API --> HOST["agent_host/"]
     API --> RUNTIME
     API --> INTEGRATIONS
-    API --> UI
+    API --> UI["ui/"]
 
-    HOST --> BRIDGE
     HOST --> WORKER
-    BRIDGE --> WORKER
     WORKER --> RUNTIME
-    RUNTIME --> DAYTONA
-    RUNTIME --> INTEGRATIONS
-    QUALITY --> RUNTIME
+    RUNTIME --> DAYTONA["integrations/daytona/"]
+    RUNTIME --> QUALITY["runtime/quality/"]
 ```
 
 ## Runtime Surfaces
@@ -47,40 +32,25 @@ graph TB
 | FastAPI server | `api/main.py:create_app` | `api/routers/*`, `api/auth/*`, `agent_host/*`, `integrations/database/*`, `integrations/observability/*` |
 | FastMCP server | `integrations/mcp/server.py:create_mcp_server` | `cli/runners.py`, `runtime/agent/*`, `runtime/config.py` |
 
-## Core Runtime Map
+## Core Execution Path
 
 ```mermaid
 graph LR
-    CHAT["runtime/agent/chat_agent.py"]
-    RLM["runtime/agent/recursive_runtime.py"]
-    SIG["runtime/agent/signatures.py"]
-    TOOLS["runtime/tools/"]
-    CONTENT["runtime/content/"]
-    MODELS["runtime/models/"]
-    WORKER["worker/"]
-    EXEC["runtime/execution/*"]
-    DAYTONA_INTERPRETER["integrations/daytona/interpreter.py"]
-    DAYTONA_RUNTIME["integrations/daytona/runtime.py"]
-    QUALITY["runtime/quality/"]
-
-    WORKER --> CHAT
-    CHAT --> SIG
-    CHAT --> TOOLS
-    CHAT --> EXEC
-    CHAT --> RLM
-    CHAT --> MODELS
-    TOOLS --> CONTENT
-    EXEC --> DAYTONA_INTERPRETER
-    EXEC --> DAYTONA_RUNTIME
-    RLM --> DAYTONA_INTERPRETER
-    QUALITY --> CHAT
+    REQUEST["Workspace task request"] --> WORKER["worker/streaming.py"]
+    WORKER --> AGENT["runtime/factory.py"]
+    AGENT --> CHAT["runtime/agent/chat_agent.py"]
+    CHAT --> EXEC["runtime/execution/*"]
+    EXEC --> DAYTONA_INTERPRETER["integrations/daytona/interpreter.py"]
+    EXEC --> DAYTONA_RUNTIME["integrations/daytona/runtime.py"]
+    CHAT --> MODELS["runtime/models/*"]
+    CHAT --> QUALITY["runtime/quality/*"]
 ```
 
 ### Key dependencies
 
 | From | To | Purpose |
 | --- | --- | --- |
-| `worker/*` | `runtime/agent/*` | Worker boundary feeding the shared runtime core |
+| `worker/*` | `runtime/agent/*` | Stream prepared workspace work through the shared runtime agent |
 | `runtime/agent/chat_agent.py` | `runtime/tools/*` | Tool list assembly and tool dispatch |
 | `runtime/agent/chat_agent.py` | `runtime/execution/*` | Streaming turn execution and interpreter support |
 | `runtime/agent/recursive_runtime.py` | `integrations/daytona/*` | Recursive child execution over the Daytona substrate |
@@ -88,7 +58,7 @@ graph LR
 | `runtime/models/*` | `runtime/agent/*` | Builder, registry, and runtime-model exports |
 | `runtime/quality/*` | `runtime/agent/*`, `runtime/models/*` | Offline evaluation and optimization against the live runtime graph |
 
-## API, Host, and Transition Map
+## API and Host Map
 
 ```mermaid
 graph LR
@@ -97,27 +67,27 @@ graph LR
     WS_ENDPOINT["api/routers/ws/endpoint.py"]
     WS_STREAM["api/routers/ws/stream.py"]
     WS_SESSION["api/routers/ws/session.py"]
-    WS_HELPERS["api/routers/ws/* helpers"]
+    WS_TURN_SETUP["api/routers/ws/turn_setup.py"]
+    WS_COMPLETION["api/routers/ws/completion.py"]
     RUNTIME_SERVICES["api/runtime_services/*"]
+    EVENTS["api/events/*"]
     HOST_WORKFLOW["agent_host/workflow.py"]
-    HOST_APP["agent_host/app.py"]
-    BRIDGE["orchestration_app/*"]
-    API_BRIDGE["api/orchestration/*"]
+    HOST_POLICY["agent_host/hitl_flow.py + terminal_flow.py"]
     WORKER["worker/*"]
     RUNTIME["runtime/*"]
 
     APP --> ROUTERS
     ROUTERS --> WS_ENDPOINT
     ROUTERS --> RUNTIME_SERVICES
-    WS_ENDPOINT --> WS_SESSION
+    ROUTERS --> EVENTS
     WS_ENDPOINT --> WS_STREAM
-    WS_ENDPOINT --> WS_HELPERS
+    WS_ENDPOINT --> WS_SESSION
+    WS_ENDPOINT --> WS_TURN_SETUP
+    WS_ENDPOINT --> WS_COMPLETION
     WS_STREAM --> HOST_WORKFLOW
-    WS_SESSION --> HOST_APP
-    HOST_WORKFLOW --> BRIDGE
+    HOST_WORKFLOW --> HOST_POLICY
     HOST_WORKFLOW --> WORKER
-    BRIDGE --> API_BRIDGE
-    BRIDGE --> RUNTIME
+    WORKER --> RUNTIME
 ```
 
 ### Key dependencies
@@ -126,11 +96,11 @@ graph LR
 | --- | --- | --- |
 | `api/main.py` | `api/bootstrap.py` | Runtime bootstrap lifecycle, critical startup, and optional warmup scheduling |
 | `api/routers/ws/*` | `agent_host/*` | Hosted execution, HITL policy, execution events, and startup/repl bridging |
-| `agent_host/workflow.py` | `orchestration_app/*`, `worker/*` | Host policy around the worker seam |
-| `api/orchestration/*` | `agent_host/*`, `orchestration_app/*` | Compatibility shims that preserve older orchestration call sites |
+| `agent_host/workflow.py` | `worker/*` | Hosted policy around the worker seam |
 | `api/runtime_services/settings.py` | `integrations/config/*` | Runtime settings mutation and env/config synchronization |
 | `api/runtime_services/diagnostics.py` | `integrations/config/*`, `integrations/daytona/*` | Runtime diagnostics, status, and provider connectivity tests |
 | `api/runtime_services/volumes.py` | `integrations/daytona/volumes.py` | Volume browsing |
+| `api/events/*` | `runtime/execution/streaming_context.py`, frontend workspace stores | Event shaping for passive execution subscriptions and workbench hydration |
 
 ## Integration Packages
 
@@ -138,6 +108,7 @@ graph LR
 | --- | --- | --- |
 | `integrations/config/` | App/env/runtime settings | `env.py`, `runtime_settings.py`, `_env_utils.py`, `config.yaml` |
 | `integrations/database/` | Persistence boundary | `engine.py`, `models.py`, `repository.py`, `types.py` |
+| `integrations/local_store.py` | Local sidecar persistence | session history, turn transcripts, optimization-run tracking |
 | `integrations/mcp/` | FastMCP server surface | `server.py` |
 | `integrations/observability/` | Telemetry and tracing | `posthog_callback.py`, `mlflow_runtime.py`, `mlflow_traces.py`, `trace_context.py` |
 | `integrations/daytona/` | Daytona execution and workspace substrate | `interpreter.py`, `runtime.py`, `volumes.py`, `config.py`, `diagnostics.py`, `types.py`, `bridge.py`, `runtime_helpers.py` |

--- a/docs/reference/source-layout.md
+++ b/docs/reference/source-layout.md
@@ -1,7 +1,6 @@
 # Source Layout (`src/fleet_rlm`)
 
-This document reflects the current backend package structure in
-`src/fleet_rlm/`. Paths below are relative to that directory.
+This document reflects the current backend package structure in `src/fleet_rlm/`. Paths below are relative to that directory.
 
 ## Top-Level Areas
 
@@ -9,83 +8,102 @@ This document reflects the current backend package structure in
 | --- | --- |
 | `__init__.py` | Minimal public package exports and version marker. |
 | `AGENTS.md` | Backend-specific contributor guidance. |
-| `api/` | FastAPI transport, auth, schemas, routers, and API-specific helpers. |
-| `cli/` | `fleet` / `fleet-rlm` entrypoints, command registration, runtime factory helpers, and terminal UX. |
-| `runtime/` | Shared agent loop, execution engine, content processing, tools, and runtime models. |
-| `integrations/` | Config, database, MCP, observability, and provider backends. |
+| `agent_host/` | Hosted policy layer around the worker seam, HITL, checkpoints, and terminal/session flow. |
+| `api/` | FastAPI transport, auth, schemas, routers, websocket lifecycle, runtime services, and event shaping. |
+| `cli/` | `fleet` / `fleet-rlm` entrypoints, command registration, runtime helpers, and terminal UX. |
+| `integrations/` | Config, database, observability, MCP, Daytona, and local-store integrations. |
+| `runtime/` | Shared agent loop, execution helpers, content processing, tools, runtime models, and offline quality. |
 | `scaffold/` | Bundled init assets: skills, agents, hooks, and team inboxes. |
 | `ui/` | Packaged frontend build assets used by installed distributions. |
 | `utils/` | Small shared helpers. |
 
-## CLI (`cli/`)
+## `api/`
 
 | Path | Description |
 | --- | --- |
-| `main.py` | Entry point for the lightweight `fleet` launcher. |
-| `fleet_cli.py` | Typer-based `fleet-rlm` command surface. |
-| `runners.py` | Shared runner helpers used by CLI, MCP, API bootstrap, and tests. |
-| `runtime_factory.py` | Shared runtime config assembly for API and MCP surfaces. |
-| `commands/init_cmd.py` | `fleet-rlm init` registration and scaffold install flow. |
-| `commands/serve_cmds.py` | `serve-api` and `serve-mcp` registration. |
-| `terminal/` | Terminal chat UX, settings persistence, and session rendering. |
-
-## API (`api/`)
-
-| Path | Description |
-| --- | --- |
-| `main.py` | FastAPI app factory, lifespan management, and SPA mounting. |
+| `main.py` | FastAPI app factory, lifespan management, route registration, and SPA mounting. |
 | `bootstrap.py` | Runtime bootstrap, critical persistence init, optional background warmup, and shutdown orchestration. |
 | `config.py` | `ServerRuntimeConfig` for the HTTP/WebSocket server. |
 | `dependencies.py` | Shared `ServerState` container and dependency helpers. |
+| `middleware.py` | Cross-cutting HTTP middleware registration. |
 | `server_utils.py` | Shared API utility helpers. |
 | `auth/` | Auth providers, tenant admission, and auth types. |
-| `execution/` | Execution-step/event assembly for the workbench and traces. |
+| `events/` | Execution-event models, sanitization, and payload shaping for the passive event stream. |
 | `routers/` | HTTP and websocket route handlers. |
-| `runtime_services/` | Runtime settings, diagnostics/status, and volume browsing helpers. |
+| `runtime_services/` | Runtime settings, diagnostics/status, volume browsing, chat runtime prep, and persistence helpers. |
 | `schemas/` | Request/response models shared across routes. |
 
-### WebSocket Runtime (`api/routers/ws/`)
-
-The websocket transport layer is intentionally split into focused modules rather
-than one large chat loop.
+### HTTP routers
 
 | Path | Description |
 | --- | --- |
-| `endpoint.py` | `/ws/chat` and `/ws/execution` websocket entrypoints. |
-| `stream.py` | Turn execution and stream emission. |
-| `session.py` | Runtime preparation and session switching. |
-| `commands.py` | Command-frame dispatch plus run lifecycle initialization. |
-| `types.py` | Typed websocket contracts and Daytona request normalization. |
-| `helpers.py` | Low-level websocket send/close/auth helpers. |
-| `lifecycle.py` | Execution lifecycle manager, run persistence, and terminal error classification. |
-| `messages.py`, `persistence.py`, `manifest.py`, `artifacts.py` | Message parsing plus durable session/workbench state updates. |
-| `runtime.py`, `turn_setup.py`, `turn_lifecycle.py` | Runtime prep and per-turn setup/finalization helpers. |
-| `errors.py`, `failures.py`, `loop_exit.py`, `task_control.py`, `terminal.py`, `completion.py`, `execution_support.py`, `hitl.py` | Focused helpers for failure handling, cancellation, terminal ordering, execution summaries, and human-in-the-loop control. |
+| `routers/auth.py` | Auth identity endpoint. |
+| `routers/health.py` | Health and readiness endpoints. |
+| `routers/runtime.py` | Runtime settings, diagnostics, and Daytona volume browsing routes. |
+| `routers/optimization.py` | GEPA/optimization routes. |
+| `routers/sessions.py` | Session state, history, transcript, archive, and export routes. |
+| `routers/traces.py` | Feedback and trace-reporting routes. |
+| `routers/ws/` | Websocket transport for execution and execution-event subscriptions. |
 
-## Runtime (`runtime/`)
+### WebSocket runtime (`api/routers/ws/`)
+
+| Path | Description |
+| --- | --- |
+| `endpoint.py` | `/api/v1/ws/execution` and `/api/v1/ws/execution/events` entrypoints. |
+| `stream.py` | Execution turn streaming and message loop coordination. |
+| `session.py` | Runtime preparation and session restore/switch helpers. |
+| `turn_setup.py` | Converts a websocket payload into a prepared runtime turn. |
+| `turn_runner.py` | Turn execution coordination around the worker boundary. |
+| `turn_persistence.py` | Local and durable persistence hooks for a turn. |
+| `commands.py` | Command-frame dispatch and run lifecycle initialization. |
+| `messages.py` | Websocket message parsing and validation. |
+| `terminal.py` | Terminal event shaping and ordering. |
+| `completion.py` | Completion summary and workbench hydration payload assembly. |
+| `hitl.py` | Human-in-the-loop request handling. |
+| `manifest.py` | Session manifest handling. |
+| `artifacts.py` | Artifact event helpers. |
+| `execution_support.py` | Passive execution event emitter wiring. |
+| `errors.py`, `failures.py`, `loop_exit.py`, `task_control.py`, `worker_request.py`, `helpers.py`, `types.py` | Focused helpers for errors, shutdown, task control, request normalization, and websocket utility code. |
+
+## `agent_host/`
+
+| Path | Description |
+| --- | --- |
+| `workflow.py` | Hosted Agent Framework workflow around the worker seam. |
+| `hitl_flow.py` | HITL checkpoint and resume logic. |
+| `terminal_flow.py` | Terminal ordering and completion policy. |
+| `checkpoints.py` | Checkpoint helpers for hosted execution. |
+| `sessions.py` | Session continuation, restore, and orchestration-context helpers. |
+| `execution_events.py` | Host-side execution-event normalization and metadata shaping. |
+| `repl_bridge.py` | Interpreter callback bridge into host/state handling. |
+| `startup_status.py` | Delayed startup-status policy for slow initial turns. |
+| `app.py`, `adapters.py`, `types.py` | Workflow adapters and host-facing types. |
+
+## `runtime/`
 
 | Path | Description |
 | --- | --- |
 | `config.py` | Planner/delegate LM bootstrap from environment. |
-| `__init__.py` | Lazy runtime export surface for `DaytonaInterpreter`, planner helpers, and `sandbox_driver`. |
 | `agent/` | Shared DSPy orchestration, chat/session state, delegation policy, memory, and command helpers. |
-| `execution/` | Interpreter implementation, streaming helpers, runtime factory, and execution profiles. |
-| `content/` | Chunking, document ingestion, and execution-log processing helpers. |
-| `models/` | Shared runtime/streaming models plus DSPy runtime module assembly. |
-| `tools/` | Typed tool adapters exposed to the shared ReAct/RLM runtime. |
+| `execution/` | Interpreter support, streaming helpers, runtime factory glue, and execution profiles. |
+| `content/` | Chunking, ingestion, and execution-log processing helpers. |
+| `models/` | Shared runtime/streaming models plus runtime-module assembly. |
+| `quality/` | DSPy evaluation and optimization. |
+| `tools/` | Typed tool adapters exposed to the shared runtime. |
 
-### Runtime Warmup Policy
+### Runtime warmup policy
 
-- FastAPI serves once critical startup completes: config resolution, auth setup, persistence wiring, and app state initialization.
-- Optional warmup happens in the background from `api/bootstrap.py`: planner/delegate LM construction, PostHog startup, and MLflow runtime startup.
+- FastAPI serves once critical startup completes: config resolution, auth setup, persistence wiring, and app-state initialization.
+- Optional warmup happens in the background from `api/bootstrap.py`: planner/delegate LM construction, observability startup, and any noncritical backend readiness work.
 - `/ready` reflects critical readiness only; use `/api/v1/runtime/status` and `/api/v1/runtime/tests/*` to inspect optional service health.
 
-## Integrations (`integrations/`)
+## `integrations/`
 
 | Path | Description |
 | --- | --- |
 | `config/` | App/env/runtime settings helpers and defaults. |
-| `database/` | `DatabaseManager`, SQLModel models, repository, and DB-facing types. |
+| `database/` | Database manager, SQLModel models, repository, and DB-facing types. |
+| `local_store.py` | Local session/history/optimization persistence. |
 | `mcp/` | FastMCP server surface. |
 | `observability/` | PostHog and MLflow integrations plus trace/request-context helpers. |
 | `daytona/` | Daytona interpreter backend, bridge/runtime helpers, diagnostics, and volume access. |

--- a/docs/tutorials/03-interactive-chat.md
+++ b/docs/tutorials/03-interactive-chat.md
@@ -107,7 +107,7 @@ $ fleet --docs-path README.md --trace-mode compact
 [trace: analyzing structure...]
 
 The Fleet-RLM project uses a modular architecture with:
-- Core execution layer (Modal sandbox)
+- Core execution layer (Daytona sandbox)
 - ReAct agent orchestration (DSPy)
 - WebSocket streaming for real-time updates
 
@@ -119,7 +119,7 @@ The Fleet-RLM project uses a modular architecture with:
 
 [trace: searching documentation...]
 
-The sandbox uses Modal for isolated Python execution...
+The sandbox uses Daytona for isolated Python execution...
 ```
 
 ## Starting the Web UI
@@ -155,7 +155,7 @@ fleet --trace-mode off
 
 > What is Fleet-RLM?
 
-> How do I configure Modal?
+> How do I configure Daytona?
 ```
 
 ### Debugging Session


### PR DESCRIPTION
## Summary
- rewrite the live documentation set to match the current Daytona-backed architecture
- refresh frontend and backend architecture, integration, product, and user-flow docs
- clean remaining setup/tutorial/reference drift from older runtime terminology

## Verification
- uv run python scripts/check_docs_quality.py
- make check-release