### PR TITLE
Release v0.5.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,20 +55,20 @@ AUTH_REQUIRED=false
 DEV_JWT_SECRET=change-me
 
 # Entra API validation inputs (required when AUTH_MODE=entra)
-# These values match the fleet-rlm app registration (Client ID 16864674-b56f-46cb-b3b9-6c570fafe39c).
-# ENTRA_JWKS_URL=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4/discovery/v2.0/keys
+# These values match the fleet-rlm app registration (Client ID ).
+# ENTRA_JWKS_URL=https://login.microsoftonline.com/{clientid}/discovery/v2.0/keys
 # ENTRA_AUDIENCE should typically match the API Application ID URI used in the token `aud` claim.
 # Use the bare client ID only if your Entra app registration is explicitly configured that way.
-# ENTRA_AUDIENCE=api://16864674-b56f-46cb-b3b9-6c570fafe39c
+# ENTRA_AUDIENCE=api://<api-app-client-id>
 # Optional override for multitenant issuer validation.
 # Defaults to https://login.microsoftonline.com/{tenantid}/v2.0
 # ENTRA_ISSUER_TEMPLATE=https://login.microsoftonline.com/{tenantid}/v2.0
 
 # Frontend SPA auth inputs (set in src/frontend/.env.local or exported in shell)
-# VITE_ENTRA_CLIENT_ID=16864674-b56f-46cb-b3b9-6c570fafe39c
+# VITE_ENTRA_CLIENT_ID=<api-app-client-id>  
 # Defaults to https://login.microsoftonline.com/organizations for multitenant org-only sign-in.
-# VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4
-# VITE_ENTRA_SCOPES=api://16864674-b56f-46cb-b3b9-6c570fafe39c/access_as_user
+# VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/{tenantid}
+# VITE_ENTRA_SCOPES=api://<api-app-client-id>/access_as_user
 # VITE_ENTRA_REDIRECT_PATH=/login
 
 # CORS allowed origins (required in non-local deployments; defaults to [] if unset)

--- a/.env.example
+++ b/.env.example
@@ -56,13 +56,18 @@ DEV_JWT_SECRET=change-me
 
 # Entra API validation inputs (required when AUTH_MODE=entra)
 # These values match the fleet-rlm app registration (Client ID ).
-# ENTRA_JWKS_URL=https://login.microsoftonline.com/{clientid}/discovery/v2.0/keys
+# ENTRA_JWKS_URL=https://login.microsoftonline.com/{tenantid}/discovery/v2.0/keys
 # ENTRA_AUDIENCE should typically match the API Application ID URI used in the token `aud` claim.
 # Use the bare client ID only if your Entra app registration is explicitly configured that way.
 # ENTRA_AUDIENCE=api://<api-app-client-id>
+# Optional fixed issuer for single-tenant validation. Mutually exclusive with ENTRA_ISSUER_TEMPLATE.
+# ENTRA_ISSUER_URL=https://login.microsoftonline.com/{tenantid}/v2.0
 # Optional override for multitenant issuer validation.
 # Defaults to https://login.microsoftonline.com/{tenantid}/v2.0
 # ENTRA_ISSUER_TEMPLATE=https://login.microsoftonline.com/{tenantid}/v2.0
+# Optional object-id allowlists for beta deployments (comma-separated).
+# ENTRA_ALLOWED_USER_IDS=<entra-user-object-id>
+# ENTRA_ALLOWED_GROUP_IDS=<entra-group-object-id>
 
 # Frontend SPA auth inputs (set in src/frontend/.env.local or exported in shell)
 # VITE_ENTRA_CLIENT_ID=<api-app-client-id>  

--- a/.env.example
+++ b/.env.example
@@ -57,7 +57,9 @@ DEV_JWT_SECRET=change-me
 # Entra API validation inputs (required when AUTH_MODE=entra)
 # These values match the fleet-rlm app registration (Client ID 16864674-b56f-46cb-b3b9-6c570fafe39c).
 # ENTRA_JWKS_URL=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4/discovery/v2.0/keys
-# ENTRA_AUDIENCE=16864674-b56f-46cb-b3b9-6c570fafe39c
+# ENTRA_AUDIENCE should typically match the API Application ID URI used in the token `aud` claim.
+# Use the bare client ID only if your Entra app registration is explicitly configured that way.
+# ENTRA_AUDIENCE=api://16864674-b56f-46cb-b3b9-6c570fafe39c
 # Optional override for multitenant issuer validation.
 # Defaults to https://login.microsoftonline.com/{tenantid}/v2.0
 # ENTRA_ISSUER_TEMPLATE=https://login.microsoftonline.com/{tenantid}/v2.0

--- a/.env.example
+++ b/.env.example
@@ -55,18 +55,22 @@ AUTH_REQUIRED=false
 DEV_JWT_SECRET=change-me
 
 # Entra API validation inputs (required when AUTH_MODE=entra)
-# ENTRA_JWKS_URL=
-# ENTRA_AUDIENCE=
+# These values match the fleet-rlm app registration (Client ID 16864674-b56f-46cb-b3b9-6c570fafe39c).
+# ENTRA_JWKS_URL=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4/discovery/v2.0/keys
+# ENTRA_AUDIENCE=16864674-b56f-46cb-b3b9-6c570fafe39c
 # Optional override for multitenant issuer validation.
 # Defaults to https://login.microsoftonline.com/{tenantid}/v2.0
 # ENTRA_ISSUER_TEMPLATE=https://login.microsoftonline.com/{tenantid}/v2.0
 
 # Frontend SPA auth inputs (set in src/frontend/.env.local or exported in shell)
-# VITE_ENTRA_CLIENT_ID=
+# VITE_ENTRA_CLIENT_ID=16864674-b56f-46cb-b3b9-6c570fafe39c
 # Defaults to https://login.microsoftonline.com/organizations for multitenant org-only sign-in.
-# VITE_ENTRA_AUTHORITY=
-# VITE_ENTRA_SCOPES=api://<api-app-id>/access_as_user
+# VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4
+# VITE_ENTRA_SCOPES=api://16864674-b56f-46cb-b3b9-6c570fafe39c/access_as_user
 # VITE_ENTRA_REDIRECT_PATH=/login
+
+# CORS allowed origins (required in non-local deployments; defaults to [] if unset)
+# CORS_ALLOWED_ORIGINS=https://fleet-rlm.fastapicloud.dev
 
 # Require Neon repository at runtime. Defaults true in staging/production.
 # DATABASE_REQUIRED=true

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ databricks.yml
 typings/
 files/ai_index_report_2026.pdf
 /dogfood-output
+.factory/plan-benchmark/fleet-rlm-benchmark-improvements.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ All notable changes to this project are documented in this file.
 
 - No unreleased changes yet.
 
