### PR TITLE
Validate document download redirects

### DIFF
--- a/src/fleet_rlm/runtime/tools/document_tools.py
+++ b/src/fleet_rlm/runtime/tools/document_tools.py
@@ -140,7 +140,8 @@ def _download_url(url: str) -> Path:
     )
     with opener.open(req, timeout=_DOWNLOAD_TIMEOUT_S) as response:  # noqa: S310
         headers = dict(response.headers)
-        suffix = _suffix_from_url(url, headers)
+        final_url = response.geturl() or url
+        suffix = _suffix_from_url(final_url, headers)
 
         fd, tmp_path = tempfile.mkstemp(suffix=suffix)
         cleanup_tmp = False

--- a/src/fleet_rlm/runtime/tools/document_tools.py
+++ b/src/fleet_rlm/runtime/tools/document_tools.py
@@ -140,7 +140,8 @@ def _download_url(url: str) -> Path:
     )
     with opener.open(req, timeout=_DOWNLOAD_TIMEOUT_S) as response:  # noqa: S310
         headers = dict(response.headers)
-        final_url = response.geturl() or url
+        response_geturl = getattr(response, "geturl", None)
+        final_url = response_geturl() if callable(response_geturl) else url
         suffix = _suffix_from_url(final_url, headers)
 
         fd, tmp_path = tempfile.mkstemp(suffix=suffix)

--- a/src/fleet_rlm/runtime/tools/document_tools.py
+++ b/src/fleet_rlm/runtime/tools/document_tools.py
@@ -11,6 +11,7 @@ caching, URL fetching with size limits) use the builder in
 
 from __future__ import annotations
 
+import io
 import os
 import ipaddress
 import socket
@@ -90,7 +91,7 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(
         self,
         req: urllib.request.Request,
-        fp: IO[bytes],
+        fp: IO[bytes] | None,
         code: int,
         msg: str,
         headers: HTTPMessage,
@@ -98,7 +99,8 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
     ) -> urllib.request.Request | None:
         safe_url = urllib.parse.urljoin(req.full_url, newurl)
         _validate_download_url(safe_url)
-        return super().redirect_request(req, fp, code, msg, headers, safe_url)
+        redirect_fp = fp if fp is not None else io.BytesIO()
+        return super().redirect_request(req, redirect_fp, code, msg, headers, safe_url)
 
 
 def _suffix_from_url(url: str, headers: dict[str, str]) -> str:

--- a/src/fleet_rlm/runtime/tools/document_tools.py
+++ b/src/fleet_rlm/runtime/tools/document_tools.py
@@ -17,8 +17,9 @@ import socket
 import tempfile
 import urllib.parse
 import urllib.request
+from http.client import HTTPMessage
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from fleet_rlm.runtime.tools._marker import tool_fn
 
@@ -83,6 +84,23 @@ def _validate_download_url(url: str) -> None:
             raise ValueError("Document download URL targets a private network address.")
 
 
+class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Validate each redirect target before urllib follows it."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        safe_url = urllib.parse.urljoin(req.full_url, newurl)
+        _validate_download_url(safe_url)
+        return super().redirect_request(req, fp, code, msg, headers, safe_url)
+
+
 def _suffix_from_url(url: str, headers: dict[str, str]) -> str:
     """Derive a file suffix from URL path or Content-Type header."""
     parsed = urllib.parse.urlparse(url)
@@ -114,12 +132,13 @@ def _suffix_from_url(url: str, headers: dict[str, str]) -> str:
 def _download_url(url: str) -> Path:
     """Download *url* to a temporary file and return the path."""
     _validate_download_url(url)
+    opener = urllib.request.build_opener(_ValidatingRedirectHandler())
     req = urllib.request.Request(
         url,
         headers={"User-Agent": "fleet-rlm/1.0"},
         method="GET",
     )
-    with urllib.request.urlopen(req, timeout=_DOWNLOAD_TIMEOUT_S) as response:  # noqa: S310
+    with opener.open(req, timeout=_DOWNLOAD_TIMEOUT_S) as response:  # noqa: S310
         headers = dict(response.headers)
         suffix = _suffix_from_url(url, headers)
 

--- a/tests/unit/runtime/tools/test_document_tools.py
+++ b/tests/unit/runtime/tools/test_document_tools.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import io
 import os
+from http.client import HTTPMessage
 from pathlib import Path
 import socket
 from typing import Any
