### PR TITLE
refactor(runtime): decouple RecursiveWorkspaceModule from Daytona adapter

### DIFF
--- a/src/fleet_rlm/integrations/daytona/evidence_bridge.py
+++ b/src/fleet_rlm/integrations/daytona/evidence_bridge.py
@@ -152,7 +152,43 @@ def list_evidence(
 
 _EVIDENCE_TOOL_NAMES = frozenset({"store_evidence", "fetch_evidence", "list_evidence"})
 
+
+class DaytonaEvidenceSink:
+    """Adapts module-level evidence functions to the EvidenceSink protocol.
+
+    Used by runtime modules that accept an ``EvidenceSink`` without knowing
+    Daytona exists. The module-level functions stay the public API for sandbox
+    code registered via ``bridge_callbacks``; this class is the shape the
+    runtime business logic sees.
+    """
+
+    def __init__(self, interpreter: Any) -> None:
+        self._interpreter = interpreter
+
+    def store(
+        self,
+        *,
+        key: str,
+        content: str,
+        kind: str = "context",
+        scope: str = "run",
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]:
+        return store_evidence(
+            self._interpreter,
+            key=key,
+            content=content,
+            kind=kind,
+            scope=scope,
+            tags=tags,
+        )
+
+    def list_items(self, *, scope: str = "run", limit: int = 50) -> dict[str, Any]:
+        return list_evidence(self._interpreter, scope=scope, limit=limit)
+
+
 __all__ = [
+    "DaytonaEvidenceSink",
     "fetch_evidence",
     "list_evidence",
     "store_evidence",

--- a/src/fleet_rlm/runtime/agent/runtime.py
+++ b/src/fleet_rlm/runtime/agent/runtime.py
@@ -249,6 +249,7 @@ def _bound_runtime_tool_factories(
         max_passes: int = 3,
     ) -> dict[str, Any]:
         """Run a multi-pass recursive analysis with decomposition and verification."""
+        from fleet_rlm.integrations.daytona.evidence_bridge import DaytonaEvidenceSink
         from fleet_rlm.runtime.models.builders import RecursiveWorkspaceModule
 
         module = RecursiveWorkspaceModule(
@@ -256,6 +257,7 @@ def _bound_runtime_tool_factories(
             max_passes=max_passes,
             verbose=False,
             sub_lm=getattr(interpreter, "sub_lm", None),
+            evidence_sink=DaytonaEvidenceSink(interpreter),
         )
         prediction = module(user_request=query, context=context)
         return {

--- a/src/fleet_rlm/runtime/models/builders.py
+++ b/src/fleet_rlm/runtime/models/builders.py
@@ -28,6 +28,7 @@ from fleet_rlm.runtime.content.chunking import (
     chunk_by_size,
     chunk_by_timestamps,
 )
+from fleet_rlm.runtime.models.evidence import EvidenceSink
 
 
 def create_runtime_rlm(
@@ -624,6 +625,7 @@ class RecursiveWorkspaceModule(dspy.Module):
         context_budget_chars: int = 32_000,
         verbose: bool = False,
         sub_lm: dspy.LM | None = None,
+        evidence_sink: EvidenceSink | None = None,
     ) -> None:
         super().__init__()
         self.interpreter = interpreter
@@ -631,6 +633,7 @@ class RecursiveWorkspaceModule(dspy.Module):
         self.max_repair_attempts = max_repair_attempts
         self.subquery_budget = subquery_budget
         self.context_budget_chars = context_budget_chars
+        self._evidence = evidence_sink
 
         rlm_kwargs: dict[str, Any] = {
             "interpreter": interpreter,
@@ -810,19 +813,18 @@ class RecursiveWorkspaceModule(dspy.Module):
         return outputs
 
     def _fetch_memory_catalog(self) -> list[str]:
-        from fleet_rlm.integrations.daytona.evidence_bridge import list_evidence
-
-        result = list_evidence(self.interpreter, scope="run", limit=50)
+        if self._evidence is None:
+            return []
+        result = self._evidence.list_items(scope="run", limit=50)
         return [
             f"{item['scope_id']}:{item['kind']}" for item in result.get("items", [])
         ]
 
     def _store_pass_evidence(self, pass_idx: int, outputs: list[str]) -> None:
-        from fleet_rlm.integrations.daytona.evidence_bridge import store_evidence
-
+        if self._evidence is None:
+            return
         for i, output in enumerate(outputs):
-            store_evidence(
-                self.interpreter,
+            self._evidence.store(
                 key=f"pass_{pass_idx}_output_{i}",
                 content=output[:10_000],
                 kind="context",

--- a/src/fleet_rlm/runtime/models/builders.py
+++ b/src/fleet_rlm/runtime/models/builders.py
@@ -610,7 +610,12 @@ class RecursiveWorkspaceModule(dspy.Module):
     Runs a bounded loop: assemble context → plan decomposition → execute
     subqueries → verify → reflect (finalize / recurse / repair). Each
     sub-module is a ``dspy.RLM`` so the LLM writes code at every step.
-    Evidence is persisted across passes via the host-mediated NeonDB bridge.
+
+    Evidence is persisted across passes via an injected :class:`EvidenceSink`.
+    Pass ``evidence_sink=None`` (the default) to skip persistence — this
+    matches the behaviour of runs without a host repository attached.  The
+    production adapter is
+    ``fleet_rlm.integrations.daytona.evidence_bridge.DaytonaEvidenceSink``.
     """
 
     def __init__(

--- a/src/fleet_rlm/runtime/models/evidence.py
+++ b/src/fleet_rlm/runtime/models/evidence.py
@@ -27,9 +27,11 @@ class EvidenceSink(Protocol):
         kind: str = "context",
         scope: str = "run",
         tags: list[str] | None = None,
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        pass
 
-    def list_items(self, *, scope: str = "run", limit: int = 50) -> dict[str, Any]: ...
+    def list_items(self, *, scope: str = "run", limit: int = 50) -> dict[str, Any]:
+        pass
 
 
 __all__ = ["EvidenceSink"]

--- a/src/fleet_rlm/runtime/models/evidence.py
+++ b/src/fleet_rlm/runtime/models/evidence.py
@@ -1,0 +1,35 @@
+"""Evidence-sink protocol for runtime modules.
+
+Runtime modules that persist cross-pass evidence declare what they need from a
+storage backend via the :class:`EvidenceSink` protocol. Concrete backends
+(Daytona, in-memory test fakes) live outside ``runtime/`` and are injected at
+construction so business logic never imports its own adapters.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class EvidenceSink(Protocol):
+    """Structural surface for storing and listing cross-pass evidence.
+
+    Implementations satisfy this protocol by shape — no inheritance required.
+    See ``fleet_rlm.integrations.daytona.evidence_bridge.DaytonaEvidenceSink``
+    for the production adapter.
+    """
+
+    def store(
+        self,
+        *,
+        key: str,
+        content: str,
+        kind: str = "context",
+        scope: str = "run",
+        tags: list[str] | None = None,
+    ) -> dict[str, Any]: ...
+
+    def list_items(self, *, scope: str = "run", limit: int = 50) -> dict[str, Any]: ...
+
+
+__all__ = ["EvidenceSink"]

--- a/tests/unit/runtime/agent/test_recursive_workspace.py
+++ b/tests/unit/runtime/agent/test_recursive_workspace.py
@@ -422,20 +422,47 @@ class TestHelpers:
         catalog = module._fetch_memory_catalog()
         assert isinstance(catalog, list)
 
-    def test_store_pass_evidence_calls_bridge(self) -> None:
+    def test_store_pass_evidence_calls_injected_sink(self) -> None:
+        sink_calls: list[dict[str, Any]] = []
+
+        class _FakeSink:
+            def store(self, **kwargs: Any) -> dict[str, Any]:
+                sink_calls.append(kwargs)
+                return {"status": "ok", "id": "x"}
+
+            def list_items(self, **kwargs: Any) -> dict[str, Any]:
+                return {"items": []}
+
+        module = _build_module(evidence_sink=_FakeSink())
+        module._store_pass_evidence(0, ["output1", "output2"])
+
+        assert len(sink_calls) == 2
+        assert sink_calls[0]["key"] == "pass_0_output_0"
+        assert sink_calls[0]["kind"] == "context"
+        assert "orchestrator" in sink_calls[0]["tags"]
+
+    def test_store_pass_evidence_noops_when_no_sink(self) -> None:
+        # Regression: the None-sink branch preserves the pre-refactor silent-skip
+        # behavior when no host repository is attached to the interpreter.
         module = _build_module()
+        module._store_pass_evidence(0, ["output1", "output2"])  # must not raise
 
-        with patch(
-            "fleet_rlm.integrations.daytona.evidence_bridge.store_evidence"
-        ) as mock_store:
-            mock_store.return_value = {"status": "skipped"}
-            module._store_pass_evidence(0, ["output1", "output2"])
+    def test_fetch_memory_catalog_uses_injected_sink(self) -> None:
+        class _FakeSink:
+            def store(self, **kwargs: Any) -> dict[str, Any]:
+                return {"status": "ok"}
 
-        assert mock_store.call_count == 2
-        first_call = mock_store.call_args_list[0]
-        assert first_call[1]["key"] == "pass_0_output_0"
-        assert first_call[1]["kind"] == "context"
-        assert "orchestrator" in first_call[1]["tags"]
+            def list_items(self, **kwargs: Any) -> dict[str, Any]:
+                return {
+                    "items": [
+                        {"scope_id": "s1", "kind": "context"},
+                        {"scope_id": "s2", "kind": "observation"},
+                    ]
+                }
+
+        module = _build_module(evidence_sink=_FakeSink())
+        catalog = module._fetch_memory_catalog()
+        assert catalog == ["s1:context", "s2:observation"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Inverts the dependency between `runtime/models/` business logic and the `integrations/daytona/` adapter. Previously `RecursiveWorkspaceModule._fetch_memory_catalog` and `_store_pass_evidence` reached into `evidence_bridge` via late imports (lines 813, 821 on main) — a layering violation that also silently worked around a circular dependency.
- Introduces `runtime/models/evidence.EvidenceSink`, a structural Protocol (store / list_items) that the runtime module declares as its contract. Adds `DaytonaEvidenceSink` inside the existing `evidence_bridge` module as a thin adapter over the module-level functions, which stay public and unchanged for `bridge_callbacks` to register as sandbox-callable tools.
- Wires the adapter at the one production construction site in `runtime/agent/runtime.py`. `RecursiveWorkspaceModule` now accepts `evidence_sink: EvidenceSink | None`, with a `None` branch that preserves the pre-refactor silent-skip behavior used by tests and non-sandbox runs.

**After the refactor**, `grep "fleet_rlm.integrations" src/fleet_rlm/runtime/models/builders.py` returns zero hits. The late imports are eliminated without moving functionality or changing external behavior.

### Design note
Method named `list_items` rather than `list` — `ty` flagged the builtin-shadowing during the structural-typing check. More descriptive, costs nothing.

### Deferred (not in this PR)
- The separate late-import in `runtime/execution/llm_query.py:337` targeting `builders.py` — that's a real two-file cycle but needs its own plan.
- The `runtime/agent/runtime.py` construction site still uses a late import for `DaytonaEvidenceSink`, matching the pre-existing late-import of `RecursiveWorkspaceModule` in the same function. Cleaning up both together is a follow-up.

## Test plan

- [x] `uv run ruff check` passes on all touched files
- [x] `uv run ty check` passes on all touched files (structural-typing compatibility of DaytonaEvidenceSink confirmed)
- [x] `uv run pytest tests/unit/runtime/agent/test_recursive_workspace.py` — 19/19 pass (+3 new injection-based tests, −1 old layering-violation test)
- [x] `uv run pytest tests/ --ignore=tests/integration` — 1127 pass (baseline 1125 + net 2 from the test swap)
- [ ] Manual smoke (reviewer, requires Daytona): trigger the `recursive_workspace` tool from the chat CLI with a query that drives `_store_pass_evidence`; verify rows land in the Neon `memory_items` table, proving the `DaytonaEvidenceSink` correctly delegates to `store_evidence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)