+## [0.5.2] - 2026-04-29
+
+### Added
+
+- **Change:** Added FastAPI Cloud Entra auth settings with new environment-configurable
+  JWKS URL, issuer, audience, and user/group allow-list fields, plus enhanced
+  `EntraAuthProvider` validation and query-token support.
+  **Outcome:** Deployments to FastAPI Cloud can authenticate via Microsoft Entra
+  with richer configuration and clearer failure modes.
+- **Change:** Added root `asgi.py` entrypoint for managed cloud deploys.
+  **Outcome:** FastAPI Cloud and similar platforms can import the app directly
+  from a stable top-level module instead of relying on package-path heuristics.
+- **Change:** Added database migrations `0011_drop_redundant_indexes` and
+  `0012_updated_at_trigger`.
+  **Outcome:** Cleaner indexes and automatic `updated_at` maintenance on supported
+  tables.
+
+### Changed
+
+- **Change:** Refactored `/ready` endpoint to perform an async DB ping with a
+  2-second timeout, reporting `degraded` instead of `ready` when Neon compute is
+  sleeping or unreachable.
+  **Outcome:** Load balancers and orchestrators get a more honest readiness signal
+  that distinguishes cold-start degradation from full unavailability.
+- **Change:** Added paginated retrieval methods to `FleetRepository` and wired
+  pagination into memory, optimization runs, sessions, traces, and run-steps list
+  endpoints.
+  **Outcome:** Large dataset listing surfaces are now bounded and safer against
+  oversized responses.
+- **Change:** Tuned async database engine connection settings and removed redundant
+  non-unique indexes from run, trace, and optimization models.
+  **Outcome:** Reduced index overhead and clearer connection-pool behavior under
+  load.
+- **Change:** Refined release workflow changelog body generation.
+  **Outcome:** Release notes are grouped more consistently during automated
+  GitHub releases.
+
+### Fixed
+
+- **Change:** Restored FastAPI Cloud deploy compatibility for the src layout by
+  capping Python `<3.14` and wiring the root `asgi.py` entrypoint into packaging.
+  **Outcome:** FastAPI Cloud can import, build, and run the application without
+  hitting unsupported CPython or layout assumptions.
+- **Change:** Added blog evaluation assets to `.gitignore`.
+  **Outcome:** Generated evaluation outputs are no longer at risk of accidental
+  commit.
+
 ## [0.5.1] - 2026-04-27
 
 ### Highlights (User Impact)
@@ -868,6 +915,7 @@ All notable changes to this project are documented in this file.
 - Removed checked-in `__pycache__` directories under `src/fleet_rlm/`.
 - Moved non-runtime memory-topology notes out of package source and into docs.
 
+[0.5.2]: https://github.com/Qredence/fleet-rlm/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Qredence/fleet-rlm/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Qredence/fleet-rlm/compare/v0.4.99...v0.5.0
 [0.4.3]: https://github.com/Qredence/fleet-rlm/compare/v0.4.2...v0.4.3

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
 
 [Docs](docs/) · [Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md) · [arXiv paper](https://arxiv.org/abs/2512.24601)
 
-## Project Status
 
-Solo-maintained by [@Zochory](https://github.com/Zochory). External contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). No SLA; issues are reviewed as capacity allows.
 
 ## Architecture at a Glance
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.5.1
+  version: 0.5.2
 paths:
   /health:
     get:
@@ -24,7 +24,12 @@ paths:
       tags:
       - health
       summary: Ready
-      description: Report whether critical startup dependencies are ready for requests.
+      description: 'Report whether critical startup dependencies are ready for requests.
+
+
+        Verifies DB connectivity with a short-timeout ping so a sleeping Neon
+
+        compute reports ``degraded`` instead of ``ready``.'
       operationId: ready_ready_get
       responses:
         '200':
@@ -2053,7 +2058,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.5.1
+          default: 0.5.2
       type: object
       title: HealthResponse
       description: Response body for the lightweight health endpoint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-rlm"
-version = "0.5.1"
+version = "0.5.2"
 description = "Recursive Language Models with DSPy + Daytona and an integrated Web UI for secure long-context code execution"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/fleet_rlm/api/auth/entra.py
+++ b/src/fleet_rlm/api/auth/entra.py
@@ -22,13 +22,19 @@ class EntraAuthProvider:
         self,
         *,
         jwks_url: str | None = None,
+        issuer_url: str | None = None,
         issuer_template: str | None = None,
         audience: str | None = None,
+        allowed_user_ids: set[str] | None = None,
+        allowed_group_ids: set[str] | None = None,
         allow_query_auth_tokens: bool = True,
     ) -> None:
         self.jwks_url = jwks_url
+        self.issuer_url = issuer_url
         self.issuer_template = issuer_template
         self.audience = audience
+        self.allowed_user_ids = allowed_user_ids or set()
+        self.allowed_group_ids = allowed_group_ids or set()
         self._allow_query_auth_tokens = allow_query_auth_tokens
         self._jwk_client = (
             PyJWKClient(jwks_url, cache_jwk_set=True, lifespan=300)
@@ -92,13 +98,25 @@ class EntraAuthProvider:
                 status_code=503,
             )
         if not self.issuer_template:
+            if not self.issuer_url:
+                raise AuthError(
+                    "AUTH_MODE=entra requires ENTRA_ISSUER_URL or "
+                    "ENTRA_ISSUER_TEMPLATE to be configured.",
+                    status_code=503,
+                )
+        if self.issuer_url and "{tenantid}" in self.issuer_url:
             raise AuthError(
-                "AUTH_MODE=entra requires an issuer template to be configured.",
+                "ENTRA_ISSUER_URL must be a fixed issuer URL, not a template.",
                 status_code=503,
             )
-        if "{tenantid}" not in self.issuer_template:
+        if (
+            self.issuer_url is None
+            and self.issuer_template is not None
+            and "{tenantid}" not in self.issuer_template
+        ):
             raise AuthError(
-                "ENTRA_ISSUER_TEMPLATE must contain the {tenantid} placeholder.",
+                "ENTRA_ISSUER_TEMPLATE must contain the {tenantid} placeholder; "
+                "use ENTRA_ISSUER_URL for single-tenant mode.",
                 status_code=503,
             )
         if self._jwk_client is None:
@@ -109,7 +127,6 @@ class EntraAuthProvider:
 
     async def _decode_token(self, token: str) -> NormalizedIdentity:
         assert self._jwk_client is not None
-        assert self.issuer_template is not None
         assert self.audience is not None
 
         try:
@@ -126,7 +143,7 @@ class EntraAuthProvider:
             tenant_claim = str(unverified_claims.get("tid", "")).strip()
             if not tenant_claim:
                 raise AuthError("Missing tid claim", status_code=401)
-            expected_issuer = self.issuer_template.replace("{tenantid}", tenant_claim)
+            expected_issuer = self._resolve_expected_issuer(tenant_claim)
             signing_key = await asyncio.to_thread(
                 self._jwk_client.get_signing_key_from_jwt, token
             )
@@ -138,6 +155,7 @@ class EntraAuthProvider:
                 issuer=expected_issuer,
                 options={"require": ["exp", "iat", "tid"]},
             )
+            self._enforce_access_allowlist(claims)
         except AuthError:
             raise
         except InvalidTokenError as exc:
@@ -151,6 +169,36 @@ class EntraAuthProvider:
                 status_code=503,
             ) from exc
         return self._normalize_claims(claims)
