### PR TITLE
fix(settings): backend-driven runtime settings with rich key metadata

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2565,31 +2565,104 @@ components:
       - checked_at
       title: RuntimeConnectivityTestResponse
       description: Result payload for runtime connectivity and preflight diagnostics.
+    RuntimeSettingsCategory:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Stable category identifier.
+        label:
+          type: string
+          title: Label
+          description: Human-readable category label.
+        description:
+          type: string
+          title: Description
+          description: Human-readable category description.
+        fields:
+          items:
+            $ref: '#/components/schemas/RuntimeSettingsField'
+          type: array
+          title: Fields
+          description: Fields in this category.
+      type: object
+      required:
+      - id
+      - label
+      - description
+      title: RuntimeSettingsCategory
+      description: Categorized group of runtime settings fields.
+    RuntimeSettingsField:
+      properties:
+        key:
+          type: string
+          title: Key
+          description: Environment variable key backing this setting.
+        label:
+          type: string
+          title: Label
+          description: Human-readable setting label.
+        description:
+          type: string
+          title: Description
+          description: Human-readable setting description.
+        value:
+          type: string
+          title: Value
+          description: Display-safe setting value.
+          default: ''
+        masked_value:
+          type: string
+          title: Masked Value
+          description: Masked display value for secret settings.
+          default: ''
+        secret:
+          type: boolean
+          title: Secret
+          description: Whether the field stores sensitive data.
+          default: false
+        editable:
+          type: boolean
+          title: Editable
+          description: Whether the field can be patched through the Settings API.
+          default: true
+        reload_required:
+          type: boolean
+          title: Reload Required
+          description: Whether applying this setting reloads runtime dependencies.
+          default: false
+        placeholder:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Placeholder
+          description: Optional UI placeholder.
+        default:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Default
+          description: Optional default value displayed by settings clients.
+      type: object
+      required:
+      - key
+      - label
+      - description
+      title: RuntimeSettingsField
+      description: Single display-safe runtime setting field.
     RuntimeSettingsSnapshot:
       properties:
         env_path:
           type: string
           title: Env Path
           description: Filesystem path to the environment file being edited.
-        keys:
+        categories:
           items:
-            type: string
+            $ref: '#/components/schemas/RuntimeSettingsCategory'
           type: array
-          title: Keys
-          description: Ordered list of runtime setting keys surfaced by the Settings
+          title: Categories
+          description: Categorized runtime setting fields surfaced by the Settings
             API.
-        values:
-          additionalProperties:
-            type: string
-          type: object
-          title: Values
-          description: Unmasked runtime setting values that are safe to return directly.
-        masked_values:
-          additionalProperties:
-            type: string
-          type: object
-          title: Masked Values
-          description: Masked secret values returned for display-only settings fields.
       type: object
       required:
       - env_path

--- a/src/fleet_rlm/api/config.py
+++ b/src/fleet_rlm/api/config.py
@@ -36,7 +36,7 @@ def _resolve_server_env_path() -> Path:
 
 def resolve_server_volume_name(config: AppConfig) -> str | None:
     """Resolve the server-side volume name from shared app config."""
-    volume_name = config.interpreter.volume_name
+    volume_name = config.volumes.name
     return volume_name if volume_name is not None else DEFAULT_SERVER_VOLUME_NAME
 
 
@@ -157,27 +157,32 @@ class ServerRuntimeConfig(BaseSettings):
     def from_app_config(cls, config: AppConfig) -> ServerRuntimeConfig:
         """Build server runtime settings from the shared application config."""
         kwargs: dict = {
-            "secret_name": config.interpreter.secrets[0] if config.interpreter.secrets else "LITELLM",
+            "secret_name": config.sandbox.secret_name,
             "volume_name": resolve_server_volume_name(config),
-            "timeout": config.interpreter.timeout,
+            "timeout": config.sandbox.timeout,
             "react_max_iters": config.rlm_settings.max_iters,
             "deep_react_max_iters": config.rlm_settings.deep_max_iters,
             "enable_adaptive_iters": config.rlm_settings.enable_adaptive_iters,
-            "rlm_max_iterations": config.agent.rlm_max_iterations,
+            "rlm_max_iterations": config.llm.rlm_max_iterations,
             "rlm_max_llm_calls": config.rlm_settings.max_llm_calls,
             "rlm_max_depth": config.rlm_settings.max_depth,
             "rlm_child_isolation_mode": config.rlm_settings.child_isolation_mode,
             "rlm_child_fork_fallback": config.rlm_settings.child_fork_fallback,
             "delegate_max_calls_per_turn": config.rlm_settings.delegate_max_calls_per_turn,
             "delegate_result_truncation_chars": config.rlm_settings.delegate_result_truncation_chars,
-            "interpreter_async_execute": config.interpreter.async_execute,
-            "agent_guardrail_mode": config.agent.guardrail_mode,
-            "agent_min_substantive_chars": config.agent.min_substantive_chars,
+            "interpreter_async_execute": config.sandbox.async_execute,
+            "agent_guardrail_mode": config.llm.guardrail_mode,
+            "agent_min_substantive_chars": config.llm.min_substantive_chars,
             "agent_max_output_chars": config.rlm_settings.max_output_chars,
-            "agent_model": config.agent.model,
-            "agent_delegate_model": config.agent.delegate_model,
-            "agent_delegate_max_tokens": config.agent.delegate_max_tokens,
-            "db_validate_on_startup": True,
+            "agent_model": config.llm.model,
+            "agent_delegate_model": config.llm.delegate_model,
+            "agent_delegate_small_model": config.llm.delegate_small_model,
+            "agent_delegate_max_tokens": config.llm.delegate_max_tokens,
+            "database_url": config.database.url,
+            "database_admin_url": config.database.admin_url,
+            "database_required": config.database.required,
+            "db_echo": config.database.echo,
+            "db_validate_on_startup": config.database.validate_on_startup,
         }
         return cls(**kwargs)
 

--- a/src/fleet_rlm/api/runtime_services/settings.py
+++ b/src/fleet_rlm/api/runtime_services/settings.py
@@ -39,19 +39,21 @@ from ..schemas.runtime import (
     RuntimeSettingsUpdateResponse,
 )
 
-RUNTIME_MODEL_RELOAD_KEYS = frozenset({
-    "DSPY_LM_MODEL",
-    "DSPY_DELEGATE_LM_MODEL",
-    "DSPY_DELEGATE_LM_SMALL_MODEL",
-    "DSPY_DELEGATE_LM_MAX_TOKENS",
-    "DSPY_LM_API_BASE",
-    "DSPY_LM_MAX_TOKENS",
-    "DSPY_ADAPTER",
-    "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
-    "DSPY_LLM_API_KEY",
-    "DSPY_LM_API_KEY",
-    "DSPY_DELEGATE_LM_API_KEY",
-})
+RUNTIME_MODEL_RELOAD_KEYS = frozenset(
+    {
+        "DSPY_LM_MODEL",
+        "DSPY_DELEGATE_LM_MODEL",
+        "DSPY_DELEGATE_LM_SMALL_MODEL",
+        "DSPY_DELEGATE_LM_MAX_TOKENS",
+        "DSPY_LM_API_BASE",
+        "DSPY_LM_MAX_TOKENS",
+        "DSPY_ADAPTER",
+        "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
+        "DSPY_LLM_API_KEY",
+        "DSPY_LM_API_KEY",
+        "DSPY_DELEGATE_LM_API_KEY",
+    }
+)
 
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 

--- a/src/fleet_rlm/api/runtime_services/settings.py
+++ b/src/fleet_rlm/api/runtime_services/settings.py
@@ -39,17 +39,29 @@ from ..schemas.runtime import (
     RuntimeSettingsUpdateResponse,
 )
 
-RUNTIME_MODEL_RELOAD_KEYS = frozenset(
-    {
-        "DSPY_LM_MODEL",
-        "DSPY_DELEGATE_LM_MODEL",
-        "DSPY_DELEGATE_LM_SMALL_MODEL",
-        "DSPY_DELEGATE_LM_MAX_TOKENS",
-        "DSPY_LM_API_BASE",
-        "DSPY_LM_MAX_TOKENS",
-        "DSPY_LLM_API_KEY",
-    }
-)
+RUNTIME_MODEL_RELOAD_KEYS = frozenset({
+    "DSPY_LM_MODEL",
+    "DSPY_DELEGATE_LM_MODEL",
+    "DSPY_DELEGATE_LM_SMALL_MODEL",
+    "DSPY_DELEGATE_LM_MAX_TOKENS",
+    "DSPY_LM_API_BASE",
+    "DSPY_LM_MAX_TOKENS",
+    "DSPY_ADAPTER",
+    "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
+    "DSPY_LLM_API_KEY",
+    "DSPY_LM_API_KEY",
+    "DSPY_DELEGATE_LM_API_KEY",
+})
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _settings_bool(value: str) -> bool:
+    return value.strip().lower() in _TRUE_VALUES
+
+
+def _settings_positive_int(value: str, *, default: int) -> int:
+    return max(int(value.strip() or str(default)), 1)
 
 
 class RuntimeConfigSnapshot(TypedDict):