@@ -147,10 +149,10 @@ def test_download_url_rejects_private_redirect_targets(
                 _ = timeout
                 redirect_handler.redirect_request(
                     request,
-                    None,
+                    io.BytesIO(b""),
                     302,
                     "Found",
-                    {},
+                    HTTPMessage(),
                     "http://169.254.169.254/latest/meta-data/",
                 )
                 raise AssertionError("private redirect should be blocked")

--- a/tests/unit/runtime/tools/test_document_tools.py
+++ b/tests/unit/runtime/tools/test_document_tools.py
@@ -28,15 +28,27 @@ class _FakeResponse:
         return self._chunks.pop(0)
 
 
+class _FakeOpener:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    def open(self, request: Any, timeout: int) -> _FakeResponse:
+        _ = (request, timeout)
+        return self._response
+
+
 def test_download_url_removes_partial_temp_file_on_size_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     created: list[Path] = []
 
-    def fake_urlopen(request: Any, timeout: int) -> _FakeResponse:
-        _ = (request, timeout)
-        return _FakeResponse([b"abcd", b"efgh"])
+    def fake_build_opener(*handlers: Any) -> _FakeOpener:
+        assert any(
+            isinstance(handler, document_tools._ValidatingRedirectHandler)
+            for handler in handlers
+        )
+        return _FakeOpener(_FakeResponse([b"abcd", b"efgh"]))
 
     def fake_getaddrinfo(*args: Any, **kwargs: Any) -> list[Any]:
         _ = (args, kwargs)
@@ -49,7 +61,9 @@ def test_download_url_removes_partial_temp_file_on_size_limit(
         return fd, str(path)
 
     monkeypatch.setattr(document_tools.socket, "getaddrinfo", fake_getaddrinfo)
-    monkeypatch.setattr(document_tools.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        document_tools.urllib.request, "build_opener", fake_build_opener
+    )
     monkeypatch.setattr(document_tools.tempfile, "mkstemp", fake_mkstemp)
     monkeypatch.setattr(document_tools, "_MAX_DOWNLOAD_BYTES", 4)
 
@@ -73,11 +87,13 @@ def test_download_url_rejects_private_network_targets(
     url: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fail_urlopen(*args: Any, **kwargs: Any) -> None:
+    def fail_build_opener(*args: Any, **kwargs: Any) -> None:
         _ = (args, kwargs)
-        raise AssertionError("urlopen should not be called for blocked URLs")
+        raise AssertionError("build_opener should not be called for blocked URLs")
 
-    monkeypatch.setattr(document_tools.urllib.request, "urlopen", fail_urlopen)
+    monkeypatch.setattr(
+        document_tools.urllib.request, "build_opener", fail_build_opener
+    )
 
     with pytest.raises(ValueError, match="private network"):
         document_tools._download_url(url)
@@ -90,12 +106,52 @@ def test_download_url_rejects_hosts_resolving_to_private_addresses(
         _ = (args, kwargs)
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))]
 
-    def fail_urlopen(*args: Any, **kwargs: Any) -> None:
+    def fail_build_opener(*args: Any, **kwargs: Any) -> None:
         _ = (args, kwargs)
-        raise AssertionError("urlopen should not be called for blocked URLs")
+        raise AssertionError("build_opener should not be called for blocked URLs")
 
     monkeypatch.setattr(document_tools.socket, "getaddrinfo", fake_getaddrinfo)
-    monkeypatch.setattr(document_tools.urllib.request, "urlopen", fail_urlopen)
+    monkeypatch.setattr(
+        document_tools.urllib.request, "build_opener", fail_build_opener
+    )
+
+    with pytest.raises(ValueError, match="private network"):
+        document_tools._download_url("https://docs.example.test/file.txt")
+
+
+def test_download_url_rejects_private_redirect_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_getaddrinfo(*args: Any, **kwargs: Any) -> list[Any]:
+        _ = (args, kwargs)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    def fake_build_opener(*handlers: Any) -> Any:
+        redirect_handler = next(
+            handler
+            for handler in handlers
+            if isinstance(handler, document_tools._ValidatingRedirectHandler)
+        )
+
+        class _RedirectingOpener:
+            def open(self, request: Any, timeout: int) -> _FakeResponse:
+                _ = timeout
+                redirect_handler.redirect_request(
+                    request,
+                    None,
+                    302,
+                    "Found",
+                    {},
+                    "http://169.254.169.254/latest/meta-data/",
+                )
+                raise AssertionError("private redirect should be blocked")
+
+        return _RedirectingOpener()
+
+    monkeypatch.setattr(document_tools.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        document_tools.urllib.request, "build_opener", fake_build_opener
+    )
 
     with pytest.raises(ValueError, match="private network"):
         document_tools._download_url("https://docs.example.test/file.txt")

--- a/tests/unit/runtime/tools/test_document_tools.py
+++ b/tests/unit/runtime/tools/test_document_tools.py
@@ -28,6 +28,15 @@ class _FakeResponse:
         return self._chunks.pop(0)
 
 
+class _FakeResponseWithUrl(_FakeResponse):
+    def __init__(self, chunks: list[bytes], final_url: str) -> None:
+        super().__init__(chunks)
+        self._final_url = final_url
+
+    def geturl(self) -> str:
+        return self._final_url
+
+
 class _FakeOpener:
     def __init__(self, response: _FakeResponse) -> None:
         self._response = response
@@ -155,6 +164,81 @@ def test_download_url_rejects_private_redirect_targets(
 
     with pytest.raises(ValueError, match="private network"):
         document_tools._download_url("https://docs.example.test/file.txt")
+
+
+def test_download_url_falls_back_to_original_url_without_geturl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[Path] = []
+
+    def fake_getaddrinfo(*args: Any, **kwargs: Any) -> list[Any]:
+        _ = (args, kwargs)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    def fake_build_opener(*handlers: Any) -> _FakeOpener:
+        assert any(
+            isinstance(handler, document_tools._ValidatingRedirectHandler)
+            for handler in handlers
+        )
+        return _FakeOpener(_FakeResponse([b"hello world"]))
+
+    def fake_mkstemp(suffix: str) -> tuple[int, str]:
+        path = tmp_path / f"download{suffix}"
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+        created.append(path)
+        return fd, str(path)
+
+    monkeypatch.setattr(document_tools.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        document_tools.urllib.request, "build_opener", fake_build_opener
+    )
+    monkeypatch.setattr(document_tools.tempfile, "mkstemp", fake_mkstemp)
+
+    downloaded_path = document_tools._download_url("https://example.test/doc.md")
+
+    assert downloaded_path == created[0]
+    assert downloaded_path.suffix == ".md"
+    assert downloaded_path.read_bytes() == b"hello world"
+
+
+def test_download_url_uses_redirect_final_url_for_suffix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[Path] = []
+
+    def fake_getaddrinfo(*args: Any, **kwargs: Any) -> list[Any]:
+        _ = (args, kwargs)
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    def fake_build_opener(*handlers: Any) -> _FakeOpener:
+        assert any(
+            isinstance(handler, document_tools._ValidatingRedirectHandler)
+            for handler in handlers
+        )
+        return _FakeOpener(
+            _FakeResponseWithUrl(
+                [b"hello world"], "https://example.test/downloads/final.pdf"
+            )
+        )
+
+    def fake_mkstemp(suffix: str) -> tuple[int, str]:
+        path = tmp_path / f"download{suffix}"
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+        created.append(path)
+        return fd, str(path)
+
+    monkeypatch.setattr(document_tools.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(
+        document_tools.urllib.request, "build_opener", fake_build_opener
+    )
+    monkeypatch.setattr(document_tools.tempfile, "mkstemp", fake_mkstemp)
+
+    downloaded_path = document_tools._download_url("https://example.test/redirect")
+
+    assert downloaded_path == created[0]
+    assert downloaded_path.suffix == ".pdf"
 
 
 def test_fetch_document_text_rejects_local_paths() -> None:


### PR DESCRIPTION
## Summary
- validate every HTTP redirect hop during document downloads before following it
- keep bridged document fetches protected when a public URL redirects into private or link-local targets
- add unit coverage for redirect-based SSRF attempts and update opener mocking accordingly

## Verification
- uv run pytest -q tests/unit/runtime/tools/test_document_tools.py tests/unit/integrations/daytona/test_interpreter.py::test_invoke_tool_dispatches_bridged_fetch_document_text -m "not live_llm and not benchmark"
- uv run ruff check src/fleet_rlm/runtime/tools/document_tools.py tests/unit/runtime/tools/test_document_tools.py
- uv run ty check src/fleet_rlm/runtime/tools/document_tools.py
- make lint
- make typecheck
- make format-check