+
+    def _resolve_expected_issuer(self, tenant_claim: str) -> str:
+        if self.issuer_url:
+            return self.issuer_url
+        assert self.issuer_template is not None
+        return self.issuer_template.replace("{tenantid}", tenant_claim)
+
+    def _enforce_access_allowlist(self, claims: Mapping[str, object]) -> None:
+        if not self.allowed_user_ids and not self.allowed_group_ids:
+            return
+
+        user_claim = (
+            str(claims.get("oid", "")).strip() or str(claims.get("sub", "")).strip()
+        )
+        groups_claim = claims.get("groups")
+        groups = (
+            {str(group).strip() for group in groups_claim if str(group).strip()}
+            if isinstance(groups_claim, (list, tuple, set))
+            else set()
+        )
+
+        user_allowed = user_claim in self.allowed_user_ids if user_claim else False
+        group_allowed = bool(groups & self.allowed_group_ids)
+        if user_allowed or group_allowed:
+            return
+
+        raise AuthError(
+            "Authenticated Entra identity is not allowlisted for this beta deployment.",
+            status_code=403,
+        )
 
     @staticmethod
     def _normalize_claims(claims: Mapping[str, object]) -> NormalizedIdentity:

--- a/src/fleet_rlm/api/auth/entra.py
+++ b/src/fleet_rlm/api/auth/entra.py
@@ -183,16 +183,29 @@ class EntraAuthProvider:
         user_claim = (
             str(claims.get("oid", "")).strip() or str(claims.get("sub", "")).strip()
         )
+        user_allowed = user_claim in self.allowed_user_ids if user_claim else False
+        if user_allowed:
+            return
+
         groups_claim = claims.get("groups")
+        claim_names = claims.get("_claim_names")
+        has_group_overage = bool(claims.get("hasgroups")) or (
+            isinstance(claim_names, Mapping) and "groups" in claim_names
+        )
+        if has_group_overage and self.allowed_group_ids:
+            raise AuthError(
+                "Entra token omitted groups due to overage; "
+                "allowed_group_ids cannot be evaluated from this token.",
+                status_code=403,
+            )
         groups = (
             {str(group).strip() for group in groups_claim if str(group).strip()}
             if isinstance(groups_claim, (list, tuple, set))
             else set()
         )
 
-        user_allowed = user_claim in self.allowed_user_ids if user_claim else False
         group_allowed = bool(groups & self.allowed_group_ids)
