### PR TITLE
fix(security+imports): patch GitPython CVEs and promote late import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ override-dependencies = [
     # patched floors until upstream relaxes its metadata.
     "aiohttp>=3.13.4",
     "python-dotenv>=1.2.2",
+    # GitPython <3.1.47 has two command-injection CVEs (Dependabot alerts).
+    # mlflow-skinny is the only dependent; 3.1.47 is a drop-in upgrade.
+    "gitpython>=3.1.47",
 ]
 
 [tool.setuptools]

--- a/src/fleet_rlm/runtime/execution/llm_query.py
+++ b/src/fleet_rlm/runtime/execution/llm_query.py
@@ -23,6 +23,8 @@ from unittest.mock import Mock
 
 import dspy
 
+from fleet_rlm.runtime.models.builders import build_recursive_subquery_rlm
+
 logger = logging.getLogger(__name__)
 
 _BROKER_ERROR_MARKER = "Broker server failed to start"
@@ -334,9 +336,6 @@ class LLMQueryMixin:
         llm_budget_lease: int | None = None,
     ) -> str:
         """Spawn a child dspy.RLM interpreter and return its answer."""
-        # Late imports to avoid circular dependencies
-        from fleet_rlm.runtime.models.builders import build_recursive_subquery_rlm
-
         remaining = self._remaining_llm_budget()
         if remaining <= 0:
             raise RuntimeError(

--- a/tests/unit/runtime/agent/test_sub_rlm.py
+++ b/tests/unit/runtime/agent/test_sub_rlm.py
@@ -112,7 +112,7 @@ def test_sub_rlm_batched_siblings_receive_bounded_budget_leases() -> None:
 
     with (
         patch(
-            "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm",
+            "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm",
             side_effect=_fake_build,
         ),
         pytest.raises(RuntimeError, match="sub_rlm_batched failed"),
@@ -132,7 +132,7 @@ def test_sub_rlm_calls_child_module_and_returns_answer() -> None:
     fake_pred = _make_fake_prediction("child answer")
 
     with patch(
-        "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm"
+        "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm"
     ) as mock_build:
         mock_module = MagicMock(return_value=fake_pred)
         mock_build.return_value = mock_module
@@ -148,7 +148,7 @@ def test_sub_rlm_passes_context() -> None:
     fake_pred = _make_fake_prediction("ok")
 
     with patch(
-        "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm"
+        "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm"
     ) as mock_build:
         mock_module = MagicMock(return_value=fake_pred)
         mock_build.return_value = mock_module
@@ -163,7 +163,7 @@ def test_sub_rlm_null_answer_raises_runtime_error() -> None:
 
     with (
         patch(
-            "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm",
+            "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm",
             return_value=MagicMock(return_value=_make_fake_prediction(None)),
         ),
         pytest.raises(RuntimeError, match="without SUBMIT"),
@@ -180,7 +180,7 @@ def test_sub_rlm_detects_broker_error_in_child_prediction() -> None:
 
     with (
         patch(
-            "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm",
+            "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm",
             return_value=MagicMock(return_value=prediction),
         ),
         pytest.raises(RuntimeError, match="broker unavailable"),
@@ -200,7 +200,7 @@ def test_sub_rlm_batched_returns_ordered_results() -> None:
         return MagicMock(return_value=pred)
 
     with patch(
-        "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm",
+        "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm",
         side_effect=_fake_build,
     ):
         results = interp.sub_rlm_batched(["a", "b", "c"])
@@ -237,7 +237,7 @@ def test_child_depth_incremented() -> None:
     interp.build_delegate_child = _capture_child
 
     with patch(
-        "fleet_rlm.runtime.models.builders.build_recursive_subquery_rlm"
+        "fleet_rlm.runtime.execution.llm_query.build_recursive_subquery_rlm"
     ) as mock_build:
         mock_build.return_value = MagicMock(return_value=_make_fake_prediction("ok"))
         interp.sub_rlm("test")

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "gitpython", specifier = ">=3.1.47" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -1595,14 +1596,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Security**: Adds `gitpython>=3.1.47` to `tool.uv.override-dependencies`, resolving the two open Dependabot command-injection alerts. `mlflow-skinny` was pulling in 3.1.46; the override bumps it to 3.1.49 (latest).
- **Late import removal**: Promotes the defensive late `build_recursive_subquery_rlm` import in `llm_query.py` to top-level. The circular dependency it was guarding no longer exists — verified by importing both modules simultaneously. Removes the stale `# Late imports to avoid circular dependencies` comment.
- **Test fix**: Updates 7 `patch()` targets in `test_sub_rlm.py` from the source module path to the consumer module path (`fleet_rlm.runtime.execution.llm_query.*`), following Python's "patch where it's used" rule.

## Test plan

- [x] `uv lock` resolves to `gitpython 3.1.49` (up from 3.1.46)
- [x] `uv run pytest tests/unit/runtime/agent/test_sub_rlm.py` — 18/18 pass
- [x] `uv run pytest tests/ --ignore=tests/integration` — 1125 pass (matches main baseline, zero regressions)
- [x] `uv run ruff check` — clean on all touched files
- [ ] Verify Dependabot alerts close after merge (GitHub resolves them automatically when the vulnerable version leaves the dependency graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)