@@ -75,10 +87,37 @@ def apply_runtime_settings_to_config(*, config: ServerRuntimeConfig, normalized:
         config.agent_delegate_small_model = resolved_delegate_small_model or None
 
     if "DSPY_DELEGATE_LM_MAX_TOKENS" in normalized:
-        config.agent_delegate_max_tokens = max(
-            int(normalized["DSPY_DELEGATE_LM_MAX_TOKENS"].strip() or "64000"),
-            1,
+        config.agent_delegate_max_tokens = _settings_positive_int(
+            normalized["DSPY_DELEGATE_LM_MAX_TOKENS"],
+            default=64000,
         )
+
+    if "VOLUME_NAME" in normalized:
+        resolved_volume_name = normalized["VOLUME_NAME"].strip()
+        config.volume_name = resolved_volume_name or None
+
+    if "TIMEOUT" in normalized:
+        config.timeout = _settings_positive_int(normalized["TIMEOUT"], default=900)
+
+    if "INTERPRETER_ASYNC_EXECUTE" in normalized:
+        config.interpreter_async_execute = _settings_bool(normalized["INTERPRETER_ASYNC_EXECUTE"])
+
+    if "DATABASE_URL" in normalized:
+        resolved_database_url = normalized["DATABASE_URL"].strip()
+        config.database_url = resolved_database_url or None
+
+    if "DATABASE_ADMIN_URL" in normalized:
+        resolved_database_admin_url = normalized["DATABASE_ADMIN_URL"].strip()
+        config.database_admin_url = resolved_database_admin_url or None
+
+    if "DATABASE_REQUIRED" in normalized:
+        config.database_required = _settings_bool(normalized["DATABASE_REQUIRED"])
+
+    if "DB_ECHO" in normalized:
+        config.db_echo = _settings_bool(normalized["DB_ECHO"])
+
+    if "DB_VALIDATE_ON_STARTUP" in normalized:
+        config.db_validate_on_startup = _settings_bool(normalized["DB_VALIDATE_ON_STARTUP"])
 
 
 def _capture_runtime_config_snapshot(*, config: ServerRuntimeConfig, lm_deps: LmDeps) -> RuntimeConfigSnapshot:
@@ -156,6 +195,12 @@ async def apply_runtime_settings_patch(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    validation_config = config.model_copy(deep=True)
+    try:
+        apply_runtime_settings_to_config(config=validation_config, normalized=normalized)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid runtime setting value: {exc}") from exc
 
     runtime_snapshot = _capture_runtime_config_snapshot(config=config, lm_deps=lm_deps)
     env_text = config.env_path.read_text(encoding="utf-8") if config.env_path.exists() else None

--- a/src/fleet_rlm/api/schemas/runtime.py
+++ b/src/fleet_rlm/api/schemas/runtime.py
@@ -11,21 +11,39 @@ from .volumes import VolumeProvider
 ExecutionMode = Literal["auto", "rlm_only", "tools_only"]
 
 
+class RuntimeSettingsField(BaseModel):
+    """Single display-safe runtime setting field."""
+
+    key: str = Field(description="Environment variable key backing this setting.")
+    label: str = Field(description="Human-readable setting label.")
+    description: str = Field(description="Human-readable setting description.")
+    value: str = Field(default="", description="Display-safe setting value.")
+    masked_value: str = Field(default="", description="Masked display value for secret settings.")
+    secret: bool = Field(default=False, description="Whether the field stores sensitive data.")
+    editable: bool = Field(default=True, description="Whether the field can be patched through the Settings API.")
+    reload_required: bool = Field(
+        default=False, description="Whether applying this setting reloads runtime dependencies."
+    )
+    placeholder: str | None = Field(default=None, description="Optional UI placeholder.")
+    default: str | None = Field(default=None, description="Optional default value displayed by settings clients.")
+
+
+class RuntimeSettingsCategory(BaseModel):
+    """Categorized group of runtime settings fields."""
+
+    id: str = Field(description="Stable category identifier.")
+    label: str = Field(description="Human-readable category label.")
+    description: str = Field(description="Human-readable category description.")
+    fields: list[RuntimeSettingsField] = Field(default_factory=list, description="Fields in this category.")
+
+
 class RuntimeSettingsSnapshot(BaseModel):
     """Current runtime settings snapshot returned by the Settings API."""
 
     env_path: str = Field(description="Filesystem path to the environment file being edited.")
-    keys: list[str] = Field(
+    categories: list[RuntimeSettingsCategory] = Field(
         default_factory=list,
-        description="Ordered list of runtime setting keys surfaced by the Settings API.",
-    )
-    values: dict[str, str] = Field(
-        default_factory=dict,
-        description="Unmasked runtime setting values that are safe to return directly.",
-    )
-    masked_values: dict[str, str] = Field(
-        default_factory=dict,
-        description="Masked secret values returned for display-only settings fields.",
+        description="Categorized runtime setting fields surfaced by the Settings API.",
     )
 
 

--- a/src/fleet_rlm/integrations/config/config.yaml
+++ b/src/fleet_rlm/integrations/config/config.yaml
@@ -1,33 +1,52 @@
 defaults:
   - _self_
 
-agent:
+llm:
   max_iters: 60
-  # Default to DSPY_LM_MODEL environment variable if set, otherwise fallback to a known model
-  # from config/config.yaml (e.g., gemini-3-flash-preview or deepseek-v3.2-maas).
-  # We use OC env interpolation to respect user's existing .env setup.
   model: ${oc.env:DSPY_LM_MODEL,openai/gemini-3-flash-preview}
   temperature: 1
   delegate_model: ${oc.env:DSPY_DELEGATE_LM_MODEL,null}
-  delegate_max_tokens: 64000
+  delegate_small_model: ${oc.env:DSPY_DELEGATE_LM_SMALL_MODEL,null}
+  max_tokens: ${oc.env:DSPY_LM_MAX_TOKENS,64000}
+  delegate_max_tokens: ${oc.env:DSPY_DELEGATE_LM_MAX_TOKENS,64000}
+  api_base: ${oc.env:DSPY_LM_API_BASE,null}
+  adapter: ${oc.env:DSPY_ADAPTER,null}
+  adapter_use_native_function_calling: ${oc.env:DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING,false}
   rlm_max_iterations: 30
   guardrail_mode: "off"
   min_substantive_chars: 20
 
-interpreter:
+api_keys:
+  llm_api_key: ${oc.env:DSPY_LLM_API_KEY,null}
+  legacy_lm_api_key: ${oc.env:DSPY_LM_API_KEY,null}
+  delegate_lm_api_key: ${oc.env:DSPY_DELEGATE_LM_API_KEY,null}
+  daytona_api_key: ${oc.env:DAYTONA_API_KEY,null}
+  posthog_api_key: ${oc.env:POSTHOG_API_KEY,null}
+
+sandbox:
+  provider: "daytona"
   image: "python:3.13-slim-bookworm"
-  timeout: 900
-  secrets: ["LITELLM"]
-  volume_name: ${oc.env:VOLUME_NAME,null}
-  async_execute: true
+  timeout: ${oc.env:TIMEOUT,900}
+  secret_name: "LITELLM"
+  daytona_api_url: ${oc.env:DAYTONA_API_URL,null}
+  daytona_target: ${oc.env:DAYTONA_TARGET,null}
+  async_execute: ${oc.env:INTERPRETER_ASYNC_EXECUTE,true}
+
+volumes:
+  name: ${oc.env:VOLUME_NAME,null}
+
+database:
+  url: ${oc.env:DATABASE_URL,null}
+  admin_url: ${oc.env:DATABASE_ADMIN_URL,null}
+  required: ${oc.env:DATABASE_REQUIRED,false}
+  echo: ${oc.env:DB_ECHO,false}
+  validate_on_startup: ${oc.env:DB_VALIDATE_ON_STARTUP,false}
 
 memory:
-  # Limits for core memory blocks (in characters)
   core_memory_limits:
     persona: 2000
     human: 2000
     scratchpad: 1000
-  # Path in the volume for archival memory
   archival_path: "/data/memory"
 
 rlm_settings:

--- a/src/fleet_rlm/integrations/config/env.py
+++ b/src/fleet_rlm/integrations/config/env.py
@@ -5,9 +5,11 @@ and memory systems. It is designed to be used with Hydra for hierarchical
 configuration management (YAML -> Dict -> Pydantic).
 """
 
+from __future__ import annotations
+
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from fleet_rlm.integrations.observability.config import MlflowConfig, PostHogConfig
 
@@ -54,6 +56,155 @@ class InterpreterConfig(BaseModel):
     )
 
 
+class LlmConfig(BaseModel):
+    """Configuration for language-model provider and model selection."""
+
+    model: str = Field(
+        default="openai/gemini-3-flash-preview",
+        description="Planner LLM model identifier.",
+    )
+    delegate_model: str | None = Field(
+        default=None,
+        description="Optional model identifier used for delegate/sub-agent turns.",
+    )
+    delegate_small_model: str | None = Field(
+        default=None,
+        description="Optional small delegate model identifier.",
+    )
+    max_tokens: int = Field(
+        default=64000,
+        description="Maximum token budget for planner model calls.",
+    )
+    delegate_max_tokens: int = Field(
+        default=64000,
+        description="Maximum token budget for delegate model calls.",
+    )
+    api_base: str | None = Field(
+        default=None,
+        description="Optional LiteLLM-compatible provider API base URL.",
+    )
+    adapter: str | None = Field(
+        default=None,
+        description="Optional default DSPy adapter.",
+    )
+    adapter_use_native_function_calling: bool = Field(
+        default=False,
+        description="Enable native function calling on the default DSPy adapter.",
+    )
+    max_iters: int = Field(
+        default=60,
+        description="Maximum number of ReAct loop iterations per turn.",
+    )
+    temperature: float = Field(
+        default=1.0,
+        description="LLM sampling temperature.",
+    )
+    rlm_max_iterations: int = Field(
+        default=30,
+        description="Maximum total RLM iterations across delegation.",
+    )
+    guardrail_mode: Literal["off", "warn", "strict"] = Field(
+        default="off",
+        description="Guardrail behavior for assistant responses.",
+    )
+    min_substantive_chars: int = Field(
+        default=20,
+        description="Minimum response length considered substantive for warning-level guardrails.",
+    )
+
+
+class ApiKeysConfig(BaseModel):
+    """Configuration for runtime credentials."""
+
+    llm_api_key: str | None = Field(
+        default=None,
+        description="Primary provider API key for planner and fallback delegate LM calls.",
+    )
+    legacy_lm_api_key: str | None = Field(
+        default=None,
+        description="Backward-compatible LM provider API key.",
+    )
+    delegate_lm_api_key: str | None = Field(
+        default=None,
+        description="Optional provider key dedicated to delegate model calls.",
+    )
+    daytona_api_key: str | None = Field(
+        default=None,
+        description="API key used for Daytona provisioning.",
+    )
+    posthog_api_key: str | None = Field(
+        default=None,
+        description="Optional PostHog API key.",
+    )
+
+
+class SandboxConfig(BaseModel):
+    """Configuration for the Daytona sandbox runtime."""
+
+    provider: Literal["daytona"] = Field(
+        default="daytona",
+        description="Sandbox provider used by the public runtime.",
+    )
+    image: str = Field(
+        default="python:3.13-slim-bookworm",
+        description="Base Docker image for the sandbox.",
+    )
+    timeout: int = Field(
+        default=900,
+        description="Maximum execution time for the sandbox in seconds.",
+    )
+    secret_name: str = Field(
+        default="LITELLM",
+        description="Secret name injected into the sandbox.",
+    )
+    daytona_api_url: str | None = Field(
+        default=None,
+        description="Base URL for the Daytona API.",
+    )
+    daytona_target: str | None = Field(
+        default=None,
+        description="Daytona target used for provisioning.",
+    )
+    async_execute: bool = Field(
+        default=True,
+        description="Whether interpreter calls should use the async wrapper.",
+    )
+
+
+class VolumesConfig(BaseModel):
+    """Configuration for durable runtime volumes."""
+
+    name: str | None = Field(
+        default=None,
+        description="Name of the persistent volume to mount.",
+    )
+
+
+class DatabaseConfig(BaseModel):
+    """Configuration for Postgres persistence."""
+
+    url: str | None = Field(
+        default=None,
+        description="Pooled runtime database URL.",
+    )
+    admin_url: str | None = Field(
+        default=None,
+        description="Direct database URL for schema and admin tasks.",
+    )
+    required: bool = Field(
+        default=False,
+        description="Require database connectivity during server startup.",
+    )
+    echo: bool = Field(
+        default=False,
+        description="Enable SQLAlchemy echo logging.",
+    )
+    validate_on_startup: bool = Field(
+        default=False,
+        description="Validate database connectivity during server startup.",
+    )
+
+
 class AgentConfig(BaseModel):
     """Configuration for the agent."""
 
@@ -62,7 +213,7 @@ class AgentConfig(BaseModel):
         description="Maximum number of ReAct loop iterations per turn.",
     )
     model: str = Field(
-        default="openai/gemini/gemini-3.1-pro-preview",
+        default="openai/gemini-3-flash-preview",
         description="LLM model identifier to use. Must include LiteLLM provider prefix e.g. 'openai/model-name'.",
     )
     temperature: float = Field(
@@ -171,8 +322,79 @@ class AnalyticsConfig(BaseModel):
 class AppConfig(BaseModel):
     """Root configuration for the fleet-rlm application."""
 
+    llm: LlmConfig = Field(default_factory=LlmConfig)
+    api_keys: ApiKeysConfig = Field(default_factory=ApiKeysConfig)
+    sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
+    volumes: VolumesConfig = Field(default_factory=VolumesConfig)
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     agent: AgentConfig = Field(default_factory=AgentConfig)
     interpreter: InterpreterConfig = Field(default_factory=InterpreterConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
     rlm_settings: RlmSettings = Field(default_factory=RlmSettings)
     analytics: AnalyticsConfig = Field(default_factory=AnalyticsConfig)
+
+    @model_validator(mode="after")
+    def _sync_legacy_sections(self) -> AppConfig:
+        fields_set = set(self.model_fields_set)
+        if "llm" in fields_set or "agent" not in fields_set:
+            self.agent = AgentConfig(
+                max_iters=self.llm.max_iters,
+                model=self.llm.model,
+                temperature=self.llm.temperature,
+                delegate_model=self.llm.delegate_model,
+                delegate_max_tokens=self.llm.delegate_max_tokens,
+                rlm_max_iterations=self.llm.rlm_max_iterations,
+                guardrail_mode=self.llm.guardrail_mode,
+                min_substantive_chars=self.llm.min_substantive_chars,
+            )
+        else:
+            self.llm = LlmConfig(
+                model=self.agent.model,
+                delegate_model=self.agent.delegate_model,
+                delegate_max_tokens=self.agent.delegate_max_tokens,
+                max_iters=self.agent.max_iters,
+                temperature=self.agent.temperature,
+                rlm_max_iterations=self.agent.rlm_max_iterations,
+                guardrail_mode=self.agent.guardrail_mode,
+                min_substantive_chars=self.agent.min_substantive_chars,
+            )
+
+        if "interpreter" not in fields_set:
+            self.interpreter = InterpreterConfig(
+                image=self.sandbox.image,
+                volume_name=self.volumes.name,
+                timeout=self.sandbox.timeout,
+                secrets=[self.sandbox.secret_name] if self.sandbox.secret_name else [],
+                async_execute=self.sandbox.async_execute,
+            )
+        elif "sandbox" in fields_set or "volumes" in fields_set:
+            self.interpreter = InterpreterConfig(
+                image=self.sandbox.image if "sandbox" in fields_set else self.interpreter.image,
+                volume_name=self.volumes.name if "volumes" in fields_set else self.interpreter.volume_name,
+                timeout=self.sandbox.timeout if "sandbox" in fields_set else self.interpreter.timeout,
+                secrets=(
+                    [self.sandbox.secret_name]
+                    if "sandbox" in fields_set and self.sandbox.secret_name
+                    else self.interpreter.secrets
+                ),
+                async_execute=self.sandbox.async_execute if "sandbox" in fields_set else self.interpreter.async_execute,
+            )
+            if "sandbox" not in fields_set:
+                self.sandbox = SandboxConfig(
+                    image=self.interpreter.image,
+                    timeout=self.interpreter.timeout,
+                    secret_name=self.interpreter.secrets[0] if self.interpreter.secrets else "LITELLM",
+                    async_execute=self.interpreter.async_execute,
+                )
+            if "volumes" not in fields_set:
+                self.volumes = VolumesConfig(name=self.interpreter.volume_name)
+        else:
+            self.sandbox = SandboxConfig(
+                image=self.interpreter.image,
+                timeout=self.interpreter.timeout,
+                secret_name=self.interpreter.secrets[0] if self.interpreter.secrets else "LITELLM",
+                async_execute=self.interpreter.async_execute,
+            )
+            self.volumes = VolumesConfig(name=self.interpreter.volume_name)
+
+        return self

--- a/src/fleet_rlm/integrations/config/runtime_settings.py
+++ b/src/fleet_rlm/integrations/config/runtime_settings.py
@@ -16,22 +16,261 @@ class RuntimeSettingDefinition:
     """Single-source metadata for runtime settings surfaces."""
 
     key: str
+    category: str
+    category_label: str
+    category_description: str
+    label: str
+    description: str
     secret: bool = False
     include_in_default_snapshot: bool = True
     editable: bool = True
+    reload_required: bool = False
+    placeholder: str | None = None
+    default: str | None = None
+
+
+_CATEGORY_METADATA: tuple[tuple[str, str, str], ...] = (
+    (
+        "llm",
+        "LLM provider and models",
+        "Planner, delegate, adapter, and provider routing settings used by DSPy.",
+    ),
+    (
+        "api_keys",
+        "API keys and credentials",
+        "Write-only credentials used by language-model providers, Daytona, and optional services.",
+    ),
+    (
+        "sandbox_volumes",
+        "Sandbox and volumes",
+        "Daytona runtime, sandbox execution, and durable volume parameters.",
+    ),
+    (
+        "database",
+        "Database",
+        "Postgres persistence URLs and database startup behavior.",
+    ),
+)
+
+
+_CATEGORY_INDEX = {category: (label, description) for category, label, description in _CATEGORY_METADATA}
+
+
+def _definition(
+    key: str,
+    *,
+    category: str,
+    label: str,
+    description: str,
+    secret: bool = False,
+    include_in_default_snapshot: bool = True,
+    editable: bool = True,
+    reload_required: bool = False,
+    placeholder: str | None = None,
+    default: str | None = None,
+) -> RuntimeSettingDefinition:
+    category_label, category_description = _CATEGORY_INDEX[category]
+    return RuntimeSettingDefinition(
+        key=key,
+        category=category,
+        category_label=category_label,
+        category_description=category_description,
+        label=label,
+        description=description,
+        secret=secret,
+        include_in_default_snapshot=include_in_default_snapshot,
+        editable=editable,
+        reload_required=reload_required,
+        placeholder=placeholder,
+        default=default,
+    )
 
 
 _RUNTIME_SETTING_DEFINITIONS: tuple[RuntimeSettingDefinition, ...] = (
-    RuntimeSettingDefinition("DSPY_LM_MODEL"),
-    RuntimeSettingDefinition("DSPY_DELEGATE_LM_MODEL"),
-    RuntimeSettingDefinition("DSPY_DELEGATE_LM_SMALL_MODEL"),
-    RuntimeSettingDefinition("DSPY_DELEGATE_LM_MAX_TOKENS"),
-    RuntimeSettingDefinition("DSPY_LLM_API_KEY", secret=True),
-    RuntimeSettingDefinition("DSPY_LM_API_BASE"),
-    RuntimeSettingDefinition("DSPY_LM_MAX_TOKENS"),
-    RuntimeSettingDefinition("DAYTONA_API_KEY", secret=True),
-    RuntimeSettingDefinition("DAYTONA_API_URL"),
-    RuntimeSettingDefinition("DAYTONA_TARGET"),
+    _definition(
+        "DSPY_LM_MODEL",
+        category="llm",
+        label="Planner LM model",
+        description="LiteLLM model identifier for the planner runtime.",
+        reload_required=True,
+        placeholder="openai/gpt-4o",
+        default="openai/gemini-3-flash-preview",
+    ),
+    _definition(
+        "DSPY_DELEGATE_LM_MODEL",
+        category="llm",
+        label="Delegate LM model",
+        description="Optional model identifier for recursive delegate turns.",
+        reload_required=True,
+        placeholder="openai/gpt-4o-mini",
+    ),
+    _definition(
+        "DSPY_DELEGATE_LM_SMALL_MODEL",
+        category="llm",
+        label="Delegate small LM model",
+        description="Optional small model used by lightweight delegate tasks.",
+        reload_required=True,
+        placeholder="openai/gpt-4o-mini",
+    ),
+    _definition(
+        "DSPY_DELEGATE_LM_MAX_TOKENS",
+        category="llm",
+        label="Delegate max tokens",
+        description="Maximum token budget for delegate model calls.",
+        reload_required=True,
+        placeholder="64000",
+        default="64000",
+    ),
+    _definition(
+        "DSPY_LM_API_BASE",
+        category="llm",
+        label="Provider API base",
+        description="Optional custom API base URL for LiteLLM-compatible providers.",
+        reload_required=True,
+        placeholder="https://api.openai.com/v1",
+    ),
+    _definition(
+        "DSPY_LM_MAX_TOKENS",
+        category="llm",
+        label="Planner max tokens",
+        description="Maximum token budget for planner responses.",
+        reload_required=True,
+        placeholder="64000",
+        default="64000",
+    ),
+    _definition(
+        "DSPY_ADAPTER",
+        category="llm",
+        label="DSPy adapter",
+        description="Optional default DSPy adapter for non-runtime-module calls.",
+        reload_required=True,
+        placeholder="chat",
+    ),
+    _definition(
+        "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
+        category="llm",
+        label="Native function calling",
+        description="Enable native function calling for the default DSPy adapter.",
+        reload_required=True,
+        placeholder="false",
+        default="false",
+    ),
+    _definition(
+        "DSPY_LLM_API_KEY",
+        category="api_keys",
+        label="Primary LM API key",
+        description="Primary provider key for planner and fallback delegate LM calls.",
+        secret=True,
+        reload_required=True,
+    ),
+    _definition(
+        "DSPY_LM_API_KEY",
+        category="api_keys",
+        label="Legacy LM API key",
+        description="Backward-compatible LM provider key used when the primary key is unset.",
+        secret=True,
+        reload_required=True,
+    ),
+    _definition(
+        "DSPY_DELEGATE_LM_API_KEY",
+        category="api_keys",
+        label="Delegate LM API key",
+        description="Optional provider key dedicated to delegate model calls.",
+        secret=True,
+        reload_required=True,
+    ),
+    _definition(
+        "DAYTONA_API_KEY",
+        category="api_keys",
+        label="Daytona API key",
+        description="API key used for Daytona workspace and volume provisioning.",
+        secret=True,
+    ),
+    _definition(
+        "POSTHOG_API_KEY",
+        category="api_keys",
+        label="PostHog API key",
+        description="Optional PostHog project key for analytics.",
+        secret=True,
+    ),
+    _definition(
+        "DAYTONA_API_URL",
+        category="sandbox_volumes",
+        label="Daytona API URL",
+        description="Base URL for the Daytona API.",
+        placeholder="http://127.0.0.1:3000",
+    ),
+    _definition(
+        "DAYTONA_TARGET",
+        category="sandbox_volumes",
+        label="Daytona target",
+        description="Execution target or backend selected for Daytona provisioning.",
+        placeholder="local",
+    ),
+    _definition(
+        "VOLUME_NAME",
+        category="sandbox_volumes",
+        label="Volume name",
+        description="Durable Daytona volume mounted into workbench sandboxes.",
+        placeholder="rlm-volume-dspy",
+        default="rlm-volume-dspy",
+    ),
+    _definition(
+        "TIMEOUT",
+        category="sandbox_volumes",
+        label="Sandbox timeout",
+        description="Maximum sandbox execution time in seconds.",
+        placeholder="900",
+        default="900",
+    ),
+    _definition(
+        "INTERPRETER_ASYNC_EXECUTE",
+        category="sandbox_volumes",
+        label="Async interpreter execution",
+        description="Run interpreter execute calls through the async wrapper.",
+        placeholder="true",
+        default="true",
+    ),
+    _definition(
+        "DATABASE_URL",
+        category="database",
+        label="Runtime database URL",
+        description="Pooled Postgres URL used by application runtime traffic.",
+        secret=True,
+        placeholder="postgresql://...",
+    ),
+    _definition(
+        "DATABASE_ADMIN_URL",
+        category="database",
+        label="Admin database URL",
+        description="Direct Postgres URL used for Alembic, schema, and admin tasks.",
+        secret=True,
+        placeholder="postgresql://...",
+    ),
+    _definition(
+        "DATABASE_REQUIRED",
+        category="database",
+        label="Require database",
+        description="Require database connectivity during server startup.",
+        placeholder="false",
+        default="false",
+    ),
+    _definition(
+        "DB_ECHO",
+        category="database",
+        label="SQL echo",
+        description="Enable SQLAlchemy SQL echo logging.",
+        placeholder="false",
+        default="false",
+    ),
+    _definition(
+        "DB_VALIDATE_ON_STARTUP",
+        category="database",
+        label="Validate database on startup",
+        description="Ping the configured database during server startup.",
+        placeholder="false",
+        default="false",
+    ),
 )
 
 _RUNTIME_SETTING_INDEX: dict[str, RuntimeSettingDefinition] = {
@@ -47,6 +286,7 @@ RUNTIME_SETTINGS_KEYS: tuple[str, ...] = tuple(
 )
 
 RUNTIME_SETTINGS_ALLOWLIST: frozenset[str] = frozenset(RUNTIME_SETTINGS_KEYS)
+RUNTIME_SETTING_DEFINITIONS: tuple[RuntimeSettingDefinition, ...] = _RUNTIME_SETTING_DEFINITIONS
 
 _LEGACY_SECRET_KEYS = frozenset({"DSPY_LM_API_KEY"})
 _NON_SECRET_KEYS = frozenset(definition.key for definition in _RUNTIME_SETTING_DEFINITIONS if not definition.secret)
@@ -191,6 +431,7 @@ def get_settings_snapshot(
     resolved_env_path = env_path or resolve_env_path()
     file_values = _read_env_file_values(resolved_env_path)
     raw_values: dict[str, str] = {}
+    requested = {key.upper() for key in keys}
 
     for key in keys:
         env_value = file_values.get(key)
@@ -202,12 +443,40 @@ def get_settings_snapshot(
         extra = extras.get(key)
         raw_values[key] = "" if extra is None else str(extra)
 
-    masked_values = {key: mask_secret(value) if should_mask_key(key) else value for key, value in raw_values.items()}
+    categories: list[dict[str, Any]] = []
+    for category, category_label, category_description in _CATEGORY_METADATA:
+        fields: list[dict[str, Any]] = []
+        for definition in _RUNTIME_SETTING_DEFINITIONS:
+            if definition.category != category or definition.key not in requested:
+                continue
+            value = raw_values.get(definition.key, "")
+            masked_value = mask_secret(value) if should_mask_key(definition.key) else value
+            fields.append(
+                {
+                    "key": definition.key,
+                    "label": definition.label,
+                    "description": definition.description,
+                    "value": masked_value,
+                    "masked_value": masked_value,
+                    "secret": definition.secret,
+                    "editable": definition.editable,
+                    "reload_required": definition.reload_required,
+                    "placeholder": definition.placeholder,
+                    "default": definition.default,
+                }
+            )
+        if fields:
+            categories.append(
+                {
+                    "id": category,
+                    "label": category_label,
+                    "description": category_description,
+                    "fields": fields,
+                }
+            )
     return {
         "env_path": str(resolved_env_path),
-        "keys": keys,
-        "values": masked_values,
-        "masked_values": masked_values,
+        "categories": categories,
     }
 
 

--- a/src/frontend/knip.json
+++ b/src/frontend/knip.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": [
-    "src/main.tsx",
-    "src/router.tsx"
-  ],
-  "project": [
-    "src/**/*.{ts,tsx}"
-  ],
+  "entry": ["src/main.tsx", "src/router.tsx"],
+  "project": ["src/**/*.{ts,tsx}"],
   "ignore": [
     "**/*.test.ts",
     "**/*.test.tsx",

--- a/src/frontend/openapi/fleet-rlm.openapi.yaml
+++ b/src/frontend/openapi/fleet-rlm.openapi.yaml
@@ -2565,31 +2565,104 @@ components:
         - checked_at
       title: RuntimeConnectivityTestResponse
       description: Result payload for runtime connectivity and preflight diagnostics.
+    RuntimeSettingsCategory:
+      properties:
+        id:
+          type: string
+          title: Id
+          description: Stable category identifier.
+        label:
+          type: string
+          title: Label
+          description: Human-readable category label.
+        description:
+          type: string
+          title: Description
+          description: Human-readable category description.
+        fields:
+          items:
+            $ref: "#/components/schemas/RuntimeSettingsField"
+          type: array
+          title: Fields
+          description: Fields in this category.
+      type: object
+      required:
+        - id
+        - label
+        - description
+      title: RuntimeSettingsCategory
+      description: Categorized group of runtime settings fields.
+    RuntimeSettingsField:
+      properties:
+        key:
+          type: string
+          title: Key
+          description: Environment variable key backing this setting.
+        label:
+          type: string
+          title: Label
+          description: Human-readable setting label.
+        description:
+          type: string
+          title: Description
+          description: Human-readable setting description.
+        value:
+          type: string
+          title: Value
+          description: Display-safe setting value.
+          default: ""
+        masked_value:
+          type: string
+          title: Masked Value
+          description: Masked display value for secret settings.
+          default: ""
+        secret:
+          type: boolean
+          title: Secret
+          description: Whether the field stores sensitive data.
+          default: false
+        editable:
+          type: boolean
+          title: Editable
+          description: Whether the field can be patched through the Settings API.
+          default: true
+        reload_required:
+          type: boolean
+          title: Reload Required
+          description: Whether applying this setting reloads runtime dependencies.
+          default: false
+        placeholder:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Placeholder
+          description: Optional UI placeholder.
+        default:
+          anyOf:
+            - type: string
+            - type: "null"
+          title: Default
+          description: Optional default value displayed by settings clients.
+      type: object
+      required:
+        - key
+        - label
+        - description
+      title: RuntimeSettingsField
+      description: Single display-safe runtime setting field.
     RuntimeSettingsSnapshot:
       properties:
         env_path:
           type: string
           title: Env Path
           description: Filesystem path to the environment file being edited.
-        keys:
+        categories:
           items:
-            type: string
+            $ref: "#/components/schemas/RuntimeSettingsCategory"
           type: array
-          title: Keys
-          description: Ordered list of runtime setting keys surfaced by the Settings
+          title: Categories
+          description: Categorized runtime setting fields surfaced by the Settings
             API.
-        values:
-          additionalProperties:
-            type: string
-          type: object
-          title: Values
-          description: Unmasked runtime setting values that are safe to return directly.
-        masked_values:
-          additionalProperties:
-            type: string
-          type: object
-          title: Masked Values
-          description: Masked secret values returned for display-only settings fields.
       type: object
       required:
         - env_path

--- a/src/frontend/src/features/settings/__tests__/grouped-settings-pane.test.tsx
+++ b/src/frontend/src/features/settings/__tests__/grouped-settings-pane.test.tsx
@@ -6,6 +6,39 @@ import type { ComponentProps } from "react";
 import { GroupedSettingsPane } from "@/features/settings/settings-screen";
 
 vi.mock("@/features/settings/use-runtime-settings", () => ({
+  flattenRuntimeSettingsValues: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; value?: string }> }>;
+  }) =>
+    Object.fromEntries(
+      (snapshot?.categories ?? []).flatMap((category) =>
+        (category.fields ?? []).map((field) => [field.key, field.value ?? ""]),
+      ),
+    ),
+  flattenRuntimeSettingsMaskedValues: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; value?: string; masked_value?: string }> }>;
+  }) =>
+    Object.fromEntries(
+      (snapshot?.categories ?? []).flatMap((category) =>
+        (category.fields ?? []).map((field) => [
+          field.key,
+          field.masked_value ?? field.value ?? "",
+        ]),
+      ),
+    ),
+  runtimeEditableKeysFromSnapshot: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; editable?: boolean }> }>;
+  }) =>
+    (snapshot?.categories ?? []).flatMap((category) =>
+      (category.fields ?? []).filter((field) => field.editable).map((field) => field.key),
+    ),
+  runtimeSecretKeysFromSnapshot: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; editable?: boolean; secret?: boolean }> }>;
+  }) =>
+    (snapshot?.categories ?? []).flatMap((category) =>
+      (category.fields ?? [])
+        .filter((field) => field.editable && field.secret)
+        .map((field) => field.key),
+    ),
   computeRuntimeUpdates: (current: Record<string, string>, baseline: Record<string, string>) => {
     const updates: Record<string, string> = {};
     for (const key of [
@@ -43,17 +76,67 @@ vi.mock("@/features/settings/use-runtime-settings", () => ({
   useRuntimeSettings: () => ({
     settingsQuery: {
       data: {
-        values: {
-          DSPY_LM_MODEL: "openai/gpt-4o-mini",
-          DSPY_DELEGATE_LM_MODEL: "openai/gpt-4.1-mini",
-          DSPY_DELEGATE_LM_SMALL_MODEL: "openai/gpt-4o-mini",
-          DSPY_LM_MAX_TOKENS: "64000",
-          DSPY_LM_API_BASE: "https://litellm.example.com/v1",
-          DSPY_LLM_API_KEY: "[REDACTED:api-key]",
-          DAYTONA_API_KEY: "[REDACTED:daytona-key]",
-          DAYTONA_API_URL: "https://daytona.example.com",
-          DAYTONA_TARGET: "local",
-        },
+        categories: [
+          {
+            id: "llm",
+            label: "LLM provider and models",
+            description: "Planner and provider settings.",
+            fields: [
+              {
+                key: "DSPY_LM_MODEL",
+                label: "Planner LM model",
+                description: "LiteLLM model identifier for the planner runtime.",
+                value: "openai/gpt-4o-mini",
+                masked_value: "openai/gpt-4o-mini",
+                secret: false,
+                editable: true,
+              },
+              {
+                key: "DSPY_DELEGATE_LM_MODEL",
+                label: "Delegate LM model",
+                description: "Optional model identifier for recursive delegate turns.",
+                value: "openai/gpt-4.1-mini",
+                masked_value: "openai/gpt-4.1-mini",
+                secret: false,
+                editable: true,
+              },
+              {
+                key: "DSPY_DELEGATE_LM_SMALL_MODEL",
+                label: "Delegate small LM model",
+                description: "Optional small model used by lightweight delegate tasks.",
+                value: "openai/gpt-4o-mini",
+                masked_value: "openai/gpt-4o-mini",
+                secret: false,
+                editable: true,
+              },
+              {
+                key: "DSPY_LM_API_BASE",
+                label: "Provider API base",
+                description: "Custom API endpoint for LiteLLM-compatible providers.",
+                value: "https://litellm.example.com/v1",
+                masked_value: "https://litellm.example.com/v1",
+                secret: false,
+                editable: true,
+              },
+            ],
+          },
+          {
+            id: "api_keys",
+            label: "API keys and credentials",
+            description: "Write-only credentials.",
+            fields: [
+              {
+                key: "DSPY_LLM_API_KEY",
+                label: "API key",
+                description: "Primary provider key for planner and fallback delegate LM calls.",
+                value: "[REDACTED:api-key]",
+                masked_value: "[REDACTED:api-key]",
+                secret: true,
+                editable: true,
+              },
+            ],
+          },
+        ],
       },
     },
     statusQuery: {

--- a/src/frontend/src/features/settings/__tests__/runtime-form.test.tsx
+++ b/src/frontend/src/features/settings/__tests__/runtime-form.test.tsx
@@ -4,29 +4,130 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { RuntimeForm, shouldHydrateRuntimeForm } from "@/features/settings/runtime-form";
 
 vi.mock("@/features/settings/use-runtime-settings", () => ({
+  flattenRuntimeSettingsValues: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; value?: string }> }>;
+  }) =>
+    Object.fromEntries(
+      (snapshot?.categories ?? []).flatMap((category) =>
+        (category.fields ?? []).map((field) => [field.key, field.value ?? ""]),
+      ),
+    ),
+  flattenRuntimeSettingsMaskedValues: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; value?: string; masked_value?: string }> }>;
+  }) =>
+    Object.fromEntries(
+      (snapshot?.categories ?? []).flatMap((category) =>
+        (category.fields ?? []).map((field) => [
+          field.key,
+          field.masked_value ?? field.value ?? "",
+        ]),
+      ),
+    ),
+  runtimeEditableKeysFromSnapshot: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; editable?: boolean }> }>;
+  }) =>
+    (snapshot?.categories ?? []).flatMap((category) =>
+      (category.fields ?? []).filter((field) => field.editable).map((field) => field.key),
+    ),
+  runtimeSecretKeysFromSnapshot: (snapshot?: {
+    categories?: Array<{ fields?: Array<{ key: string; editable?: boolean; secret?: boolean }> }>;
+  }) =>
+    (snapshot?.categories ?? []).flatMap((category) =>
+      (category.fields ?? [])
+        .filter((field) => field.editable && field.secret)
+        .map((field) => field.key),
+    ),
   useRuntimeSettings: () => ({
     settingsQuery: {
       data: {
         env_path: "/tmp/.env",
-        keys: [],
-        values: {
-          DSPY_LM_MODEL: "openai/gemini-3-flash-preview",
-          DSPY_LLM_API_KEY: "sk-...yz",
-          DSPY_LM_API_BASE: "https://api.example.com/v1",
-          DSPY_LM_MAX_TOKENS: "64000",
-          DAYTONA_API_KEY: "daytona-...12",
-          DAYTONA_API_URL: "https://daytona.example.com",
-          DAYTONA_TARGET: "local",
-        },
-        masked_values: {
-          DSPY_LM_MODEL: "openai/gemini-3-flash-preview",
-          DSPY_LLM_API_KEY: "sk-...yz",
-          DSPY_LM_API_BASE: "https://api.example.com/v1",
-          DSPY_LM_MAX_TOKENS: "64000",
-          DAYTONA_API_KEY: "daytona-...12",
-          DAYTONA_API_URL: "https://daytona.example.com",
-          DAYTONA_TARGET: "local",
-        },
+        categories: [
+          {
+            id: "llm",
+            label: "LLM provider and models",
+            description: "Planner and provider settings.",
+            fields: [
+              {
+                key: "DSPY_LM_MODEL",
+                label: "Planner LM model",
+                description: "Planner model identifier.",
+                value: "openai/gemini-3-flash-preview",
+                masked_value: "openai/gemini-3-flash-preview",
+                secret: false,
+                editable: true,
+              },
+              {
+                key: "DSPY_LM_API_BASE",
+                label: "Provider API base",
+                description: "Optional base URL for LM provider routing.",
+                value: "https://api.example.com/v1",
+                masked_value: "https://api.example.com/v1",
+                secret: false,
+                editable: true,
+              },
+              {
+                key: "DSPY_LM_MAX_TOKENS",
+                label: "Planner max tokens",
+                description: "Maximum token budget per planner response.",
+                value: "64000",
+                masked_value: "64000",
+                secret: false,
+                editable: true,
+              },
+            ],
+          },
+          {
+            id: "api_keys",
+            label: "API keys and credentials",
+            description: "Write-only credentials.",
+            fields: [
+              {
+                key: "DSPY_LLM_API_KEY",
+                label: "Primary LM API key",
+                description:
+                  "Primary provider key for LM calls. Leave unchanged to keep current value.",
+                value: "sk-...yz",
+                masked_value: "sk-...yz",
+                secret: true,
+                editable: true,
+              },
+              {
+                key: "DAYTONA_API_KEY",
+                label: "Daytona API key",
+                description: "API key for Daytona Workspace provisioning.",
+                value: "daytona-...12",
+                masked_value: "daytona-...12",
+                secret: true,
+                editable: true,
+              },
+            ],
+          },
+          {
+            id: "sandbox_volumes",
+            label: "Sandbox and volumes",
+            description: "Daytona runtime settings.",
+            fields: [
+              {
+                key: "DAYTONA_API_URL",
+                label: "Daytona API URL",
+                description: "URL for Daytona API.",
+                value: "https://daytona.example.com",
+                masked_value: "https://daytona.example.com",
+                secret: false,
+                editable: true,
+              },
+              {
+                key: "DAYTONA_TARGET",
+                label: "Daytona target",
+                description: "Execution target/backend for Daytona provisioning.",
+                value: "local",
+                masked_value: "local",
+                secret: false,
+                editable: true,
+              },
+            ],
+          },
+        ],
       },
     },
     statusQuery: {
@@ -92,8 +193,8 @@ vi.mock("@/features/settings/use-runtime-settings", () => ({
 describe("RuntimeForm", () => {
   it("hydrates runtime form only when snapshot exists and no unsaved edits", () => {
     expect(shouldHydrateRuntimeForm(undefined, false)).toBe(false);
-    expect(shouldHydrateRuntimeForm({ values: {} }, true)).toBe(false);
-    expect(shouldHydrateRuntimeForm({ values: {} }, false)).toBe(true);
+    expect(shouldHydrateRuntimeForm({ categories: [] }, true)).toBe(false);
+    expect(shouldHydrateRuntimeForm({ categories: [] }, false)).toBe(true);
   });
 
   it("renders masked runtime values and smoke-test states", () => {

--- a/src/frontend/src/features/settings/__tests__/use-runtime-settings.test.ts
+++ b/src/frontend/src/features/settings/__tests__/use-runtime-settings.test.ts
@@ -28,7 +28,7 @@ describe("computeRuntimeUpdates", () => {
       DAYTONA_TARGET: "staging",
     };
 
-    expect(computeRuntimeUpdates(current, baseline)).toEqual({
+    expect(computeRuntimeUpdates(current, baseline, undefined, Object.keys(current))).toEqual({
       DSPY_LM_MODEL: "openai/gpt-4.1-mini",
       DAYTONA_TARGET: "staging",
     });
@@ -42,7 +42,7 @@ describe("computeRuntimeUpdates", () => {
       DAYTONA_API_URL: "",
     };
 
-    expect(computeRuntimeUpdates(current, baseline)).toEqual({
+    expect(computeRuntimeUpdates(current, baseline, undefined, Object.keys(current))).toEqual({
       DAYTONA_API_URL: "",
     });
   });
@@ -57,7 +57,9 @@ describe("computeRuntimeUpdates", () => {
       DSPY_LLM_API_KEY: "",
     };
 
-    expect(computeRuntimeUpdates(current, baseline)).toEqual({});
+    expect(
+      computeRuntimeUpdates(current, baseline, undefined, Object.keys(current), ["DSPY_LLM_API_KEY"]),
+    ).toEqual({});
   });
 
   it("includes secret keys when a new secret is entered", () => {
@@ -66,12 +68,14 @@ describe("computeRuntimeUpdates", () => {
       {},
       {
         secretInputs: {
-          DSPY_LLM_API_KEY: "sk-new",
+          DATABASE_URL: "postgresql://runtime",
         },
       },
+      ["DATABASE_URL"],
+      ["DATABASE_URL"],
     );
     expect(updates).toEqual({
-      DSPY_LLM_API_KEY: "sk-new",
+      DATABASE_URL: "postgresql://runtime",
     });
   });
 
@@ -80,11 +84,34 @@ describe("computeRuntimeUpdates", () => {
       {},
       {},
       {
-        clearedSecrets: ["DSPY_LLM_API_KEY"],
+        clearedSecrets: ["DATABASE_ADMIN_URL"],
       },
+      ["DATABASE_ADMIN_URL"],
+      ["DATABASE_ADMIN_URL"],
     );
     expect(updates).toEqual({
-      DSPY_LLM_API_KEY: "",
+      DATABASE_ADMIN_URL: "",
+    });
+  });
+
+  it("uses backend-provided editable keys to include new non-secret settings", () => {
+    const baseline = {
+      TIMEOUT: "900",
+      INTERPRETER_ASYNC_EXECUTE: "true",
+    };
+    const current = {
+      TIMEOUT: "1200",
+      INTERPRETER_ASYNC_EXECUTE: "false",
+    };
+
+    expect(
+      computeRuntimeUpdates(current, baseline, undefined, [
+        "TIMEOUT",
+        "INTERPRETER_ASYNC_EXECUTE",
+      ]),
+    ).toEqual({
+      TIMEOUT: "1200",
+      INTERPRETER_ASYNC_EXECUTE: "false",
     });
   });
 });

--- a/src/frontend/src/features/settings/__tests__/use-runtime-settings.test.ts
+++ b/src/frontend/src/features/settings/__tests__/use-runtime-settings.test.ts
@@ -58,7 +58,9 @@ describe("computeRuntimeUpdates", () => {
     };
 
     expect(
-      computeRuntimeUpdates(current, baseline, undefined, Object.keys(current), ["DSPY_LLM_API_KEY"]),
+      computeRuntimeUpdates(current, baseline, undefined, Object.keys(current), [
+        "DSPY_LLM_API_KEY",
+      ]),
     ).toEqual({});
   });
 
@@ -105,10 +107,7 @@ describe("computeRuntimeUpdates", () => {
     };
 
     expect(
-      computeRuntimeUpdates(current, baseline, undefined, [
-        "TIMEOUT",
-        "INTERPRETER_ASYNC_EXECUTE",
-      ]),
+      computeRuntimeUpdates(current, baseline, undefined, ["TIMEOUT", "INTERPRETER_ASYNC_EXECUTE"]),
     ).toEqual({
       TIMEOUT: "1200",
       INTERPRETER_ASYNC_EXECUTE: "false",

--- a/src/frontend/src/features/settings/litellm-form.tsx
+++ b/src/frontend/src/features/settings/litellm-form.tsx
@@ -19,7 +19,13 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
-import { computeLmRuntimeUpdates, useRuntimeSettings } from "./use-runtime-settings";
+import {
+  computeLmRuntimeUpdates,
+  flattenRuntimeSettingsMaskedValues,
+  flattenRuntimeSettingsValues,
+  useRuntimeSettings,
+  type CategorizedRuntimeSettingsSnapshot,
+} from "./use-runtime-settings";
 import type { SettingsSection } from "./settings-content";
 import { sectionDescriptions } from "./settings-content";
 
@@ -52,13 +58,15 @@ export function LiteLlmForm({ showAllSections, section }: LiteLlmFormProps) {
   const [baselineDelegateLmSmallModel, setBaselineDelegateLmSmallModel] = useState("");
 
   useEffect(() => {
-    const values = settingsQuery.data?.values;
-    if (!values) return;
+    const snapshot = settingsQuery.data as CategorizedRuntimeSettingsSnapshot | undefined;
+    if (!snapshot) return;
+    const values = flattenRuntimeSettingsValues(snapshot);
+    const maskedValues = flattenRuntimeSettingsMaskedValues(snapshot);
     const nextLmModel = values.DSPY_LM_MODEL ?? "";
     const nextDelegateLmModel = values.DSPY_DELEGATE_LM_MODEL ?? "";
     const nextDelegateLmSmallModel = values.DSPY_DELEGATE_LM_SMALL_MODEL ?? "";
     const nextApiBase = values.DSPY_LM_API_BASE ?? "";
-    const nextApiKey = values.DSPY_LLM_API_KEY ?? "";
+    const nextApiKey = maskedValues.DSPY_LLM_API_KEY ?? "";
     setLmModel(nextLmModel);
     setDelegateLmModel(nextDelegateLmModel);
     setDelegateLmSmallModel(nextDelegateLmSmallModel);

--- a/src/frontend/src/features/settings/runtime-form.tsx
+++ b/src/frontend/src/features/settings/runtime-form.tsx
@@ -20,9 +20,12 @@ import {
 } from "@/components/ui/input-group";
 import {
   computeRuntimeUpdates,
+  flattenRuntimeSettingsMaskedValues,
+  flattenRuntimeSettingsValues,
+  runtimeEditableKeysFromSnapshot,
+  runtimeSecretKeysFromSnapshot,
   useRuntimeSettings,
-  type RuntimeEditableKey,
-  type RuntimeSecretEditableKey,
+  type CategorizedRuntimeSettingsSnapshot,
 } from "./use-runtime-settings";
 import type { RuntimeStatusResponse } from "@/lib/rlm-api";
 import { RuntimeStatusPanel, shouldHydrateRuntimeForm, errorMessage } from "./runtime-status-panel";
@@ -31,60 +34,15 @@ import { RuntimeConnectivityPanel } from "./runtime-connectivity-panel";
 export { shouldHydrateRuntimeForm, errorMessage } from "./runtime-status-panel";
 
 type RuntimeField = {
-  key: RuntimeEditableKey;
+  key: string;
   label: string;
   description: string;
   isSecret?: boolean;
   placeholder?: string;
 };
 
-const RUNTIME_FIELDS: RuntimeField[] = [
-  {
-    key: "DSPY_LM_MODEL",
-    label: "LM Model",
-    description: "Planner model identifier (for example: openai/gemini-3.1-pro).",
-  },
-  {
-    key: "DSPY_LLM_API_KEY",
-    label: "LM API Key",
-    description: "Primary provider key for LM calls. Leave unchanged to keep current value.",
-    isSecret: true,
-  },
-  {
-    key: "DAYTONA_API_KEY",
-    label: "Daytona API Key",
-    description: "API Key for Daytona Workspace provisioning.",
-    isSecret: true,
-  },
-  {
-    key: "DAYTONA_API_URL",
-    label: "Daytona API URL",
-    description: "URL for Daytona API (e.g. http://127.0.0.1:3000).",
-  },
-  {
-    key: "DAYTONA_TARGET",
-    label: "Daytona Target",
-    description: "Execution target/backend for Daytona provisioning (e.g. local).",
-  },
-  {
-    key: "DSPY_LM_API_BASE",
-    label: "LM API Base",
-    description: "Optional base URL for LM provider routing.",
-  },
-  {
-    key: "DSPY_LM_MAX_TOKENS",
-    label: "LM Max Tokens",
-    description: "Maximum token budget per planner response.",
-    placeholder: "64000",
-  },
-];
-
-const RUNTIME_SECRET_KEYS: RuntimeSecretEditableKey[] = ["DSPY_LLM_API_KEY", "DAYTONA_API_KEY"];
-
-const RUNTIME_SECRET_KEY_SET = new Set<RuntimeSecretEditableKey>(RUNTIME_SECRET_KEYS);
-
-function isRuntimeSecretKey(key: RuntimeEditableKey): key is RuntimeSecretEditableKey {
-  return RUNTIME_SECRET_KEY_SET.has(key as RuntimeSecretEditableKey);
+function isRuntimeSecretKey(key: string, secretKeys: readonly string[]): boolean {
+  return secretKeys.includes(key);
 }
 
 export function RuntimeForm() {
@@ -97,34 +55,63 @@ export function RuntimeForm() {
     testAllConnections,
   } = useRuntimeSettings();
 
-  const initialValues = settingsQuery.data?.values ?? {};
-  const maskedValues = settingsQuery.data?.masked_values ?? initialValues;
+  const snapshot = settingsQuery.data as CategorizedRuntimeSettingsSnapshot | undefined;
+  const runtimeFields = useMemo<RuntimeField[]>(
+    () =>
+      (snapshot?.categories ?? []).flatMap((category) =>
+        (category.fields ?? [])
+          .filter((field) => field.editable)
+          .map((field) => ({
+            key: field.key,
+            label: field.label,
+            description: field.description,
+            isSecret: field.secret,
+            placeholder: field.placeholder ?? field.default ?? undefined,
+          })),
+      ),
+    [snapshot],
+  );
+  const runtimeEditableKeys = useMemo(() => runtimeEditableKeysFromSnapshot(snapshot), [snapshot]);
+  const runtimeSecretKeys = useMemo(() => runtimeSecretKeysFromSnapshot(snapshot), [snapshot]);
+  const initialValues = useMemo(() => flattenRuntimeSettingsValues(snapshot), [snapshot]);
+  const maskedValues = useMemo(() => flattenRuntimeSettingsMaskedValues(snapshot), [snapshot]);
   const [baselineValues, setBaselineValues] = useState<Record<string, string>>(initialValues);
   const [formValues, setFormValues] = useState<Record<string, string>>(initialValues);
-  const [clearSecretFlags, setClearSecretFlags] = useState<
-    Partial<Record<RuntimeSecretEditableKey, boolean>>
-  >({});
+  const [clearSecretFlags, setClearSecretFlags] = useState<Record<string, boolean>>({});
 
   const clearedSecrets = useMemo(
-    () => RUNTIME_SECRET_KEYS.filter((key) => clearSecretFlags[key] === true),
-    [clearSecretFlags],
+    () => runtimeSecretKeys.filter((key) => clearSecretFlags[key] === true),
+    [clearSecretFlags, runtimeSecretKeys],
   );
 
   const secretInputs = useMemo(
     () =>
-      Object.fromEntries(RUNTIME_SECRET_KEYS.map((key) => [key, formValues[key] ?? ""])) as Partial<
-        Record<RuntimeSecretEditableKey, string>
+      Object.fromEntries(runtimeSecretKeys.map((key) => [key, formValues[key] ?? ""])) as Partial<
+        Record<string, string>
       >,
-    [formValues],
+    [formValues, runtimeSecretKeys],
   );
 
   const updates = useMemo(
     () =>
-      computeRuntimeUpdates(formValues, baselineValues, {
-        secretInputs,
-        clearedSecrets,
-      }),
-    [baselineValues, clearedSecrets, formValues, secretInputs],
+      computeRuntimeUpdates(
+        formValues,
+        baselineValues,
+        {
+          secretInputs,
+          clearedSecrets,
+        },
+        runtimeEditableKeys,
+        runtimeSecretKeys,
+      ),
+    [
+      baselineValues,
+      clearedSecrets,
+      formValues,
+      runtimeEditableKeys,
+      runtimeSecretKeys,
+      secretInputs,
+    ],
   );
   const dirtyKeys = useMemo(() => Object.keys(updates), [updates]);
   const hasUnsavedRuntimeChanges = dirtyKeys.length > 0;
@@ -133,18 +120,17 @@ export function RuntimeForm() {
   const lmTest = status?.tests?.lm;
 
   useEffect(() => {
-    const snapshot = settingsQuery.data;
     if (!snapshot) return;
     if (!shouldHydrateRuntimeForm(snapshot, hasUnsavedRuntimeChanges)) return;
-    const nextBaseline = snapshot.values ?? {};
+    const nextBaseline = flattenRuntimeSettingsValues(snapshot);
     const nextFormValues = { ...nextBaseline };
-    for (const key of RUNTIME_SECRET_KEYS) {
+    for (const key of runtimeSecretKeys) {
       nextFormValues[key] = "";
     }
     setBaselineValues(nextBaseline);
     setFormValues(nextFormValues);
     setClearSecretFlags({});
-  }, [hasUnsavedRuntimeChanges, settingsQuery.data]);
+  }, [hasUnsavedRuntimeChanges, runtimeSecretKeys, snapshot]);
 
   const showUnsavedRuntimeTestWarning = () => {
     toast.error("Save runtime settings before testing", {
@@ -185,7 +171,7 @@ export function RuntimeForm() {
         }
         setFormValues((prev) => {
           const next = { ...prev };
-          for (const key of RUNTIME_SECRET_KEYS) {
+          for (const key of runtimeSecretKeys) {
             next[key] = "";
           }
           return next;
@@ -271,9 +257,9 @@ export function RuntimeForm() {
     !hasUnsavedRuntimeChanges || saveSettings.isPending || status?.write_enabled === false;
   const runtimeGuidance = status?.guidance ?? ["No guidance available."];
 
-  const updateFieldValue = (key: RuntimeEditableKey, value: string) => {
+  const updateFieldValue = (key: string, value: string) => {
     setFormValues((prev) => ({ ...prev, [key]: value }));
-    if (isRuntimeSecretKey(key)) {
+    if (isRuntimeSecretKey(key, runtimeSecretKeys)) {
       setClearSecretFlags((prev) => ({
         ...prev,
         [key]: false,
@@ -281,7 +267,7 @@ export function RuntimeForm() {
     }
   };
 
-  const toggleClearSecret = (secretKey: RuntimeSecretEditableKey) => {
+  const toggleClearSecret = (secretKey: string) => {
     const nextClear = !(clearSecretFlags[secretKey] ?? false);
     setClearSecretFlags((prev) => ({
       ...prev,
@@ -308,8 +294,8 @@ export function RuntimeForm() {
         </SectionCardHeader>
         <SectionCardContent className="pt-6">
           <FieldGroup className="gap-5">
-            {RUNTIME_FIELDS.map((field) => {
-              const secretKey = isRuntimeSecretKey(field.key) ? field.key : null;
+            {runtimeFields.map((field) => {
+              const secretKey = isRuntimeSecretKey(field.key, runtimeSecretKeys) ? field.key : null;
               const inputId = `runtime-${field.key.toLowerCase()}`;
               const inputValue = formValues[field.key] ?? "";
               return (

--- a/src/frontend/src/features/settings/runtime-status-panel.tsx
+++ b/src/frontend/src/features/settings/runtime-status-panel.tsx
@@ -10,7 +10,7 @@ export function formatCheckLabel(key: string): string {
 }
 
 export function shouldHydrateRuntimeForm(
-  snapshot: { values?: Record<string, string> } | undefined,
+  snapshot: object | undefined,
   hasUnsavedRuntimeChanges: boolean,
 ): boolean {
   return Boolean(snapshot) && !hasUnsavedRuntimeChanges;

--- a/src/frontend/src/features/settings/use-runtime-settings.ts
+++ b/src/frontend/src/features/settings/use-runtime-settings.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { runtimeStatusQueryKey, useRuntimeStatus } from "@/hooks/use-runtime-status";
 import { runtimeEndpoints } from "@/lib/rlm-api/runtime";
+import type { RuntimeSettingsSnapshot } from "@/lib/rlm-api";
 
 export const runtimeKeys = {
   all: ["runtime"] as const,
@@ -14,17 +15,39 @@ export const RUNTIME_EDITABLE_KEYS = [
   "DSPY_LM_MODEL",
   "DSPY_DELEGATE_LM_MODEL",
   "DSPY_DELEGATE_LM_SMALL_MODEL",
+  "DSPY_DELEGATE_LM_MAX_TOKENS",
   "DSPY_LLM_API_KEY",
+  "DSPY_LM_API_KEY",
+  "DSPY_DELEGATE_LM_API_KEY",
   "DSPY_LM_API_BASE",
   "DSPY_LM_MAX_TOKENS",
+  "DSPY_ADAPTER",
+  "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
   "DAYTONA_API_KEY",
+  "POSTHOG_API_KEY",
   "DAYTONA_API_URL",
   "DAYTONA_TARGET",
+  "VOLUME_NAME",
+  "TIMEOUT",
+  "INTERPRETER_ASYNC_EXECUTE",
+  "DATABASE_URL",
+  "DATABASE_ADMIN_URL",
+  "DATABASE_REQUIRED",
+  "DB_ECHO",
+  "DB_VALIDATE_ON_STARTUP",
 ] as const;
 
-export type RuntimeEditableKey = (typeof RUNTIME_EDITABLE_KEYS)[number];
-export const RUNTIME_SECRET_EDITABLE_KEYS = ["DSPY_LLM_API_KEY", "DAYTONA_API_KEY"] as const;
-export type RuntimeSecretEditableKey = (typeof RUNTIME_SECRET_EDITABLE_KEYS)[number];
+export type RuntimeEditableKey = string;
+export const RUNTIME_SECRET_EDITABLE_KEYS = [
+  "DSPY_LLM_API_KEY",
+  "DSPY_LM_API_KEY",
+  "DSPY_DELEGATE_LM_API_KEY",
+  "DAYTONA_API_KEY",
+  "POSTHOG_API_KEY",
+  "DATABASE_URL",
+  "DATABASE_ADMIN_URL",
+] as const;
+export type RuntimeSecretEditableKey = string;
 
 export const RUNTIME_LM_EDITABLE_KEYS = [
   "DSPY_LM_MODEL",
@@ -38,19 +61,95 @@ export type RuntimeLmEditableKey = (typeof RUNTIME_LM_EDITABLE_KEYS)[number];
 export const RUNTIME_LM_SECRET_EDITABLE_KEYS = ["DSPY_LLM_API_KEY"] as const;
 export type RuntimeLmSecretEditableKey = (typeof RUNTIME_LM_SECRET_EDITABLE_KEYS)[number];
 
-export interface RuntimeUpdateComputationOptions<SecretKey extends RuntimeSecretEditableKey> {
+export interface RuntimeSettingsFieldMetadata {
+  key: string;
+  label: string;
+  description: string;
+  value?: string;
+  masked_value?: string;
+  secret?: boolean;
+  editable?: boolean;
+  reload_required?: boolean;
+  placeholder?: string | null;
+  default?: string | null;
+}
+
+export interface RuntimeSettingsCategoryMetadata {
+  id: string;
+  label: string;
+  description: string;
+  fields?: RuntimeSettingsFieldMetadata[];
+}
+
+export type CategorizedRuntimeSettingsSnapshot = RuntimeSettingsSnapshot & {
+  categories?: RuntimeSettingsCategoryMetadata[];
+};
+
+export function flattenRuntimeSettingsValues(
+  snapshot?: CategorizedRuntimeSettingsSnapshot,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const category of snapshot?.categories ?? []) {
+    for (const field of category.fields ?? []) {
+      values[field.key] = field.value ?? "";
+    }
+  }
+  return values;
+}
+
+export function flattenRuntimeSettingsMaskedValues(
+  snapshot?: CategorizedRuntimeSettingsSnapshot,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const category of snapshot?.categories ?? []) {
+    for (const field of category.fields ?? []) {
+      values[field.key] = field.masked_value ?? field.value ?? "";
+    }
+  }
+  return values;
+}
+
+export function runtimeEditableKeysFromSnapshot(
+  snapshot?: CategorizedRuntimeSettingsSnapshot,
+): RuntimeEditableKey[] {
+  const keys = new Set<string>();
+  for (const category of snapshot?.categories ?? []) {
+    for (const field of category.fields ?? []) {
+      if (field.editable) {
+        keys.add(field.key);
+      }
+    }
+  }
+  return [...keys];
+}
+
+export function runtimeSecretKeysFromSnapshot(
+  snapshot?: CategorizedRuntimeSettingsSnapshot,
+): RuntimeSecretEditableKey[] {
+  const keys = new Set<string>();
+  for (const category of snapshot?.categories ?? []) {
+    for (const field of category.fields ?? []) {
+      if (field.editable && field.secret) {
+        keys.add(field.key);
+      }
+    }
+  }
+  return [...keys];
+}
+
+export interface RuntimeUpdateComputationOptions<SecretKey extends string> {
   secretInputs?: Partial<Record<SecretKey, string>>;
   clearedSecrets?: Iterable<SecretKey>;
 }
 
-function toSecretSet<SecretKey extends RuntimeSecretEditableKey>(
+function toSecretSet<SecretKey extends string>(
   options?: RuntimeUpdateComputationOptions<SecretKey>,
 ): Set<SecretKey> {
   if (!options?.clearedSecrets) return new Set<SecretKey>();
   return new Set(options.clearedSecrets);
 }
 
-function computeSecretUpdate<SecretKey extends RuntimeSecretEditableKey>(
+function computeSecretUpdate<SecretKey extends string>(
   key: SecretKey,
   updates: Record<string, string>,
   options?: RuntimeUpdateComputationOptions<SecretKey>,
@@ -70,15 +169,22 @@ export function computeRuntimeUpdates(
   current: Record<string, string>,
   baseline: Record<string, string>,
   options?: RuntimeUpdateComputationOptions<RuntimeSecretEditableKey>,
+  editableKeys?: readonly string[],
+  secretKeys: readonly string[] = RUNTIME_SECRET_EDITABLE_KEYS,
 ): Record<string, string> {
   const updates: Record<string, string> = {};
-  for (const key of RUNTIME_EDITABLE_KEYS) {
-    if ((RUNTIME_SECRET_EDITABLE_KEYS as readonly string[]).includes(key)) {
-      computeSecretUpdate(
-        key as RuntimeSecretEditableKey,
-        updates,
-        options as RuntimeUpdateComputationOptions<RuntimeSecretEditableKey>,
-      );
+  const resolvedEditableKeys =
+    editableKeys ??
+    Array.from(
+      new Set([
+        ...Object.keys(current),
+        ...Object.keys(options?.secretInputs ?? {}),
+        ...Array.from(options?.clearedSecrets ?? []),
+      ]),
+    );
+  for (const key of resolvedEditableKeys) {
+    if (secretKeys.includes(key)) {
+      computeSecretUpdate(key, updates, options);
       continue;
     }
     const next = current[key] ?? "";

--- a/src/frontend/src/lib/data/mock/runtime.ts
+++ b/src/frontend/src/lib/data/mock/runtime.ts
@@ -65,7 +65,11 @@ const runtimeSettingCategories = [
         "Optional custom API base URL for LiteLLM-compatible providers.",
       ],
       ["DSPY_LM_MAX_TOKENS", "Planner max tokens", "Maximum token budget for planner responses."],
-      ["DSPY_ADAPTER", "DSPy adapter", "Optional default DSPy adapter for non-runtime-module calls."],
+      [
+        "DSPY_ADAPTER",
+        "DSPy adapter",
+        "Optional default DSPy adapter for non-runtime-module calls.",
+      ],
       [
         "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
         "Native function calling",
@@ -127,13 +131,21 @@ const runtimeSettingCategories = [
     label: "Database",
     description: "Postgres persistence URLs and database startup behavior.",
     fields: [
-      ["DATABASE_URL", "Runtime database URL", "Pooled Postgres URL used by application runtime traffic."],
+      [
+        "DATABASE_URL",
+        "Runtime database URL",
+        "Pooled Postgres URL used by application runtime traffic.",
+      ],
       [
         "DATABASE_ADMIN_URL",
         "Admin database URL",
         "Direct Postgres URL used for Alembic, schema, and admin tasks.",
       ],
-      ["DATABASE_REQUIRED", "Require database", "Require database connectivity during server startup."],
+      [
+        "DATABASE_REQUIRED",
+        "Require database",
+        "Require database connectivity during server startup.",
+      ],
       ["DB_ECHO", "SQL echo", "Enable SQLAlchemy SQL echo logging."],
       [
         "DB_VALIDATE_ON_STARTUP",

--- a/src/frontend/src/lib/data/mock/runtime.ts
+++ b/src/frontend/src/lib/data/mock/runtime.ts
@@ -11,20 +11,141 @@ const fallbackValues: Record<string, string> = {
   DSPY_LM_MODEL: "openai/gemini-3-flash-preview",
   DSPY_DELEGATE_LM_MODEL: "openai/gemini-3-flash-preview",
   DSPY_DELEGATE_LM_SMALL_MODEL: "openai/gemini-3-flash-preview",
+  DSPY_DELEGATE_LM_MAX_TOKENS: "64000",
   DSPY_LM_API_BASE: "",
   DSPY_LM_MAX_TOKENS: "64000",
+  DSPY_ADAPTER: "",
+  DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING: "false",
   DAYTONA_API_URL: "http://127.0.0.1:3000",
   DAYTONA_TARGET: "local",
+  VOLUME_NAME: "rlm-volume-dspy",
+  TIMEOUT: "900",
+  INTERPRETER_ASYNC_EXECUTE: "true",
+  DATABASE_REQUIRED: "false",
+  DB_ECHO: "false",
+  DB_VALIDATE_ON_STARTUP: "false",
 };
 
 const fallbackMaskedValues: Record<string, string> = {
   DSPY_LLM_API_KEY: "sk-...demo",
+  DSPY_LM_API_KEY: "sk-...legacy",
+  DSPY_DELEGATE_LM_API_KEY: "sk-...delegate",
   DAYTONA_API_KEY: "dyt-...demo",
+  POSTHOG_API_KEY: "phc-...demo",
+  DATABASE_URL: "pos.../db",
+  DATABASE_ADMIN_URL: "pos...admin",
   ...fallbackValues,
 };
 
-function clone<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
+const runtimeSettingCategories = [
+  {
+    id: "llm",
+    label: "LLM provider and models",
+    description: "Planner, delegate, adapter, and provider routing settings used by DSPy.",
+    fields: [
+      ["DSPY_LM_MODEL", "Planner LM model", "LiteLLM model identifier for the planner runtime."],
+      [
+        "DSPY_DELEGATE_LM_MODEL",
+        "Delegate LM model",
+        "Optional model identifier for recursive delegate turns.",
+      ],
+      [
+        "DSPY_DELEGATE_LM_SMALL_MODEL",
+        "Delegate small LM model",
+        "Optional small model used by lightweight delegate tasks.",
+      ],
+      [
+        "DSPY_DELEGATE_LM_MAX_TOKENS",
+        "Delegate max tokens",
+        "Maximum token budget for delegate model calls.",
+      ],
+      [
+        "DSPY_LM_API_BASE",
+        "Provider API base",
+        "Optional custom API base URL for LiteLLM-compatible providers.",
+      ],
+      ["DSPY_LM_MAX_TOKENS", "Planner max tokens", "Maximum token budget for planner responses."],
+      ["DSPY_ADAPTER", "DSPy adapter", "Optional default DSPy adapter for non-runtime-module calls."],
+      [
+        "DSPY_ADAPTER_USE_NATIVE_FUNCTION_CALLING",
+        "Native function calling",
+        "Enable native function calling for the default DSPy adapter.",
+      ],
+    ],
+  },
+  {
+    id: "api_keys",
+    label: "API keys and credentials",
+    description:
+      "Write-only credentials used by language-model providers, Daytona, and optional services.",
+    fields: [
+      [
+        "DSPY_LLM_API_KEY",
+        "Primary LM API key",
+        "Primary provider key for planner and fallback delegate LM calls.",
+      ],
+      [
+        "DSPY_LM_API_KEY",
+        "Legacy LM API key",
+        "Backward-compatible LM provider key used when the primary key is unset.",
+      ],
+      [
+        "DSPY_DELEGATE_LM_API_KEY",
+        "Delegate LM API key",
+        "Optional provider key dedicated to delegate model calls.",
+      ],
+      [
+        "DAYTONA_API_KEY",
+        "Daytona API key",
+        "API key used for Daytona workspace and volume provisioning.",
+      ],
+      ["POSTHOG_API_KEY", "PostHog API key", "Optional PostHog project key for analytics."],
+    ],
+  },
+  {
+    id: "sandbox_volumes",
+    label: "Sandbox and volumes",
+    description: "Daytona runtime, sandbox execution, and durable volume parameters.",
+    fields: [
+      ["DAYTONA_API_URL", "Daytona API URL", "Base URL for the Daytona API."],
+      [
+        "DAYTONA_TARGET",
+        "Daytona target",
+        "Execution target or backend selected for Daytona provisioning.",
+      ],
+      ["VOLUME_NAME", "Volume name", "Durable Daytona volume mounted into workbench sandboxes."],
+      ["TIMEOUT", "Sandbox timeout", "Maximum sandbox execution time in seconds."],
+      [
+        "INTERPRETER_ASYNC_EXECUTE",
+        "Async interpreter execution",
+        "Run interpreter execute calls through the async wrapper.",
+      ],
+    ],
+  },
+  {
+    id: "database",
+    label: "Database",
+    description: "Postgres persistence URLs and database startup behavior.",
+    fields: [
+      ["DATABASE_URL", "Runtime database URL", "Pooled Postgres URL used by application runtime traffic."],
+      [
+        "DATABASE_ADMIN_URL",
+        "Admin database URL",
+        "Direct Postgres URL used for Alembic, schema, and admin tasks.",
+      ],
+      ["DATABASE_REQUIRED", "Require database", "Require database connectivity during server startup."],
+      ["DB_ECHO", "SQL echo", "Enable SQLAlchemy SQL echo logging."],
+      [
+        "DB_VALIDATE_ON_STARTUP",
+        "Validate database on startup",
+        "Ping the configured database during server startup.",
+      ],
+    ],
+  },
+] as const;
+
+function isMockSecretKey(key: string): boolean {
+  return key.endsWith("API_KEY") || (key.endsWith("_URL") && key.startsWith("DATABASE_"));
 }
 
 function buildConnectivityTest(
@@ -51,10 +172,24 @@ function buildConnectivityTest(
 export function getMockRuntimeSettings(): RuntimeSettingsSnapshot {
   return {
     env_path: FALLBACK_ENV_PATH,
-    keys: Object.keys(fallbackValues),
-    values: clone(fallbackValues),
-    masked_values: clone(fallbackMaskedValues),
-  };
+    categories: runtimeSettingCategories.map((category) => ({
+      id: category.id,
+      label: category.label,
+      description: category.description,
+      fields: category.fields.map(([key, label, description]) => ({
+        key,
+        label,
+        description,
+        value: fallbackMaskedValues[key] ?? fallbackValues[key] ?? "",
+        masked_value: fallbackMaskedValues[key] ?? fallbackValues[key] ?? "",
+        secret: isMockSecretKey(key),
+        editable: true,
+        reload_required: key.startsWith("DSPY_"),
+        placeholder: null,
+        default: null,
+      })),
+    })),
+  } as RuntimeSettingsSnapshot;
 }
 
 export function getMockRuntimeStatus(): RuntimeStatusResponse {
@@ -101,7 +236,7 @@ export function applyMockRuntimeUpdates(
     }
 
     fallbackValues[key] = value;
-    fallbackMaskedValues[key] = key.endsWith("API_KEY")
+    fallbackMaskedValues[key] = isMockSecretKey(key)
       ? value.length > 8
         ? `${value.slice(0, 2)}...${value.slice(-4)}`
         : "***"

--- a/src/frontend/src/lib/rlm-api/__tests__/runtime.test.ts
+++ b/src/frontend/src/lib/rlm-api/__tests__/runtime.test.ts
@@ -47,9 +47,7 @@ describe("runtimeEndpoints", () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse({
         env_path: "/tmp/.env",
-        keys: [],
-        values: {},
-        masked_values: {},
+        categories: [],
       }),
     );
     vi.stubGlobal("fetch", fetchMock);

--- a/src/frontend/src/lib/rlm-api/generated/openapi.ts
+++ b/src/frontend/src/lib/rlm-api/generated/openapi.ts
@@ -1168,6 +1168,93 @@ export interface components {
       error?: string | null;
     };
     /**
+     * RuntimeSettingsCategory
+     * @description Categorized group of runtime settings fields.
+     */
+    RuntimeSettingsCategory: {
+      /**
+       * Id
+       * @description Stable category identifier.
+       */
+      id: string;
+      /**
+       * Label
+       * @description Human-readable category label.
+       */
+      label: string;
+      /**
+       * Description
+       * @description Human-readable category description.
+       */
+      description: string;
+      /**
+       * Fields
+       * @description Fields in this category.
+       */
+      fields?: components["schemas"]["RuntimeSettingsField"][];
+    };
+    /**
+     * RuntimeSettingsField
+     * @description Single display-safe runtime setting field.
+     */
+    RuntimeSettingsField: {
+      /**
+       * Key
+       * @description Environment variable key backing this setting.
+       */
+      key: string;
+      /**
+       * Label
+       * @description Human-readable setting label.
+       */
+      label: string;
+      /**
+       * Description
+       * @description Human-readable setting description.
+       */
+      description: string;
+      /**
+       * Value
+       * @description Display-safe setting value.
+       * @default
+       */
+      value?: string;
+      /**
+       * Masked Value
+       * @description Masked display value for secret settings.
+       * @default
+       */
+      masked_value?: string;
+      /**
+       * Secret
+       * @description Whether the field stores sensitive data.
+       * @default false
+       */
+      secret?: boolean;
+      /**
+       * Editable
+       * @description Whether the field can be patched through the Settings API.
+       * @default true
+       */
+      editable?: boolean;
+      /**
+       * Reload Required
+       * @description Whether applying this setting reloads runtime dependencies.
+       * @default false
+       */
+      reload_required?: boolean;
+      /**
+       * Placeholder
+       * @description Optional UI placeholder.
+       */
+      placeholder?: string | null;
+      /**
+       * Default
+       * @description Optional default value displayed by settings clients.
+       */
+      default?: string | null;
+    };
+    /**
      * RuntimeSettingsSnapshot
      * @description Current runtime settings snapshot returned by the Settings API.
      */
@@ -1178,24 +1265,10 @@ export interface components {
        */
       env_path: string;
       /**
-       * Keys
-       * @description Ordered list of runtime setting keys surfaced by the Settings API.
+       * Categories
+       * @description Categorized runtime setting fields surfaced by the Settings API.
        */
-      keys?: string[];
-      /**
-       * Values
-       * @description Unmasked runtime setting values that are safe to return directly.
-       */
-      values?: {
-        [key: string]: string;
-      };
-      /**
-       * Masked Values
-       * @description Masked secret values returned for display-only settings fields.
-       */
-      masked_values?: {
-        [key: string]: string;
-      };
+      categories?: components["schemas"]["RuntimeSettingsCategory"][];
     };
     /**
      * RuntimeSettingsUpdateRequest

--- a/tests/unit/api/test_config.py
+++ b/tests/unit/api/test_config.py
@@ -15,6 +15,6 @@ def test_resolve_server_volume_name_defaults_to_persistent_volume() -> None:
 def test_resolve_server_volume_name_preserves_configured_volume() -> None:
     """Configured volume name should be preserved when set."""
     config = AppConfig(
-        interpreter={"volume_name": "custom-volume"},
+        volumes={"name": "custom-volume"},
     )
     assert resolve_server_volume_name(config) == "custom-volume"

--- a/tests/unit/api/test_runtime_settings.py
+++ b/tests/unit/api/test_runtime_settings.py
@@ -6,12 +6,18 @@ from pathlib import Path
 import pytest
 
 from fleet_rlm.integrations.config.runtime_settings import (
+    RUNTIME_SETTING_DEFINITIONS,
     RUNTIME_SETTINGS_ALLOWLIST,
+    RUNTIME_SETTINGS_KEYS,
     apply_env_updates,
     get_settings_snapshot,
     normalize_updates,
 )
 from tests.unit.fixtures_env import MASKED_SECRET_VALUES, clear_env, write_env_file
+
+
+def _snapshot_fields(snapshot: dict) -> dict[str, dict]:
+    return {field["key"]: field for category in snapshot["categories"] for field in category["fields"]}
 
 
 def test_get_settings_snapshot_masks_secrets(
@@ -29,10 +35,14 @@ def test_get_settings_snapshot_masks_secrets(
         extra_values={"DAYTONA_TARGET": "local"},
     )
 
-    assert snapshot["values"]["DSPY_LM_MODEL"] == "openai/gpt-4o-mini"
-    assert snapshot["values"]["DSPY_LLM_API_KEY"] != "sk-super-secret-key"
-    assert "..." in snapshot["values"]["DSPY_LLM_API_KEY"]
-    assert snapshot["values"]["DAYTONA_TARGET"] == "local"
+    fields = _snapshot_fields(snapshot)
+    assert [category["id"] for category in snapshot["categories"]] == ["llm", "api_keys", "sandbox_volumes"]
+    assert fields["DSPY_LM_MODEL"]["value"] == "openai/gpt-4o-mini"
+    assert fields["DSPY_LLM_API_KEY"]["value"] != "sk-super-secret-key"
+    assert fields["DSPY_LLM_API_KEY"]["masked_value"] == fields["DSPY_LLM_API_KEY"]["value"]
+    assert fields["DSPY_LLM_API_KEY"]["secret"] is True
+    assert "..." in fields["DSPY_LLM_API_KEY"]["value"]
+    assert fields["DAYTONA_TARGET"]["value"] == "local"
 
 
 def test_get_settings_snapshot_prefers_configured_env_file_values(
@@ -54,9 +64,53 @@ def test_get_settings_snapshot_prefers_configured_env_file_values(
         env_path=env_path,
     )
 
+    fields = _snapshot_fields(snapshot)
     assert snapshot["env_path"] == str(env_path)
-    assert snapshot["values"]["DSPY_LM_MODEL"] == "openai/gpt-4.1"
-    assert snapshot["values"]["DSPY_LLM_API_KEY"] != "sk-from-env"
+    assert fields["DSPY_LM_MODEL"]["value"] == "openai/gpt-4.1"
+    assert fields["DSPY_LLM_API_KEY"]["value"] != "sk-from-env"
+
+
+def test_get_settings_snapshot_includes_database_category(
+    tmp_path: Path,
+) -> None:
+    env_path = write_env_file(
+        tmp_path,
+        lines=[
+            "DATABASE_URL=postgresql://user:pass@example/db",
+            "DATABASE_REQUIRED=true",
+        ],
+    )
+
+    snapshot = get_settings_snapshot(
+        keys=["DATABASE_URL", "DATABASE_REQUIRED"],
+        env_path=env_path,
+    )
+
+    assert snapshot["categories"][0]["id"] == "database"
+    fields = _snapshot_fields(snapshot)
+    assert fields["DATABASE_URL"]["secret"] is True
+    assert fields["DATABASE_URL"]["value"] != "postgresql://user:pass@example/db"
+    assert fields["DATABASE_REQUIRED"]["value"] == "true"
+
+
+def test_default_settings_snapshot_includes_all_editable_metadata(tmp_path: Path) -> None:
+    env_path = write_env_file(tmp_path)
+
+    snapshot = get_settings_snapshot(keys=list(RUNTIME_SETTINGS_KEYS), env_path=env_path)
+    fields = _snapshot_fields(snapshot)
+
+    assert set(fields) == set(RUNTIME_SETTINGS_KEYS)
+    for definition in RUNTIME_SETTING_DEFINITIONS:
+        if not definition.editable:
+            continue
+        field = fields[definition.key]
+        assert field["label"] == definition.label
+        assert field["description"] == definition.description
+        assert field["secret"] is definition.secret
+        assert field["editable"] is definition.editable
+        assert field["reload_required"] is definition.reload_required
+        assert field["placeholder"] == definition.placeholder
+        assert field["default"] == definition.default
 
 
 def test_normalize_updates_enforces_allowlist() -> None:
@@ -65,6 +119,16 @@ def test_normalize_updates_enforces_allowlist() -> None:
             {"DSPY_LM_MODEL": "openai/gpt-4o-mini", "UNSUPPORTED_KEY": "value"},
             allowlist=RUNTIME_SETTINGS_ALLOWLIST,
         )
+
+
+def test_apply_runtime_settings_to_config_rejects_invalid_positive_int() -> None:
+    from fleet_rlm.api.config import ServerRuntimeConfig
+    from fleet_rlm.api.runtime_services.settings import apply_runtime_settings_to_config
+
+    config = ServerRuntimeConfig()
+
+    with pytest.raises(ValueError):
+        apply_runtime_settings_to_config(config=config, normalized={"TIMEOUT": "not-an-int"})
 
 
 def test_apply_env_updates_writes_dotenv_and_process_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/integrations/config/test_env_config.py
+++ b/tests/unit/integrations/config/test_env_config.py
@@ -32,6 +32,13 @@ class _FakeChatAdapter:
         self.kwargs = kwargs
 
 
+def _oc_env_default(value: object) -> str:
+    text = str(value)
+    if text.startswith("${oc.env:") and text.endswith("}"):
+        return text.rsplit(",", 1)[1][:-1]
+    return text
+
+
 def test_configure_planner_from_env_with_quotes(monkeypatch, tmp_path: Path):
     env_file = write_env_file(
         tmp_path,
@@ -129,6 +136,89 @@ def test_app_config_includes_rlm_settings():
     assert config.rlm_settings.max_depth == 3
 
 
+def test_app_config_syncs_categorized_runtime_sections():
+    """Categorized runtime sections should populate legacy CLI-compatible sections."""
+    from fleet_rlm.integrations.config.env import AppConfig
+
+    config = AppConfig(
+        llm={
+            "model": "openai/gpt-4.1",
+            "delegate_model": "openai/gpt-4.1-mini",
+            "delegate_small_model": "openai/gpt-4o-mini",
+            "max_tokens": 8192,
+            "delegate_max_tokens": 2048,
+            "api_base": "https://proxy.example/v1",
+            "adapter": "chat",
+            "adapter_use_native_function_calling": True,
+        },
+        sandbox={
+            "image": "python:3.13-slim-bookworm",
+            "timeout": 120,
+            "secret_name": "CUSTOM_SECRET",
+            "async_execute": False,
+        },
+        volumes={"name": "custom-volume"},
+        database={"url": "postgresql://runtime", "required": True},
+    )
+
+    assert config.agent.model == "openai/gpt-4.1"
+    assert config.agent.delegate_model == "openai/gpt-4.1-mini"
+    assert config.llm.delegate_small_model == "openai/gpt-4o-mini"
+    assert config.llm.max_tokens == 8192
+    assert config.agent.delegate_max_tokens == 2048
+    assert config.llm.api_base == "https://proxy.example/v1"
+    assert config.llm.adapter == "chat"
+    assert config.llm.adapter_use_native_function_calling is True
+    assert config.interpreter.timeout == 120
+    assert config.interpreter.secrets == ["CUSTOM_SECRET"]
+    assert config.interpreter.volume_name == "custom-volume"
+    assert config.interpreter.async_execute is False
+    assert config.database.url == "postgresql://runtime"
+    assert config.database.required is True
+
+
+def test_app_config_prefers_categorized_sections_over_legacy_sections():
+    """Categorized runtime sections should be authoritative when both schemas are present."""
+    from fleet_rlm.integrations.config.env import AppConfig
+
+    config = AppConfig(
+        llm={
+            "model": "openai/new-model",
+            "delegate_model": "openai/new-delegate",
+            "delegate_small_model": "openai/new-small",
+            "delegate_max_tokens": 4096,
+        },
+        agent={
+            "model": "openai/legacy-model",
+            "delegate_model": "openai/legacy-delegate",
+            "delegate_max_tokens": 1024,
+        },
+        sandbox={
+            "timeout": 321,
+            "secret_name": "NEW_SECRET",
+            "async_execute": False,
+        },
+        volumes={"name": "new-volume"},
+        interpreter={
+            "timeout": 111,
+            "secrets": ["LEGACY_SECRET"],
+            "volume_name": "legacy-volume",
+            "async_execute": True,
+        },
+    )
+
+    assert config.llm.model == "openai/new-model"
+    assert config.llm.delegate_model == "openai/new-delegate"
+    assert config.llm.delegate_small_model == "openai/new-small"
+    assert config.agent.model == "openai/new-model"
+    assert config.agent.delegate_model == "openai/new-delegate"
+    assert config.agent.delegate_max_tokens == 4096
+    assert config.interpreter.timeout == 321
+    assert config.interpreter.secrets == ["NEW_SECRET"]
+    assert config.interpreter.volume_name == "new-volume"
+    assert config.interpreter.async_execute is False
+
+
 def test_interpreter_config_async_execute_default():
     """InterpreterConfig should default async_execute to True."""
     from fleet_rlm.integrations.config.env import InterpreterConfig
@@ -143,7 +233,7 @@ def test_agent_config_guardrail_defaults():
 
     agent = AgentConfig()
     assert agent.max_iters == 60
-    assert agent.temperature == 1.0
+    assert agent.temperature == pytest.approx(1.0)
     assert agent.delegate_model is None
     assert agent.delegate_max_tokens == 64000
     assert agent.guardrail_mode == "off"
@@ -152,18 +242,21 @@ def test_agent_config_guardrail_defaults():
 
 def test_config_model_defaults_match_hydra_yaml():
     """Pydantic defaults should mirror Hydra defaults for shared runtime keys."""
-    from fleet_rlm.integrations.config.env import AgentConfig, RlmSettings
+    from fleet_rlm.integrations.config.env import LlmConfig, RlmSettings, SandboxConfig
 
     config_path = Path("src/fleet_rlm/integrations/config/config.yaml")
     raw = yaml.safe_load(config_path.read_text())
 
     assert isinstance(raw, dict)
-    agent_cfg = raw["agent"]
+    llm_cfg = raw["llm"]
+    sandbox_cfg = raw["sandbox"]
     rlm_cfg = raw["rlm_settings"]
 
-    assert AgentConfig().max_iters == agent_cfg["max_iters"]
-    assert AgentConfig().temperature == float(agent_cfg["temperature"])
-    assert AgentConfig().delegate_max_tokens == int(agent_cfg["delegate_max_tokens"])
+    assert LlmConfig().max_iters == llm_cfg["max_iters"]
+    assert LlmConfig().temperature == pytest.approx(float(llm_cfg["temperature"]))
+    assert LlmConfig().delegate_max_tokens == int(_oc_env_default(llm_cfg["delegate_max_tokens"]))
+    assert SandboxConfig().image == sandbox_cfg["image"]
+    assert SandboxConfig().secret_name == sandbox_cfg["secret_name"]
     assert RlmSettings().max_iters == rlm_cfg["max_iters"]
     assert RlmSettings().deep_max_iters == rlm_cfg["deep_max_iters"]
     assert RlmSettings().enable_adaptive_iters == bool(rlm_cfg["enable_adaptive_iters"])


### PR DESCRIPTION
## Summary

Migrates the runtime settings surface from a flat key list to a fully backend-driven schema where each setting carries rich metadata (category, label, description, placeholder, default, secret, reload_required). The frontend Settings surface now renders entirely from the schema the API returns — no hardcoded field lists.

## What changed

### Backend
- **`RuntimeSettingDefinition`** (`integrations/config/runtime_settings.py`) — extended with `category`, `category_label`, `category_description`, `label`, `description`, `placeholder`, `default`, `reload_required`; introduced `_CATEGORY_METADATA` table and `_definition()` factory to keep definitions DRY.
- **`integrations/config/env.py`** — filled in all setting definitions with human-readable labels, descriptions, and categories (`llm`, `api_keys`, `sandbox_volumes`, `database`).
- **`integrations/config/config.yaml`** — synced category metadata into the config layer.
- **`api/schemas/runtime.py`** — `RuntimeSettingSchema` now surfaces the full metadata fields from the definition.
- **`api/runtime_services/settings.py`** — service layer propagates new fields into the response payload.
- **`api/config.py`** — minor config plumbing updates.
- **`openapi.yaml`** + **`src/frontend/openapi/fleet-rlm.openapi.yaml`** — regenerated to reflect schema additions.

### Frontend
- **`use-runtime-settings.ts`** — consumes new schema fields; groups settings by category automatically.
- **`runtime-form.tsx`** — renders grouped sections driven by backend metadata; secret fields masked; reload-required fields flagged.
- **`litellm-form.tsx`** — minor alignment.
- **`runtime-status-panel.tsx`** — minor update.
- **`lib/data/mock/runtime.ts`** — mocks extended to match new schema shape.
- **`lib/rlm-api/generated/openapi.ts`** — regenerated.

### Tests
- Unit tests extended for `test_runtime_settings.py`, `test_env_config.py`, `test_config.py`, and all three frontend Settings test files to cover the new schema shape and grouping behaviour.

## Checklist
- [x] OpenAPI spec regenerated (`uv run python scripts/openapi_tools.py generate`)
- [x] Frontend types regenerated (`pnpm run api:sync`)
- [x] Backend unit tests updated
- [x] Frontend unit tests updated
- [x] AGENTS.md refreshed