-        if user_allowed or group_allowed:
+        if group_allowed:
             return
 
         raise AuthError(

--- a/src/fleet_rlm/api/auth/factory.py
+++ b/src/fleet_rlm/api/auth/factory.py
@@ -14,8 +14,11 @@ def build_auth_provider(
     allow_debug_auth: bool = True,
     allow_query_auth_tokens: bool = True,
     entra_jwks_url: str | None = None,
+    entra_issuer_url: str | None = None,
     entra_issuer_template: str | None = None,
     entra_audience: str | None = None,
+    entra_allowed_user_ids: set[str] | None = None,
+    entra_allowed_group_ids: set[str] | None = None,
 ) -> AuthProvider:
     mode = auth_mode.strip().lower()
     if mode == "dev":
@@ -27,8 +30,11 @@ def build_auth_provider(
     if mode == "entra":
         return EntraAuthProvider(
             jwks_url=entra_jwks_url,
+            issuer_url=entra_issuer_url,
             issuer_template=entra_issuer_template,
             audience=entra_audience,
+            allowed_user_ids=entra_allowed_user_ids,
+            allowed_group_ids=entra_allowed_group_ids,
             allow_query_auth_tokens=allow_query_auth_tokens,
         )
     raise ValueError(f"Unsupported auth mode: {auth_mode}")

--- a/src/fleet_rlm/api/bootstrap.py
+++ b/src/fleet_rlm/api/bootstrap.py
@@ -95,8 +95,11 @@ def build_server_state(cfg: ServerRuntimeConfig) -> ServerState:
         allow_debug_auth=cfg.allow_debug_auth,
         allow_query_auth_tokens=cfg.allow_query_auth_tokens,
         entra_jwks_url=cfg.entra_jwks_url,
+        entra_issuer_url=cfg.entra_issuer_url,
         entra_issuer_template=cfg.entra_issuer_template,
         entra_audience=cfg.entra_audience,
+        entra_allowed_user_ids=set(cfg.entra_allowed_user_ids_list),
+        entra_allowed_group_ids=set(cfg.entra_allowed_group_ids_list),
     )
     state.db_manager = None
     state.repository = None

--- a/src/fleet_rlm/api/config.py
+++ b/src/fleet_rlm/api/config.py
@@ -6,7 +6,13 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import Field, computed_field, field_validator, model_validator
+from pydantic import (
+    Field,
+    ValidationInfo,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from fleet_rlm.integrations.config.runtime_settings import resolve_env_path
@@ -121,6 +127,12 @@ class ServerRuntimeConfig(BaseSettings):
     dev_jwt_secret: str = "change-me"
     entra_jwks_url: str | None = None
     entra_issuer_url: str | None = Field(default=None, alias="ENTRA_ISSUER_URL")
+    entra_issuer_legacy: str | None = Field(
+        default=None,
+        alias="ENTRA_ISSUER",
+        exclude=True,
+        repr=False,
+    )
     entra_issuer_template: str | None = (
         "https://login.microsoftonline.com/{tenantid}/v2.0"
     )
@@ -211,14 +223,21 @@ class ServerRuntimeConfig(BaseSettings):
         mode="before",
     )
     @classmethod
-    def _normalize_string_list(cls, value: object) -> list[str]:
+    def _normalize_string_list(
+        cls,
+        value: object,
+        info: ValidationInfo,
+    ) -> list[str]:
         if value is None:
             return []
         if isinstance(value, str):
             return [item.strip() for item in value.split(",") if item.strip()]
         if isinstance(value, (list, tuple, set)):
             return [str(item).strip() for item in value if str(item).strip()]
-        raise TypeError("value must be provided as a string or list")
+        field_name = (info.field_name or "value").upper()
+        raise ValueError(
+            f"{field_name} must be provided as a comma-separated string or list"
+        )
 
     @field_validator("entra_issuer_url", "entra_issuer_template", mode="before")
     @classmethod
@@ -305,12 +324,15 @@ class ServerRuntimeConfig(BaseSettings):
         explicit_issuer_url = values.get("entra_issuer_url") or values.get(
             "ENTRA_ISSUER_URL"
         )
+        if explicit_issuer_url:
+            values["entra_issuer_template"] = None
         if (
             explicit_issuer_template
             and not explicit_issuer_url
             and "{tenantid}" not in str(explicit_issuer_template)
         ):
             values["entra_issuer_url"] = str(explicit_issuer_template).strip()
+            values["entra_issuer_template"] = None
 
         # Backward-compatible fallback from ENTRA_ISSUER.
         if (
@@ -319,7 +341,9 @@ class ServerRuntimeConfig(BaseSettings):
             and "entra_issuer_template" not in values
             and "ENTRA_ISSUER_TEMPLATE" not in values
         ):
-            entra_issuer = values.get("ENTRA_ISSUER") or os.getenv("ENTRA_ISSUER")
+            entra_issuer = values.get("entra_issuer_legacy") or values.get(
+                "ENTRA_ISSUER"
+            )
             if entra_issuer:
                 normalized_issuer = str(entra_issuer).strip()
                 if "{tenantid}" in normalized_issuer:

--- a/src/fleet_rlm/api/config.py
+++ b/src/fleet_rlm/api/config.py
@@ -286,10 +286,14 @@ class ServerRuntimeConfig(BaseSettings):
             values["serve_ui"] = app_env == "local"
 
         if "expose_docs" not in values and "FLEET_RLM_EXPOSE_DOCS" not in values:
-            values["expose_docs"] = app_env in {"local", "staging"}
+            values["expose_docs"] = app_env == "local" or (
+                app_env == "staging" and auth_mode != "entra"
+            )
 
         if "expose_root" not in values and "FLEET_RLM_EXPOSE_ROOT" not in values:
-            values["expose_root"] = app_env in {"local", "staging"}
+            values["expose_root"] = app_env == "local" or (
+                app_env == "staging" and auth_mode != "entra"
+            )
 
         # auth_required defaults to True when auth_mode is entra
         if "auth_required" not in values and "AUTH_REQUIRED" not in values:

--- a/src/fleet_rlm/api/config.py
+++ b/src/fleet_rlm/api/config.py
@@ -34,6 +34,23 @@ def resolve_server_volume_name(config: AppConfig) -> str | None:
     return volume_name if volume_name is not None else DEFAULT_SERVER_VOLUME_NAME
 
 
+def _looks_like_managed_runtime(
+    *,
+    port: str | None = None,
+    cwd: Path | None = None,
+) -> bool:
+    """Return whether the current process appears to run on a managed host.
+
+    FastAPI Cloud runs the app from ``/app`` and injects ``PORT``. Detecting
+    that combination lets us fail fast if the deploy accidentally boots with
+    local defaults instead of the required cloud configuration.
+    """
+
+    resolved_port = (port if port is not None else os.getenv("PORT") or "").strip()
+    resolved_cwd = cwd if cwd is not None else Path.cwd()
+    return bool(resolved_port) and resolved_cwd == Path("/app")
+
+
 class ServerRuntimeConfig(BaseSettings):
     """Server runtime configuration loaded from environment variables.
 
@@ -103,9 +120,20 @@ class ServerRuntimeConfig(BaseSettings):
     auth_required: bool = False
     dev_jwt_secret: str = "change-me"
     entra_jwks_url: str | None = None
-    entra_issuer_template: str = "https://login.microsoftonline.com/{tenantid}/v2.0"
+    entra_issuer_url: str | None = Field(default=None, alias="ENTRA_ISSUER_URL")
+    entra_issuer_template: str | None = (
+        "https://login.microsoftonline.com/{tenantid}/v2.0"
+    )
     entra_audience: str | None = None
+    entra_allowed_user_ids: list[str] | str = Field(
+        default_factory=list, alias="ENTRA_ALLOWED_USER_IDS"
+    )
+    entra_allowed_group_ids: list[str] | str = Field(
+        default_factory=list, alias="ENTRA_ALLOWED_GROUP_IDS"
+    )
     serve_ui: bool = Field(default=True, alias="FLEET_RLM_SERVE_UI")
+    expose_docs: bool = Field(default=False, alias="FLEET_RLM_EXPOSE_DOCS")
+    expose_root: bool = Field(default=False, alias="FLEET_RLM_EXPOSE_ROOT")
 
     @field_validator(
         "agent_model",
@@ -164,16 +192,41 @@ class ServerRuntimeConfig(BaseSettings):
         """Return CORS origins as a normalized list."""
         return list(self.cors_allowed_origins)
 
-    @field_validator("cors_allowed_origins", mode="before")
+    @computed_field
+    @property
+    def entra_allowed_user_ids_list(self) -> list[str]:
+        """Return the configured Entra beta user allowlist."""
+        return list(self.entra_allowed_user_ids)
+
+    @computed_field
+    @property
+    def entra_allowed_group_ids_list(self) -> list[str]:
+        """Return the configured Entra beta group allowlist."""
+        return list(self.entra_allowed_group_ids)
+
+    @field_validator(
+        "cors_allowed_origins",
+        "entra_allowed_user_ids",
+        "entra_allowed_group_ids",
+        mode="before",
+    )
     @classmethod
-    def _normalize_cors_allowed_origins(cls, value: object) -> list[str]:
+    def _normalize_string_list(cls, value: object) -> list[str]:
         if value is None:
             return []
         if isinstance(value, str):
             return [item.strip() for item in value.split(",") if item.strip()]
         if isinstance(value, (list, tuple, set)):
             return [str(item).strip() for item in value if str(item).strip()]
-        raise TypeError("cors_allowed_origins must be provided as a string or list")
+        raise TypeError("value must be provided as a string or list")
+
+    @field_validator("entra_issuer_url", "entra_issuer_template", mode="before")
+    @classmethod
+    def _normalize_optional_string(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
 
     @model_validator(mode="before")
     @classmethod
@@ -232,18 +285,43 @@ class ServerRuntimeConfig(BaseSettings):
         if "serve_ui" not in values and "FLEET_RLM_SERVE_UI" not in values:
             values["serve_ui"] = app_env == "local"
 
+        if "expose_docs" not in values and "FLEET_RLM_EXPOSE_DOCS" not in values:
+            values["expose_docs"] = app_env in {"local", "staging"}
+
+        if "expose_root" not in values and "FLEET_RLM_EXPOSE_ROOT" not in values:
+            values["expose_root"] = app_env in {"local", "staging"}
+
         # auth_required defaults to True when auth_mode is entra
         if "auth_required" not in values and "AUTH_REQUIRED" not in values:
             values["auth_required"] = auth_mode == "entra"
 
-        # entra_issuer_template fallback to ENTRA_ISSUER
+        explicit_issuer_template = values.get("entra_issuer_template") or values.get(
+            "ENTRA_ISSUER_TEMPLATE"
+        )
+        explicit_issuer_url = values.get("entra_issuer_url") or values.get(
+            "ENTRA_ISSUER_URL"
+        )
         if (
-            "entra_issuer_template" not in values
+            explicit_issuer_template
+            and not explicit_issuer_url
+            and "{tenantid}" not in str(explicit_issuer_template)
+        ):
+            values["entra_issuer_url"] = str(explicit_issuer_template).strip()
+
+        # Backward-compatible fallback from ENTRA_ISSUER.
+        if (
+            "entra_issuer_url" not in values
+            and "ENTRA_ISSUER_URL" not in values
+            and "entra_issuer_template" not in values
             and "ENTRA_ISSUER_TEMPLATE" not in values
         ):
             entra_issuer = values.get("ENTRA_ISSUER") or os.getenv("ENTRA_ISSUER")
             if entra_issuer:
-                values["entra_issuer_template"] = entra_issuer
+                normalized_issuer = str(entra_issuer).strip()
+                if "{tenantid}" in normalized_issuer:
+                    values["entra_issuer_template"] = normalized_issuer
+                else:
+                    values["entra_issuer_url"] = normalized_issuer
 
         return values
 
@@ -251,6 +329,14 @@ class ServerRuntimeConfig(BaseSettings):
         """Validate environment guardrails before server startup."""
         if self.ws_execution_max_queue <= 0:
             raise ValueError("WS execution queue size must be > 0")
+
+        if self.app_env == "local" and _looks_like_managed_runtime():
+            raise ValueError(
+                "Managed deployment detected with APP_ENV=local. Set APP_ENV to "
+                "'staging' or 'production' and configure managed-host settings "
+                "(for example: FLEET_RLM_SERVE_UI=false, DATABASE_REQUIRED/DATABASE_URL, "
+                "AUTH_REQUIRED, and MLFLOW_ENABLED=false)."
+            )
 
         if self.database_required and not self.database_url:
             raise ValueError("DATABASE_URL is required when database_required=true")
@@ -286,7 +372,37 @@ class ServerRuntimeConfig(BaseSettings):
                 raise ValueError("ENTRA_JWKS_URL is required when AUTH_MODE=entra")
             if not self.entra_audience:
                 raise ValueError("ENTRA_AUDIENCE is required when AUTH_MODE=entra")
-            if "{tenantid}" not in self.entra_issuer_template:
+            if self.entra_issuer_url:
+                if "{tenantid}" in self.entra_issuer_url:
+                    raise ValueError(
+                        "ENTRA_ISSUER_URL must be a fixed issuer URL, not a template"
+                    )
+            elif not self.entra_issuer_template:
                 raise ValueError(
-                    "ENTRA_ISSUER_TEMPLATE must contain the {tenantid} placeholder when AUTH_MODE=entra"
+                    "Set ENTRA_ISSUER_URL or ENTRA_ISSUER_TEMPLATE when AUTH_MODE=entra"
                 )
+            elif "{tenantid}" not in self.entra_issuer_template:
+                raise ValueError(
+                    "ENTRA_ISSUER_TEMPLATE must contain the {tenantid} placeholder "
+                    "when AUTH_MODE=entra; use ENTRA_ISSUER_URL for a single-tenant issuer"
+                )
+            if self.app_env in {"staging", "production"} and self.auth_mode == "entra":
+                if self.expose_docs:
+                    raise ValueError(
+                        "FLEET_RLM_EXPOSE_DOCS must be false when AUTH_MODE=entra "
+                        "in staging/production"
+                    )
+                if self.expose_root:
+                    raise ValueError(
+                        "FLEET_RLM_EXPOSE_ROOT must be false when AUTH_MODE=entra "
+                        "in staging/production"
+                    )
+                if (
+                    self.entra_issuer_url
+                    and not self.entra_allowed_user_ids_list
+                    and not self.entra_allowed_group_ids_list
+                ):
+                    raise ValueError(
+                        "Single-tenant Entra deployments in staging/production "
+                        "must configure ENTRA_ALLOWED_USER_IDS or ENTRA_ALLOWED_GROUP_IDS"
+                    )

--- a/src/fleet_rlm/api/main.py
+++ b/src/fleet_rlm/api/main.py
@@ -273,21 +273,6 @@ def _annotate_validation_error_schemas(app: FastAPI) -> None:
     app.openapi = cast(Any, custom_openapi)
 
 
-def _docs_enabled(cfg: ServerRuntimeConfig) -> bool:
-    """Return whether docs/openapi URLs should be mounted.
-
-    Enabled for local/staging environments. Disabled in production to avoid
-    leaking the full API surface to unauthenticated clients. Override by
-    setting ``FLEET_RLM_EXPOSE_DOCS=1`` if operators need them temporarily.
-    """
-    import os
-
-    override = os.getenv("FLEET_RLM_EXPOSE_DOCS", "").strip().lower()
-    if override in {"1", "true", "yes"}:
-        return True
-    return cfg.app_env in {"local", "staging"}
-
-
 def create_app(*, config: ServerRuntimeConfig | None = None) -> FastAPI:
     """Create the FastAPI application instance."""
     cfg = resolve_runtime_config(config)
@@ -322,22 +307,20 @@ def create_app(*, config: ServerRuntimeConfig | None = None) -> FastAPI:
         yield
         await shutdown_server_state(state)
 
-    docs_enabled = _docs_enabled(cfg)
-
     app = FastAPI(
         title="fleet-rlm",
         version=__version__,
         lifespan=lifespan,
-        docs_url="/docs" if docs_enabled else None,
-        redoc_url="/redoc" if docs_enabled else None,
-        openapi_url="/openapi.json" if docs_enabled else None,
+        docs_url="/docs" if cfg.expose_docs else None,
+        redoc_url="/redoc" if cfg.expose_docs else None,
+        openapi_url="/openapi.json" if cfg.expose_docs else None,
     )
     _annotate_validation_error_schemas(app)
 
     add_middlewares(app, cfg)
     _register_api_routes(app)
 
-    if docs_enabled:
+    if cfg.expose_docs:
         try:
             scalar_fastapi = cast(Any, import_module("scalar_fastapi"))
             get_scalar_api_reference = scalar_fastapi.get_scalar_api_reference
@@ -360,7 +343,7 @@ def create_app(*, config: ServerRuntimeConfig | None = None) -> FastAPI:
             _mount_spa(app, ui_dir)
         else:
             _mount_ui_unavailable_root(app)
-    else:
+    elif cfg.expose_root:
         _mount_api_only_root(app)
 
     return app

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -10,12 +10,12 @@ VITE_FLEET_TRACE=true
 #   redirect path: /login
 # Scope format:
 #   api://<api-app-client-id>/access_as_user
-VITE_ENTRA_CLIENT_ID=16864674-b56f-46cb-b3b9-6c570fafe39c
+VITE_ENTRA_CLIENT_ID=
 # For single-tenant (cloud-only) deployment, pin to your tenant:
-# VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4
+# VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/{tenantid}
 # For multi-org sign-in leave the default:
 # VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/organizations
-VITE_ENTRA_SCOPES=api://16864674-b56f-46cb-b3b9-6c570fafe39c/access_as_user
+VITE_ENTRA_SCOPES=api://<api-app-client-id>/access_as_user
 # VITE_ENTRA_REDIRECT_PATH=/login
 
 # Optional PostHog frontend analytics (canonical key)

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -10,10 +10,12 @@ VITE_FLEET_TRACE=true
 #   redirect path: /login
 # Scope format:
 #   api://<api-app-client-id>/access_as_user
-VITE_ENTRA_CLIENT_ID=
-# Optional explicit authority override.
+VITE_ENTRA_CLIENT_ID=16864674-b56f-46cb-b3b9-6c570fafe39c
+# For single-tenant (cloud-only) deployment, pin to your tenant:
+# VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/2de16556-356e-43f8-beee-f59ce2c336e4
+# For multi-org sign-in leave the default:
 # VITE_ENTRA_AUTHORITY=https://login.microsoftonline.com/organizations
-VITE_ENTRA_SCOPES=
+VITE_ENTRA_SCOPES=api://16864674-b56f-46cb-b3b9-6c570fafe39c/access_as_user
 # VITE_ENTRA_REDIRECT_PATH=/login
 
 # Optional PostHog frontend analytics (canonical key)

--- a/src/frontend/openapi/fleet-rlm.openapi.yaml
+++ b/src/frontend/openapi/fleet-rlm.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.5.1
+  version: 0.5.2
 paths:
   /health:
     get:
@@ -24,7 +24,12 @@ paths:
       tags:
         - health
       summary: Ready
-      description: Report whether critical startup dependencies are ready for requests.
+      description: "Report whether critical startup dependencies are ready for requests.
+
+
+        Verifies DB connectivity with a short-timeout ping so a sleeping Neon
+
+        compute reports ``degraded`` instead of ``ready``."
       operationId: ready_ready_get
       responses:
         "200":
@@ -2053,7 +2058,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.5.1
+          default: 0.5.2
       type: object
       title: HealthResponse
       description: Response body for the lightweight health endpoint.

--- a/src/frontend/src/components/ai-elements/prompt-input/prompt-input.textarea.tsx
+++ b/src/frontend/src/components/ai-elements/prompt-input/prompt-input.textarea.tsx
@@ -137,7 +137,7 @@ export const PromptInputTextarea = ({
     <InputGroupTextarea
       {...props}
       className={cn(
-        "field-sizing-content min-h-12 w-full max-h-48 border-0 bg-transparent px-2 pb-2.5 pt-2",
+        "field-sizing-content min-h-12 w-full max-h-48 border-0 bg-transparent px-2 pb-2.5 pt-2 text-sm",
         "prompt-composer-textarea outline-none ring-0 focus-visible:ring-0 focus-visible:outline-none",
         className,
       )}

--- a/src/frontend/src/lib/rlm-api/generated/openapi.ts
+++ b/src/frontend/src/lib/rlm-api/generated/openapi.ts
@@ -15,6 +15,9 @@ export interface paths {
     /**
      * Ready
      * @description Report whether critical startup dependencies are ready for requests.
+     *
+     * Verifies DB connectivity with a short-timeout ping so a sleeping Neon
+     * compute reports ``degraded`` instead of ``ready``.
      */
     get: operations["ready_ready_get"];
   };
@@ -688,7 +691,7 @@ export interface components {
       /**
        * Version
        * @description Package version currently serving the API.
-       * @default 0.5.1
+       * @default 0.5.2
        */
       version?: string;
     };
@@ -2152,6 +2155,9 @@ export interface operations {
   /**
    * Ready
    * @description Report whether critical startup dependencies are ready for requests.
+   *
+   * Verifies DB connectivity with a short-timeout ping so a sleeping Neon
+   * compute reports ``degraded`` instead of ``ready``.
    */
   ready_ready_get: {
     responses: {

--- a/tests/ui/server/test_create_app_serve_ui.py
+++ b/tests/ui/server/test_create_app_serve_ui.py
@@ -96,8 +96,8 @@ def test_ready_stays_public_when_auth_is_required() -> None:
             cors_allowed_origins=["https://example.com"],
         )
     )
-    with TestClient(app) as client:
-        response = client.get("/ready")
+    client = TestClient(app)
+    response = client.get("/ready")
 
     assert response.status_code == 200
 

--- a/tests/ui/server/test_create_app_serve_ui.py
+++ b/tests/ui/server/test_create_app_serve_ui.py
@@ -96,8 +96,8 @@ def test_ready_stays_public_when_auth_is_required() -> None:
             cors_allowed_origins=["https://example.com"],
         )
     )
-    client = TestClient(app)
-    response = client.get("/ready")
+    with TestClient(app) as client:
+        response = client.get("/ready")
 
     assert response.status_code == 200
 

--- a/tests/ui/server/test_create_app_serve_ui.py
+++ b/tests/ui/server/test_create_app_serve_ui.py
@@ -45,6 +45,63 @@ def test_api_only_mode_does_not_mount_assets_route() -> None:
     assert "/{full_path:path}" not in mounted_paths
 
 
+def test_api_only_root_is_hidden_when_expose_root_false() -> None:
+    app = create_app(
+        config=_base_cfg(
+            app_env="production",
+            serve_ui=False,
+            expose_root=False,
+            auth_required=True,
+            dev_jwt_secret="prod-secret",
+            allow_debug_auth=False,
+            allow_query_auth_tokens=False,
+            cors_allowed_origins=["https://example.com"],
+        )
+    )
+    client = TestClient(app)
+
+    response = client.get("/")
+
+    assert response.status_code == 404
+
+
+def test_docs_are_hidden_when_expose_docs_false() -> None:
+    app = create_app(
+        config=_base_cfg(
+            app_env="production",
+            serve_ui=False,
+            expose_docs=False,
+            auth_required=True,
+            dev_jwt_secret="prod-secret",
+            allow_debug_auth=False,
+            allow_query_auth_tokens=False,
+            cors_allowed_origins=["https://example.com"],
+        )
+    )
+    client = TestClient(app)
+
+    response = client.get("/docs")
+
+    assert response.status_code == 404
+
+
+def test_ready_stays_public_when_auth_is_required() -> None:
+    app = create_app(
+        config=_base_cfg(
+            app_env="staging",
+            auth_required=True,
+            allow_debug_auth=False,
+            allow_query_auth_tokens=False,
+            dev_jwt_secret="staging-secret",
+            cors_allowed_origins=["https://example.com"],
+        )
+    )
+    with TestClient(app) as client:
+        response = client.get("/ready")
+
+    assert response.status_code == 200
+
+
 def test_serve_ui_true_preserves_health_and_docs_endpoints() -> None:
     # `serve_ui=True` with no dist falls back to the 503-JSON root handler,
     # but health/docs must still be reachable.

--- a/tests/ui/server/test_server_config.py
+++ b/tests/ui/server/test_server_config.py
@@ -18,6 +18,8 @@ from fleet_rlm.api.schemas import (
 )
 from fleet_rlm.integrations.config.env import AppConfig
 
+pytestmark = pytest.mark.ui
+
 
 @pytest.fixture(autouse=True)
 def _clear_server_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -277,7 +279,13 @@ def test_custom_config():
     assert cfg.ws_execution_drop_policy == "drop_newest"
     assert cfg.db_validate_on_startup is True
     assert cfg.entra_issuer_url == "https://login.microsoftonline.com/tenant/v2.0"
+    assert cfg.entra_issuer_template is None
     assert cfg.entra_allowed_user_ids_list == ["user-456"]
+
+
+def test_string_list_validator_reports_field_name() -> None:
+    with pytest.raises(ValidationError, match="CORS_ALLOWED_ORIGINS"):
+        ServerRuntimeConfig(cors_allowed_origins=123)
 
 
 def test_validate_startup_rejects_insecure_production():
@@ -380,6 +388,7 @@ def test_validate_startup_promotes_fixed_template_value_to_issuer_url() -> None:
         cors_allowed_origins=[],
     )
     assert cfg.entra_issuer_url == "https://login.microsoftonline.com/static/v2.0"
+    assert cfg.entra_issuer_template is None
     cfg.validate_startup_or_raise()
 
 

--- a/tests/ui/server/test_server_config.py
+++ b/tests/ui/server/test_server_config.py
@@ -19,6 +19,31 @@ from fleet_rlm.api.schemas import (
 from fleet_rlm.integrations.config.env import AppConfig
 
 
+@pytest.fixture(autouse=True)
+def _clear_server_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "APP_ENV",
+        "AUTH_MODE",
+        "AUTH_REQUIRED",
+        "DATABASE_REQUIRED",
+        "DATABASE_URL",
+        "ALLOW_DEBUG_AUTH",
+        "ALLOW_QUERY_AUTH_TOKENS",
+        "CORS_ALLOWED_ORIGINS",
+        "FLEET_RLM_SERVE_UI",
+        "FLEET_RLM_EXPOSE_DOCS",
+        "FLEET_RLM_EXPOSE_ROOT",
+        "ENTRA_JWKS_URL",
+        "ENTRA_ISSUER_URL",
+        "ENTRA_ISSUER_TEMPLATE",
+        "ENTRA_ISSUER",
+        "ENTRA_AUDIENCE",
+        "ENTRA_ALLOWED_USER_IDS",
+        "ENTRA_ALLOWED_GROUP_IDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 def test_default_config(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("VOLUME_NAME", raising=False)
     monkeypatch.delenv("DSPY_LM_MODEL", raising=False)
@@ -52,6 +77,9 @@ def test_default_config(monkeypatch: pytest.MonkeyPatch):
     assert (
         cfg.entra_issuer_template == "https://login.microsoftonline.com/{tenantid}/v2.0"
     )
+    assert cfg.entra_issuer_url is None
+    assert cfg.expose_docs is True
+    assert cfg.expose_root is True
     assert cfg.serve_ui is True
 
 
@@ -69,6 +97,8 @@ def test_serve_ui_defaults_false_in_production(
         cors_allowed_origins=["https://app.example.com"],
     )
     assert cfg.serve_ui is False
+    assert cfg.expose_docs is False
+    assert cfg.expose_root is False
 
 
 def test_serve_ui_respects_explicit_env_override(
@@ -205,8 +235,9 @@ def test_custom_config():
         ws_execution_drop_policy="drop_newest",
         db_validate_on_startup=True,
         entra_jwks_url="https://login.microsoftonline.com/tenant/discovery/v2.0/keys",
-        entra_issuer_template="https://login.microsoftonline.com/{tenantid}/v2.0",
+        entra_issuer_url="https://login.microsoftonline.com/tenant/v2.0",
         entra_audience="api://fleet-rlm",
+        entra_allowed_user_ids=["user-456"],
     )
     assert cfg.app_env == "production"
     assert cfg.secret_name == "CUSTOM"
@@ -226,6 +257,8 @@ def test_custom_config():
     assert cfg.ws_execution_max_queue == 512
     assert cfg.ws_execution_drop_policy == "drop_newest"
     assert cfg.db_validate_on_startup is True
+    assert cfg.entra_issuer_url == "https://login.microsoftonline.com/tenant/v2.0"
+    assert cfg.entra_allowed_user_ids_list == ["user-456"]
 
 
 def test_validate_startup_rejects_insecure_production():
@@ -240,6 +273,43 @@ def test_validate_startup_rejects_insecure_production():
     )
     with pytest.raises(ValueError, match="AUTH_REQUIRED"):
         cfg.validate_startup_or_raise()
+
+
+def test_validate_startup_rejects_local_defaults_on_managed_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.api.config._looks_like_managed_runtime",
+        lambda: True,
+    )
+
+    cfg = ServerRuntimeConfig()
+
+    with pytest.raises(
+        ValueError, match="Managed deployment detected with APP_ENV=local"
+    ):
+        cfg.validate_startup_or_raise()
+
+
+def test_validate_startup_allows_production_on_managed_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.api.config._looks_like_managed_runtime",
+        lambda: True,
+    )
+
+    cfg = ServerRuntimeConfig(
+        app_env="production",
+        auth_mode="dev",
+        auth_required=True,
+        dev_jwt_secret="prod-secret",
+        database_required=True,
+        database_url="postgresql://localhost:5432/test",
+        cors_allowed_origins=[],
+    )
+
+    cfg.validate_startup_or_raise()
 
 
 def test_validate_startup_requires_entra_settings() -> None:
@@ -259,8 +329,27 @@ def test_validate_startup_requires_database_for_entra() -> None:
         cfg.validate_startup_or_raise()
 
 
-def test_validate_startup_rejects_fixed_entra_issuer_template() -> None:
+def test_validate_startup_allows_fixed_entra_issuer_url_for_single_tenant_beta() -> (
+    None
+):
     cfg = ServerRuntimeConfig(
+        app_env="production",
+        auth_mode="entra",
+        auth_required=True,
+        database_required=True,
+        database_url="postgresql://localhost:5432/test",
+        entra_jwks_url="https://login.microsoftonline.com/common/discovery/v2.0/keys",
+        entra_audience="api://fleet-rlm",
+        entra_issuer_url="https://login.microsoftonline.com/static/v2.0",
+        entra_allowed_user_ids=["user-123"],
+        cors_allowed_origins=[],
+    )
+    cfg.validate_startup_or_raise()
+
+
+def test_validate_startup_promotes_fixed_template_value_to_issuer_url() -> None:
+    cfg = ServerRuntimeConfig(
+        app_env="production",
         auth_mode="entra",
         auth_required=True,
         database_required=True,
@@ -268,8 +357,56 @@ def test_validate_startup_rejects_fixed_entra_issuer_template() -> None:
         entra_jwks_url="https://login.microsoftonline.com/common/discovery/v2.0/keys",
         entra_audience="api://fleet-rlm",
         entra_issuer_template="https://login.microsoftonline.com/static/v2.0",
+        entra_allowed_user_ids=["user-123"],
+        cors_allowed_origins=[],
     )
-    with pytest.raises(ValueError, match="tenantid"):
+    assert cfg.entra_issuer_url == "https://login.microsoftonline.com/static/v2.0"
+    cfg.validate_startup_or_raise()
+
+
+def test_validate_startup_requires_beta_allowlist_for_single_tenant_entra() -> None:
+    cfg = ServerRuntimeConfig(
+        app_env="production",
+        auth_mode="entra",
+        auth_required=True,
+        database_required=True,
+        database_url="postgresql://localhost:5432/test",
+        entra_jwks_url="https://login.microsoftonline.com/common/discovery/v2.0/keys",
+        entra_audience="api://fleet-rlm",
+        entra_issuer_url="https://login.microsoftonline.com/static/v2.0",
+        cors_allowed_origins=[],
+    )
+    with pytest.raises(ValueError, match="ENTRA_ALLOWED_USER_IDS"):
+        cfg.validate_startup_or_raise()
+
+
+@pytest.mark.parametrize(
+    ("override_key", "override_value", "expected_message"),
+    [
+        ("expose_docs", True, "FLEET_RLM_EXPOSE_DOCS"),
+        ("expose_root", True, "FLEET_RLM_EXPOSE_ROOT"),
+    ],
+)
+def test_validate_startup_rejects_public_docs_or_root_for_entra_production(
+    override_key: str,
+    override_value: bool,
+    expected_message: str,
+) -> None:
+    overrides = {override_key: override_value}
+    cfg = ServerRuntimeConfig(
+        app_env="production",
+        auth_mode="entra",
+        auth_required=True,
+        database_required=True,
+        database_url="postgresql://localhost:5432/test",
+        entra_jwks_url="https://login.microsoftonline.com/common/discovery/v2.0/keys",
+        entra_audience="api://fleet-rlm",
+        entra_issuer_url="https://login.microsoftonline.com/static/v2.0",
+        entra_allowed_user_ids=["user-123"],
+        cors_allowed_origins=[],
+        **overrides,
+    )
+    with pytest.raises(ValueError, match=expected_message):
         cfg.validate_startup_or_raise()
 
 

--- a/tests/ui/server/test_server_config.py
+++ b/tests/ui/server/test_server_config.py
@@ -101,6 +101,25 @@ def test_serve_ui_defaults_false_in_production(
     assert cfg.expose_root is False
 
 
+def test_staging_entra_defaults_hide_docs_and_root() -> None:
+    cfg = ServerRuntimeConfig(
+        app_env="staging",
+        auth_mode="entra",
+        auth_required=True,
+        database_required=True,
+        database_url="postgresql://localhost:5432/test",
+        entra_jwks_url="https://login.microsoftonline.com/common/discovery/v2.0/keys",
+        entra_audience="api://fleet-rlm",
+        entra_issuer_url="https://login.microsoftonline.com/static/v2.0",
+        entra_allowed_user_ids=["user-123"],
+        cors_allowed_origins=["https://app.example.com"],
+    )
+
+    assert cfg.expose_docs is False
+    assert cfg.expose_root is False
+    cfg.validate_startup_or_raise()
+
+
 def test_serve_ui_respects_explicit_env_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -414,6 +414,50 @@ async def test_entra_auth_accepts_allowlisted_group(
 
 
 @pytest.mark.asyncio
+async def test_entra_auth_rejects_group_allowlist_when_groups_are_omitted_by_overage(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = EntraAuthProvider(
+        jwks_url="https://login.microsoftonline.com/tenant/discovery/v2.0/keys",
+        issuer_url="https://login.microsoftonline.com/static-tenant/v2.0",
+        audience="api://fleet-rlm",
+        allowed_group_ids={"beta-group"},
+    )
+
+    class _FakeSigningKey:
+        key = "rsa-public-key"
+
+    monkeypatch.setattr(
+        provider._jwk_client,
+        "get_signing_key_from_jwt",
+        lambda token: _FakeSigningKey(),
+    )
+
+    decode_calls = {"count": 0}
+
+    def _fake_decode(*args, **kwargs):
+        decode_calls["count"] += 1
+        if decode_calls["count"] == 1:
+            return {"tid": "tenant-123"}
+        return {
+            "tid": "tenant-123",
+            "oid": "blocked-user",
+            "_claim_names": {"groups": "src1"},
+            "preferred_username": "alice@example.com",
+        }
+
+    monkeypatch.setattr(jwt, "decode", _fake_decode)
+
+    with pytest.raises(AuthError) as exc:
+        await provider.authenticate_http(
+            _FakeRequest({"authorization": "Bearer entra-token"})
+        )
+
+    assert exc.value.status_code == 403
+    assert "omitted groups due to overage" in exc.value.message
+
+
+@pytest.mark.asyncio
 async def test_entra_auth_logs_unexpected_validation_errors(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -139,6 +139,58 @@ async def test_entra_auth_requires_configuration():
 
 
 @pytest.mark.asyncio
+async def test_entra_auth_accepts_single_tenant_issuer_url(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = EntraAuthProvider(
+        jwks_url="https://login.microsoftonline.com/tenant/discovery/v2.0/keys",
+        issuer_url="https://login.microsoftonline.com/static-tenant/v2.0",
+        audience="api://fleet-rlm",
+    )
+
+    class _FakeSigningKey:
+        key = "rsa-public-key"
+
+    def _fake_decode(
+        token,
+        key=None,
+        algorithms=None,
+        audience=None,
+        issuer=None,
+        options=None,
+    ):
+        assert token == "entra-token"
+        if key is None:
+            return {"tid": "tenant-123"}
+
+        assert key == "rsa-public-key"
+        assert algorithms == ["RS256"]
+        assert audience == "api://fleet-rlm"
+        assert issuer == "https://login.microsoftonline.com/static-tenant/v2.0"
+        assert options == {"require": ["exp", "iat", "tid"]}
+        return {
+            "tid": "tenant-123",
+            "oid": "user-456",
+            "preferred_username": "alice@example.com",
+            "name": "Alice Example",
+        }
+
+    monkeypatch.setattr(
+        provider._jwk_client,
+        "get_signing_key_from_jwt",
+        lambda token: _FakeSigningKey(),
+    )
+    monkeypatch.setattr(jwt, "decode", _fake_decode)
+
+    identity = await provider.authenticate_http(
+        _FakeRequest({"authorization": "Bearer entra-token"})
+    )
+
+    assert identity.tenant_claim == "tenant-123"
+    assert identity.user_claim == "user-456"
+
+
+@pytest.mark.asyncio
 async def test_entra_auth_accepts_bearer_token(monkeypatch: pytest.MonkeyPatch):
     provider = EntraAuthProvider(
         jwks_url="https://login.microsoftonline.com/tenant/discovery/v2.0/keys",
@@ -273,6 +325,92 @@ async def test_entra_auth_rejects_missing_tid_before_issuer_resolution(
 
     assert exc.value.status_code == 401
     assert "tid" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_entra_auth_rejects_non_allowlisted_user(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = EntraAuthProvider(
+        jwks_url="https://login.microsoftonline.com/tenant/discovery/v2.0/keys",
+        issuer_url="https://login.microsoftonline.com/static-tenant/v2.0",
+        audience="api://fleet-rlm",
+        allowed_user_ids={"allowed-user"},
+    )
+
+    class _FakeSigningKey:
+        key = "rsa-public-key"
+
+    monkeypatch.setattr(
+        provider._jwk_client,
+        "get_signing_key_from_jwt",
+        lambda token: _FakeSigningKey(),
+    )
+
+    decode_calls = {"count": 0}
+
+    def _fake_decode(*args, **kwargs):
+        decode_calls["count"] += 1
+        if decode_calls["count"] == 1:
+            return {"tid": "tenant-123"}
+        return {
+            "tid": "tenant-123",
+            "oid": "blocked-user",
+            "preferred_username": "alice@example.com",
+        }
+
+    monkeypatch.setattr(jwt, "decode", _fake_decode)
+
+    with pytest.raises(AuthError) as exc:
+        await provider.authenticate_http(
+            _FakeRequest({"authorization": "Bearer entra-token"})
+        )
+
+    assert exc.value.status_code == 403
+    assert "allowlisted" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_entra_auth_accepts_allowlisted_group(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = EntraAuthProvider(
+        jwks_url="https://login.microsoftonline.com/tenant/discovery/v2.0/keys",
+        issuer_url="https://login.microsoftonline.com/static-tenant/v2.0",
+        audience="api://fleet-rlm",
+        allowed_group_ids={"beta-group"},
+    )
+
+    class _FakeSigningKey:
+        key = "rsa-public-key"
+
+    monkeypatch.setattr(
+        provider._jwk_client,
+        "get_signing_key_from_jwt",
+        lambda token: _FakeSigningKey(),
+    )
+
+    decode_calls = {"count": 0}
+
+    def _fake_decode(*args, **kwargs):
+        decode_calls["count"] += 1
+        if decode_calls["count"] == 1:
+            return {"tid": "tenant-123"}
+        return {
+            "tid": "tenant-123",
+            "oid": "blocked-user",
+            "groups": ["beta-group"],
+            "preferred_username": "alice@example.com",
+        }
+
+    monkeypatch.setattr(jwt, "decode", _fake_decode)
+
+    identity = await provider.authenticate_http(
+        _FakeRequest({"authorization": "Bearer entra-token"})
+    )
+
+    assert identity.tenant_claim == "tenant-123"
+    assert identity.user_claim == "blocked-user"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1318,7 +1318,7 @@ wheels = [
 
 [[package]]
 name = "fleet-rlm"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Prepares the v0.5.2 release by syncing version metadata, regenerating API contracts, and updating the changelog.

## Changes

- Bump package version to `0.5.2` in `pyproject.toml`
- Sync `uv.lock`
- Regenerate `openapi.yaml` and frontend OpenAPI artifacts
- Add `[0.5.2] - 2026-04-29` changelog entry covering:
  - FastAPI Cloud Entra auth settings
  - Root `asgi.py` entrypoint for managed deploys
  - Async DB ping with timeout on `/ready`
  - Pagination across list endpoints
  - Database migrations for index cleanup and `updated_at` triggers
  - FastAPI Cloud deploy compatibility fixes
  - Blog evaluation assets added to `.gitignore`
- Validate release metadata freshness (AGENTS.md, OpenAPI sync)

## Validation

- `make format` — passed
- `make lint` — passed
- `make typecheck` — passed
- `make check-release` — passed