### PR TITLE
chore: prepare 0.5.31 release

### DIFF
--- a/.codex/agents/api-contract.toml
+++ b/.codex/agents/api-contract.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the fleet-rlm API contract specialist.
+
+Focus on OpenAPI-facing schemas, FastAPI route metadata, websocket frame shape, generated frontend API artifacts, and backend/frontend compatibility. Do not hand-edit generated API files. For schema changes, require uv run python scripts/openapi_tools.py generate, frontend api sync/check, and focused backend/frontend contract tests.
+"""

--- a/.codex/agents/backend-runtime.toml
+++ b/.codex/agents/backend-runtime.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the fleet-rlm backend runtime specialist.
+
+Focus on FastAPI transport, websocket lifecycle, Daytona-backed runtime construction, DSPy ReAct agent behavior, recursive RLM delegation, persistence, and observability. Read the root AGENTS.md and src/fleet_rlm/AGENTS.md first. Keep transport logic thin, keep runtime behavior in runtime/ or integrations/daytona/, and preserve the Daytona-only public contract. Prefer targeted unit tests before broader make lanes.
+"""

--- a/.codex/agents/daytona-runtime.toml
+++ b/.codex/agents/daytona-runtime.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the fleet-rlm Daytona runtime specialist.
+
+Focus on integrations/daytona, sandbox lifecycle, workspace runtime, volume runtime, child isolation, bridge callbacks, context staging, diagnostics, payload models, and session manifests. Preserve the Daytona SDK-first boundary and the recursive child policy documented in AGENTS.md. Use Daytona smoke diagnostics only when credentials and live runtime prerequisites are available.
+"""

--- a/.codex/agents/docs-maintainer.toml
+++ b/.codex/agents/docs-maintainer.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the fleet-rlm docs maintainer.
+
+Keep AGENTS.md, subsystem AGENTS.md files, PLANS.md, README.md, docs/SUMMARY.md, and how-to/reference docs aligned with live repo behavior. Prefer concise durable workflow guidance over chat-only knowledge. Validate docs links and AGENTS freshness after edits.
+"""

--- a/.codex/agents/frontend-ui.toml
+++ b/.codex/agents/frontend-ui.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the fleet-rlm frontend specialist.
+
+Focus on src/frontend: React 19, TanStack Router/Start, Vite+, Tailwind v4, shadcn/Base UI primitives, Agent Elements, workspace/volumes/settings/optimization/history surfaces, and generated API clients. Read root AGENTS.md and src/frontend/AGENTS.md first. Preserve supported surfaces and keep retired routes falling through to /404. Use semantic tokens and repo-owned product components.
+"""

--- a/.codex/agents/release-manager.toml
+++ b/.codex/agents/release-manager.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the fleet-rlm release manager.
+
+Focus on release hygiene, package metadata, version alignment, bundled frontend assets under src/fleet_rlm/ui/dist, wheel validation, docs freshness, generated artifacts, changelog/release notes, and the make release/build-release lanes. Keep release commands aligned with Makefile, pyproject.toml, setup.py, and docs/how-to-guides/releasing.md.
+"""

--- a/.codex/agents/security-reviewer.toml
+++ b/.codex/agents/security-reviewer.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "high"
+developer_instructions = """
+You are the fleet-rlm security reviewer.
+
+Audit only security-relevant risks. Prioritize JWT and Entra token validation, unverified claims, bearer-token exposure, auth dependencies, CORS/middleware behavior, tenant admission, settings protection, secrets, dependency/security tooling, and generated artifacts that could leak sensitive data. Report findings as severity, location, and issue; do not spend review budget on style.
+"""

--- a/.codex/agents/testing-strategist.toml
+++ b/.codex/agents/testing-strategist.toml
@@ -1,0 +1,6 @@
+model_reasoning_effort = "medium"
+developer_instructions = """
+You are the fleet-rlm testing strategist.
+
+Choose the smallest meaningful validation lane for the touched surface. Map backend logic to tests/unit or tests/integration, frontend logic to Vitest or Playwright, contract changes to OpenAPI sync/check, and release work to release hygiene/build lanes. Call out when live_llm, live_daytona, database, or benchmark coverage is intentionally excluded.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,48 @@
+[features]
+hooks = true
+multi_agent = true
+
+[agents]
+max_threads = 8
+max_depth = 1
+job_max_runtime_seconds = 3600
+
+[agents.backend-runtime]
+description = "FastAPI, websocket, Daytona-backed runtime, DSPy ReAct, and recursive RLM implementation work."
+config_file = "agents/backend-runtime.toml"
+nickname_candidates = ["Runtime", "Backend"]
+
+[agents.frontend-ui]
+description = "React 19, TanStack Router/Start, Vite+, Tailwind, shadcn/Base UI, and Agent Elements frontend work."
+config_file = "agents/frontend-ui.toml"
+nickname_candidates = ["Frontend", "UI"]
+
+[agents.api-contract]
+description = "OpenAPI schema, backend/frontend contract, generated API artifacts, and websocket payload review."
+config_file = "agents/api-contract.toml"
+nickname_candidates = ["Contract", "OpenAPI"]
+
+[agents.testing-strategist]
+description = "Chooses and audits the smallest meaningful validation lane for backend, frontend, integration, and release work."
+config_file = "agents/testing-strategist.toml"
+nickname_candidates = ["Tests", "Validation"]
+
+[agents.security-reviewer]
+description = "Focused auth, token, middleware, settings, dependency, and secret-handling security reviewer."
+config_file = "agents/security-reviewer.toml"
+nickname_candidates = ["Security", "Reviewer"]
+
+[agents.release-manager]
+description = "Release hygiene, packaging, bundled UI assets, metadata, docs, and publish readiness."
+config_file = "agents/release-manager.toml"
+nickname_candidates = ["Release", "Packager"]
+
+[agents.daytona-runtime]
+description = "Daytona SDK integration, sandbox lifecycle, volumes, child isolation, context staging, and runtime diagnostics."
+config_file = "agents/daytona-runtime.toml"
+nickname_candidates = ["Daytona", "Sandbox"]
+
+[agents.docs-maintainer]
+description = "AGENTS.md, PLANS.md, docs, README, and durable workflow documentation consistency."
+config_file = "agents/docs-maintainer.toml"
+nickname_candidates = ["Docs", "Maintainer"]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,4 @@
+approval_policy = "never"
 [features]
 hooks = true
 multi_agent = true

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,271 @@
+version = 1
+name = "fleet-rlm"
+
+[setup]
+script = ".codex/workspace-bootstrap.zsh"
+
+[[actions]]
+name = "Setup: Bootstrap Workspace"
+icon = "run"
+command = '''
+zsh .codex/workspace-bootstrap.zsh
+'''
+
+[[actions]]
+name = "App: Run Web UI + API"
+icon = "run"
+command = '''
+uv run fleet web
+'''
+
+[[actions]]
+name = "App: Serve API on 8000"
+icon = "run"
+command = '''
+uv run fleet-rlm serve-api --port 8000
+'''
+
+[[actions]]
+name = "App: Terminal Chat"
+icon = "run"
+command = '''
+uv run fleet-rlm chat --trace-mode compact
+'''
+
+[[actions]]
+name = "Backend: Format"
+icon = "check"
+command = '''
+make format
+'''
+
+[[actions]]
+name = "Backend: Format Check"
+icon = "check"
+command = '''
+make format-check
+'''
+
+[[actions]]
+name = "Backend: Lint"
+icon = "check"
+command = '''
+make lint
+'''
+
+[[actions]]
+name = "Backend: Typecheck"
+icon = "check"
+command = '''
+make typecheck
+'''
+
+[[actions]]
+name = "Backend: Test"
+icon = "test"
+command = '''
+make test
+'''
+
+[[actions]]
+name = "Backend: Unit Tests"
+icon = "test"
+command = '''
+make test-unit
+'''
+
+[[actions]]
+name = "Backend: Integration Tests"
+icon = "test"
+command = '''
+make test-integration
+'''
+
+[[actions]]
+name = "Repo: Quality Gate"
+icon = "check"
+command = '''
+make quality-gate
+'''
+
+[[actions]]
+name = "Repo: Release Hygiene"
+icon = "check"
+command = '''
+make check-release
+'''
+
+[[actions]]
+name = "Repo: Docs Check"
+icon = "docs"
+command = '''
+make check-docs
+'''
+
+[[actions]]
+name = "Repo: Codex Feedback Loop"
+icon = "check"
+command = '''
+uv run python scripts/codex_feedback_loop.py --profile safe
+'''
+
+[[actions]]
+name = "Repo: Security Check"
+icon = "shield"
+command = '''
+make check-security
+'''
+
+[[actions]]
+name = "Repo: Dependency Check"
+icon = "check"
+command = '''
+make check-deps
+'''
+
+[[actions]]
+name = "Repo: Clean"
+icon = "clean"
+command = '''
+make clean
+'''
+
+[[actions]]
+name = "OpenAPI: Check"
+icon = "check"
+command = '''
+make api-check
+'''
+
+[[actions]]
+name = "OpenAPI: Sync"
+icon = "sync"
+command = '''
+make api-sync
+'''
+
+[[actions]]
+name = "Frontend: Install"
+icon = "run"
+command = '''
+cd src/frontend
+pnpm install --frozen-lockfile
+'''
+
+[[actions]]
+name = "Frontend: Dev Server"
+icon = "run"
+command = '''
+cd src/frontend
+pnpm run dev
+'''
+
+[[actions]]
+name = "Frontend: Typecheck"
+icon = "check"
+command = '''
+cd src/frontend
+pnpm run type-check
+'''
+
+[[actions]]
+name = "Frontend: Lint"
+icon = "check"
+command = '''
+cd src/frontend
+pnpm run lint:robustness
+'''
+
+[[actions]]
+name = "Frontend: Unit Tests"
+icon = "test"
+command = '''
+cd src/frontend
+pnpm run test:unit
+'''
+
+[[actions]]
+name = "Frontend: Build"
+icon = "build"
+command = '''
+cd src/frontend
+pnpm run build
+'''
+
+[[actions]]
+name = "Frontend: E2E Tests"
+icon = "test"
+command = '''
+cd src/frontend
+pnpm run test:e2e
+'''
+
+[[actions]]
+name = "Frontend: Full Check"
+icon = "check"
+command = '''
+make check-frontend
+'''
+
+[[actions]]
+name = "Release: Build UI"
+icon = "build"
+command = '''
+make build-ui
+'''
+
+[[actions]]
+name = "Release: Build Artifacts"
+icon = "build"
+command = '''
+make build-release
+'''
+
+[[actions]]
+name = "Release: Full Release Check"
+icon = "check"
+command = '''
+make release-check
+'''
+
+[[actions]]
+name = "Runtime: Daytona Diagnostics"
+icon = "check"
+command = '''
+uv run python scripts/validate_env.py daytona --skip-smoke
+'''
+
+[[actions]]
+name = "Runtime: Daytona Smoke"
+icon = "test"
+command = '''
+uv run fleet-rlm daytona-smoke
+'''
+
+[[actions]]
+name = "Runtime: MLflow Server"
+icon = "run"
+command = '''
+make mlflow
+'''
+
+[[actions]]
+name = "Benchmarks: RLM Capabilities"
+icon = "test"
+command = '''
+uv run python scripts/evaluate_rlm_capabilities.py --benchmark all
+'''
+
+[[actions]]
+name = "Cloud: FastAPI Preflight"
+icon = "check"
+command = '''
+make cloud-preflight
+'''
+
+[[actions]]
+name = "CLI: Help"
+icon = "docs"
+command = '''
+make cli-help
+'''

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,42 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^(Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "zsh .codex/hooks/block-env-edit.zsh",
+            "timeout": 10,
+            "statusMessage": "Checking protected env files..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "zsh .codex/hooks/python-format.zsh",
+            "timeout": 60,
+            "statusMessage": "Formatting edited Python file..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "zsh .codex/hooks/generated-artifact-check.zsh",
+            "timeout": 30,
+            "statusMessage": "Checking generated artifact drift..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/block-env-edit.zsh
+++ b/.codex/hooks/block-env-edit.zsh
@@ -1,0 +1,45 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+payload="$(cat)"
+
+if command -v jq >/dev/null 2>&1; then
+  file_path="$(
+    printf '%s' "$payload" | jq -r '
+      .tool_input.file_path //
+      .tool_input.path //
+      .toolInput.file_path //
+      .toolInput.path //
+      empty
+    ' 2>/dev/null || true
+  )"
+elif command -v python3 >/dev/null 2>&1; then
+  file_path="$(
+    printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+
+for key in ("tool_input", "toolInput"):
+    value = data.get(key)
+    if isinstance(value, dict):
+        path = value.get("file_path") or value.get("path")
+        if path:
+            print(path)
+            break
+' 2>/dev/null || true
+  )"
+else
+  file_path=""
+fi
+
+if [[ "$file_path" == ".env" || "$file_path" == */.env ]]; then
+  printf '{"decision":"block","reason":"Direct edits to .env are blocked. Edit .env.example or document required variables instead."}\n'
+  exit 2
+fi
+
+exit 0

--- a/.codex/hooks/generated-artifact-check.zsh
+++ b/.codex/hooks/generated-artifact-check.zsh
@@ -1,0 +1,36 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+generated_paths=(
+  "openapi.yaml"
+  "src/frontend/openapi/fleet-rlm.openapi.yaml"
+  "src/frontend/src/lib/rlm-api/generated/openapi.ts"
+  "src/frontend/src/routeTree.gen.ts"
+  "src/frontend/dist"
+  "src/fleet_rlm/ui/dist"
+)
+
+dirty=()
+for path in "${generated_paths[@]}"; do
+  if git status --short -- "$path" 2>/dev/null | grep -q .; then
+    dirty+=("$path")
+  fi
+done
+
+if (( ${#dirty[@]} == 0 )); then
+  exit 0
+fi
+
+{
+  echo "Generated or synced artifacts changed:"
+  for path in "${dirty[@]}"; do
+    echo "  - $path"
+  done
+  echo ""
+  echo "Use the Codex actions or commands that own these artifacts:"
+  echo "  - OpenAPI: Sync / make api-sync"
+  echo "  - OpenAPI: Check / make api-check"
+  echo "  - Release: Build UI / make build-ui"
+} >&2
+
+exit 0

--- a/.codex/hooks/python-format.zsh
+++ b/.codex/hooks/python-format.zsh
@@ -1,0 +1,47 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+payload="$(cat)"
+
+if command -v jq >/dev/null 2>&1; then
+  file_path="$(
+    printf '%s' "$payload" | jq -r '
+      .tool_input.file_path //
+      .tool_input.path //
+      .toolInput.file_path //
+      .toolInput.path //
+      empty
+    ' 2>/dev/null || true
+  )"
+elif command -v python3 >/dev/null 2>&1; then
+  file_path="$(
+    printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+
+for key in ("tool_input", "toolInput"):
+    value = data.get(key)
+    if isinstance(value, dict):
+        path = value.get("file_path") or value.get("path")
+        if path:
+            print(path)
+            break
+' 2>/dev/null || true
+  )"
+else
+  file_path=""
+fi
+
+[[ -n "$file_path" ]] || exit 0
+[[ "$file_path" == *.py ]] || exit 0
+[[ -f "$file_path" ]] || exit 0
+
+uv run ruff format "$file_path" >/dev/null
+uv run ruff check --fix --quiet "$file_path" >/dev/null || true
+
+exit 0

--- a/.codex/hooks/python-format.zsh
+++ b/.codex/hooks/python-format.zsh
@@ -41,7 +41,7 @@ fi
 [[ "$file_path" == *.py ]] || exit 0
 [[ -f "$file_path" ]] || exit 0
 
-uv run ruff format "$file_path" >/dev/null
+uv run ruff format "$file_path" >/dev/null || true
 uv run ruff check --fix --quiet "$file_path" >/dev/null || true
 
 exit 0

--- a/.codex/workspace-bootstrap.zsh
+++ b/.codex/workspace-bootstrap.zsh
@@ -1,0 +1,32 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "ERROR: uv is required for fleet-rlm bootstrap." >&2
+  exit 1
+fi
+
+echo "==> fleet-rlm Codex bootstrap"
+echo "repo: $repo_root"
+echo "python: $(uv run python --version 2>&1)"
+
+if [[ -f uv.lock ]]; then
+  uv sync --all-extras --dev --frozen
+else
+  uv sync --all-extras --dev
+fi
+
+if [[ -f src/frontend/package.json ]]; then
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "ERROR: pnpm is required for src/frontend bootstrap." >&2
+    exit 1
+  fi
+  echo "==> Installing frontend dependencies"
+  (cd src/frontend && pnpm install --frozen-lockfile)
+fi
+
+echo "==> Bootstrap complete"
+echo "Use Codex actions for run, validation, OpenAPI sync, release, and diagnostics lanes."

--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,16 @@ src/frontend/.tmp-*.mjs
 # Agent/tooling state
 .claude/
 .agents/
-.codex/
+.codex/*
+!.codex/environments/
+!.codex/environments/environment.toml
+!.codex/workspace-bootstrap.zsh
+!.codex/config.toml
+!.codex/hooks.json
+!.codex/hooks/
+!.codex/hooks/*.zsh
+!.codex/agents/
+!.codex/agents/*.toml
 .letta/
 .opencode/
 .junie/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,325 +1,78 @@
-# Repository Agent Instructions
+# Repository Agent Map
 
-## Project Overview
+`fleet-rlm` is a Web UI-first adaptive recursive language model workspace built around a
+Daytona-backed DSPy ReAct agent runtime. The root guide is intentionally short: it tells agents
+where the durable rules live and which commands prove a change.
 
-`fleet-rlm` is a Web UI-first adaptive recursive language model workspace built around a Daytona-backed DSPy ReAct agent runtime. It layers a thin FastAPI/WebSocket transport shell over a single DSPy ReAct agent that executes tasks in Daytona sandboxes.
+## Operating Model
 
-The repo ships as a single Python package (`fleet-rlm`) with a bundled React frontend. Published installs include built frontend assets, so end users do not need a separate frontend build step.
+- Treat `docs/agent-harness/README.md` as the agent-first hub for this repository.
+- Use the closest applicable `AGENTS.md` before editing files; deeper guides override this map.
+- Keep repo docs, generated contracts, and `.codex/` actions aligned with implementation changes.
+- Prefer the smallest validation lane that covers the change, then escalate when contracts move.
+- Do not hand-edit generated or synced artifacts; use the commands listed below.
+- Do not mutate user-level Codex config. Repo-local automation belongs under `.codex/`.
+- Ask before deploy, push, commit, migrations, or deletion unless explicitly requested.
 
-Supported product surfaces:
+## Reading Path
 
-- `Workbench` — adaptive chat and runtime execution
-- `Volumes` — browser for mounted durable storage
-- `Optimization` — DSPy evaluation and optimization workflows
-- `Settings` — runtime configuration and diagnostics
-- `History` — session and conversation history browser
+1. `docs/agent-harness/README.md` - harness model, reading order, and quality bar.
+2. `docs/agent-harness/feedback-loop.md` - local Codex loop and report expectations.
+3. `docs/agent-harness/architecture-invariants.md` - backend, frontend, generated-file rules.
+4. `docs/agent-harness/drift-control.md` - checks that keep docs and contracts honest.
+5. `docs/agent-harness/quality-score.md` - current quality grade and cleanup targets.
+6. `docs/reference/codebase-map.md` - source layout and ownership map.
+7. `docs/how-to-guides/testing-strategy.md` - validation lanes by change type.
+8. `docs/how-to-guides/codex-environment.md` - `.codex` actions, hooks, and subagent roles.
 
-Retired `taxonomy`, `skills`, `memory`, and `analytics` routes are intentionally unsupported and should continue to fall through to `/404`.
+## Deeper Agent Guides
 
-## Technology Stack
+- `src/fleet_rlm/AGENTS.md` - backend, runtime, API, persistence, Daytona, and package rules.
+- `src/frontend/AGENTS.md` - React, TanStack Router, Vite+, styling, and frontend checks.
 
-### Backend
-
-- **Language**: Python >= 3.11 (3.11, 3.12, 3.13 supported)
-- **Package manager**: `uv`
-- **Web framework**: FastAPI 0.136.1 with WebSocket support
-- **Runtime core**: DSPy 3.2.1 + recursive ReAct / `dspy.RLM` workbench agent
-- **Sandbox provider**: Daytona (only supported runtime substrate)
-- **Persistence**: SQLModel + SQLAlchemy with asyncpg/psycopg; SQLite sidecar for local sessions
-- **Auth**: `dev` mode or Entra (Azure AD) bearer-token validation
-- **Observability**: PostHog, MLflow
-- **CLI**: Typer + argparse (`fleet` and `fleet-rlm` entrypoints)
-
-### Frontend
-
-- **Framework**: React 19 + TypeScript 5.9+
-- **Router**: TanStack Router (file-based routes)
-- **State**: Zustand + TanStack Query
-- **Build tool**: Vite+ (`vp` CLI) — not plain Vite
-- **Package manager**: `pnpm` 10.33.0 (explicitly required; do not use `bun`)
-- **Styling**: Tailwind CSS v4 + `tw-animate-css` + shadcn/Base UI primitives
-- **Testing**: Vitest (unit), Playwright (e2e)
-- **Markdown rendering**: `streamdown` + Shiki
-
-## Architecture and Code Organization
-
-The backend is organized into two layers, innermost first:
-
-1. **DSPy ReAct Agent** — single agent with tool registry
-   - `src/fleet_rlm/runtime/agent/` — agent module (`agent.py`), runtime (`runtime.py`), chat orchestration (`chat.py`), session state, signatures
-   - `src/fleet_rlm/runtime/execution/` — execution drivers and event assembly
-  - `src/fleet_rlm/runtime/modules/` — runtime module construction and registry
-   - `src/fleet_rlm/runtime/content/` — content-oriented helpers
-   - `src/fleet_rlm/runtime/tools/` — grouped tool helpers (content, sandbox, filesystem, batch, LLM)
-   - `src/fleet_rlm/quality/` — offline DSPy evaluation, GEPA optimization, datasets, scoring, module registry
-
-2. **Daytona Substrate** — sandbox and durable storage
-   - `src/fleet_rlm/integrations/daytona/` — interpreter lifecycle, runtime, volumes, diagnostics
-   - `src/fleet_rlm/integrations/database/` — async Neon/Postgres persistence (`FleetRepository`)
-   - `src/fleet_rlm/integrations/local_store.py` — lightweight SQLite sidecar
-
-3. **Transport Shell** — auth, routing, websockets, SPA serving
-   - `src/fleet_rlm/api/main.py` — app factory, lifespan, route mounting, SPA asset resolution
-   - `src/fleet_rlm/api/bootstrap.py` — runtime bootstrap, LM loading, persistence init
-   - `src/fleet_rlm/api/routers/` — HTTP routers and websocket endpoints
-   - `src/fleet_rlm/api/runtime_services/` — thin orchestration for chat runtime, persistence, diagnostics, settings, volumes
-   - `src/fleet_rlm/api/events/` — execution event shaping
-   - `src/fleet_rlm/api/schemas/` — request/response schemas
-   - `src/fleet_rlm/api/auth/` — auth derivatives for HTTP and websocket identity
-
-Other backend areas:
-
-- `src/fleet_rlm/cli/` — `fleet` and `fleet-rlm` CLI entrypoints, commands, terminal UI
-- `src/fleet_rlm/integrations/observability/` — PostHog and MLflow wiring
-- `src/fleet_rlm/utils/` — shared helpers
-- `src/fleet_rlm/ui/dist` — **generated** bundled frontend assets for Python package distributions
-
-Evaluation and benchmarks (maintained alongside the backend):
-
-- `scripts/evaluate_rlm_capabilities.py` — unified harness that runs the S-NIAH, OOLONG, and workspace benchmarks against real Daytona + LLM infrastructure (`--benchmark {sniah, oolong, workspace, all}`)
-- `scripts/oolong_official_eval.py` — adapter plugging fleet-rlm's RLM stack into the official `primeintellect/oolong-rlm` HuggingFace dataset and `_synth_score()` rubric; ports DSPy v3 None-safety patches locally (does not modify the venv)
-- `scripts/benchmarks/sniah.py`, `scripts/benchmarks/oolong.py` — synthetic dataset generators + scoring helpers
-- `scripts/consolidate_rlm_results.py` — aggregates per-benchmark summary JSONs and writes a generated `RESULTS.md` under the evaluation output directory when the evaluation workflow is run
-- `oolong_rlm/` — **vendored** snapshot of `primeintellect/oolong-rlm` v0.1.9 pulled via `prime env pull` (reference only; do not import at runtime — the venv's `verifiers` stack has incompatible transitive deps)
-- Generated evaluation artifacts are written into the runtime evaluation output directory (for example per-benchmark `{results,summary}.json` files and a consolidated `RESULTS.md`); these outputs are produced by benchmark runs and may not exist in a fresh checkout
-- `docs/explanation/rlm-capability-evaluation.md` — methodology and paper comparison
-
-Frontend organization:
-
-- `src/frontend/src/routes/` — file-based route definitions
-- `src/frontend/src/features/layout/` — app chrome, root layout
-- `src/frontend/src/features/workspace/` — workbench surface (screen, conversation, composer, inspection, workbench, session)
-- `src/frontend/src/features/volumes/` — volumes surface
-- `src/frontend/src/features/settings/` — settings surface
-- `src/frontend/src/features/optimization/` — optimization surface
-- `src/frontend/src/components/ui/` — shadcn/Base UI primitives
-- `src/frontend/src/components/ai-elements/` — AI Elements registry components
-- `src/frontend/src/components/product/` — reusable product compositions
-- `src/frontend/src/lib/rlm-api/` — REST/websocket clients and generated OpenAPI types
-- `src/frontend/src/lib/workspace/` — backend event adapters, chat stores, frame shaping
-- `src/frontend/src/stores/` — cross-app shell/layout and navigation state
-- `src/frontend/src/styles/globals.css` — Tailwind v4 theme baseline and tokens
-
-## Build and Test Commands
-
-### Repository setup
+## Setup
 
 ```bash
-uv sync --all-extras          # install Python deps with all extras
-uv sync --extra dev           # install with dev extras only
+# from repo root
+uv sync --all-extras --dev
+cd src/frontend && pnpm install --frozen-lockfile
 ```
 
-### Running the application
+```bash
+# from repo root
+zsh .codex/workspace-bootstrap.zsh
+```
+
+## Run
 
 ```bash
-uv run fleet web              # start Web UI + API server (delegates to fleet-rlm serve-api)
+# from repo root
+uv run fleet web
 uv run fleet-rlm serve-api --port 8000
 uv run fleet-rlm chat --trace-mode compact
 ```
 
-### Backend validation
-
 ```bash
-make format                   # ruff format src tests
-make format-check             # ruff format --check
-make lint                     # ruff check
-make typecheck                # ty check src
-make test                     # pytest excluding live_llm and benchmark
-make test-unit                # unit tests only
-make test-integration         # integration + e2e tests
-make check                    # lint + format-check + typecheck + test + check-release + check-docs + check-frontend
-make quality-gate             # alias for make check
-make check-release            # release hygiene, metadata, and AGENTS.md freshness
-make check-docs               # docs quality checks
-make check-security           # pip-audit + bandit
-make check-deps               # deptry (backend) + knip (frontend)
-make clean                    # remove caches and local artifacts
+# from src/frontend
+pnpm run dev
 ```
 
-### Frontend validation (from `src/frontend/`)
+## Validation
 
 ```bash
-pnpm install --frozen-lockfile
-pnpm run dev                  # start Vite+ dev server (proxies /api/v1 to localhost:8000)
-pnpm run build                # production build
-pnpm run type-check           # tsc --noEmit
-pnpm run lint                 # vp lint
-pnpm run lint:robustness      # alias for lint
-pnpm run format               # vp fmt
-pnpm run format:check         # vp fmt --check
-pnpm run test:unit            # vitest run
-pnpm run test:watch           # vitest
-pnpm run test:coverage        # vitest run --coverage
-pnpm run test:e2e             # playwright test
-pnpm run api:sync             # sync openapi spec + regenerate types
-pnpm run api:check            # verify frontend OpenAPI artifacts are in sync
-pnpm run check                # type-check + lint + test:unit + build + test:e2e
-```
-
-### Release
-
-```bash
-make build-ui                 # build frontend and sync to src/fleet_rlm/ui/dist
-make build-release            # build-ui + build Python wheels + validate
-make release                  # clean + check + security + build-release
-```
-
-## Code Style Guidelines
-
-### Python
-
-- **Formatter / Linter**: `ruff` (enforced in CI and pre-commit)
-- **Type checker**: `ty` (not mypy)
-- **Docstrings**: required for modules and public functions
-- **Type hints**: required on all function signatures
-- **Import rules**: config/package-root modules must not have import-time side effects (no DSPy, provider SDKs, MLflow runtime helpers, or PostHog callbacks at import time)
-- **Layering**: keep transport logic in `api/`, business logic in `runtime/` or `src/fleet_rlm/integrations/daytona/`
-- **Conventional commits**: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
-
-### Frontend
-
-- **Formatter / Linter**: Vite+ built-in (`vp lint` / `vp fmt`) with oxc, typescript, unicorn, react plugins
-- **Naming**: `kebab-case` for new handwritten feature files; `PascalCase` for React components; `useThing` for hooks
-- **Ref passing**: prefer React 19 direct ref passing over `forwardRef`
-- **Styling**: use Tailwind semantic tokens and shared variants; avoid arbitrary colors or local token layers
-- **Import boundaries** (enforced by lint rules):
-  - `src/components/ui/*`, `src/components/ai-elements/*`, `src/components/product/*` must not import from `src/screens/*`
-  - `src/lib/workspace/*` must not depend on workspace UI modules
-  - `src/features/layout/*` must import workspace/volumes through top-level feature contracts only
-- **Canonical `cn()` import path**: `@/lib/utils`
-
-## Testing Instructions
-
-### Backend
-
-- **Framework**: `pytest` with `pytest-asyncio` and `pytest-timeout`
-- **Test directories**:
-  - `tests/unit/` — unit tests
-  - `tests/integration/` — integration tests
-  - `tests/e2e/` — backend e2e tests
-- **Markers**:
-  - `unit` — unit test suite
-  - `integration` — integration test suite
-  - `db` — database-backed integration tests
-  - `e2e` — end-to-end test suite
-  - `benchmark` — performance tests
-  - `live_llm` — requires a live configured LM / LiteLLM backend
-  - `live_daytona` — requires a live Daytona backend and explicit opt-in
-- **Fast lane** (default): excludes `live_llm` and `benchmark`
-- **Coverage target**: >80% on new features
-
-### Frontend
-
-- **Unit**: Vitest with jsdom environment; tests live in `src/**/__tests__/` or as `*.test.{ts,tsx}`
-- **E2E**: Playwright with Chromium; tests live in `tests/e2e/`
-- **Coverage thresholds** (v8 provider):
-  - lines: 60%, functions: 60%, branches: 50%, statements: 60%
-- **Exclusions from coverage**: `main.tsx`, `*.d.ts`, `test/`, `__tests__/`, generated OpenAPI types, shadcn primitives
-
-### CI
-
-GitHub Actions runs on push to `main`/`master` and on PRs:
-
-1. **Quality** — release hygiene, docs quality, AGENTS.md freshness, security (pip-audit + bandit), deptry, ruff, ty
-2. **Test Unit** — pytest unit tests (non-live, 120s timeout)
-3. **Test Integration** — pytest integration + e2e (non-live)
-4. **Frontend Check** — pnpm install, knip, Vite+ check, vitest, build
-
-## Security Considerations
-
-- **Supported versions**: 0.4.x and later
-- **Vulnerability reporting**: email `contact@qredence.ai` — do **not** open public GitHub issues for security vulnerabilities
-- **Static analysis**:
-  - `bandit` runs on `src/fleet_rlm` (excluding `tests`)
-  - `pip-audit` scans for known vulnerabilities (currently ignores GHSA-5239-wwwm-4pmq until Pygments patches it, CVE-2026-3219 from the transient `uvx pip-audit` runtime, and CVE-2025-69872 until DiskCache/DSPy has a patched path)
-- **Auth modes**:
-  - `dev` — permissive local development mode
-  - `entra` — real Entra bearer-token validation plus Neon-backed tenant admission
-- **Settings protection**: `PATCH /api/v1/runtime/settings` is blocked unless `APP_ENV=local`
-- **Secrets**: use `.env` for local development (never commit it); in production use the deployment platform's secret manager or equivalent
-
-## Generated and Synced Artifacts
-
-Do **not** hand-edit the following files:
-
-- `openapi.yaml` — generated from backend route/schema metadata via `uv run python scripts/openapi_tools.py generate`
-- `src/frontend/src/lib/rlm-api/generated/openapi.ts` — generated from OpenAPI spec
-- `src/frontend/openapi/fleet-rlm.openapi.yaml` — synced frontend snapshot of the root spec
-- `src/frontend/src/routeTree.gen.ts` — generated by TanStack Router
-- `src/frontend/dist` — built frontend output
-- `src/fleet_rlm/ui/dist` — packaged UI assets copied from frontend build
-
-When backend request/response shapes or OpenAPI-facing metadata change:
-
-1. Regenerate root spec: `uv run python scripts/openapi_tools.py generate`
-2. Sync frontend artifacts: `cd src/frontend && pnpm run api:sync`
-3. Verify no drift: `pnpm run api:check`
-
-## Script Support Boundary
-
-- `scripts/README.md` is the canonical inventory of retained helper scripts.
-- Keep common daily workflows on `make`, `fleet`, and `fleet-rlm` instead of adding wrapper scripts.
-- Retained Python helpers must support `uv run python scripts/<name>.py --help` without performing work.
-- If a helper is not tied to current code, tests, CI, docs, or `scripts/README.md`, delete it instead of preserving it as historical drift.
-
-## Runtime Contract
-
-The shared backend/frontend runtime contract is **Daytona-only**:
-
-- `execution_mode` is a per-turn execution hint.
-- Daytona request controls: `repo_url`, `repo_ref`, `context_paths`, `batch_concurrency`
-- Durable mounted-volume roots: `memory/`, `artifacts/`, `buffers/`, `meta/`
-- Recursive RLM children are isolated by backend policy: `RLM_CHILD_ISOLATION_MODE=auto` forks no-volume parents and uses clean child sandboxes with `meta/rlm-children/...` volume subpaths for volume-mounted parents; `context` is a local/debug opt-out only.
-- `RLM_CHILD_FORK_FALLBACK=clean|fail` controls no-volume fork failure behavior; child sandboxes are deleted after each recursive task and child artifacts are not promoted automatically.
-- Bridged `llm_query*` callbacks share `rlm_max_llm_calls` across recursive child interpreters; sandbox `sub_rlm()` / `sub_rlm_batched()` callbacks dispatch through the Daytona bridge.
-- Local host-checkout codebase delegation without `repo_url` stages a bounded evidence snapshot into the isolated child sandbox at `artifacts/rlm-inputs/local_workspace_snapshot.txt`.
-- Session manifests on durable storage: `meta/workspaces/<workspace_id>/users/<user_id>/react-session-<session_id>.json`; manifest `state` restores history, core memory, loaded document paths, and Daytona interpreter state.
-- Daytona idle lifecycle timers: `auto_stop_interval=30` (minutes), `auto_archive_interval=60` (minutes)
-
-Canonical websocket surfaces:
-
-- `/api/v1/ws/execution` — conversational websocket stream (auth + frames; rejects query `session_id`)
-- `/api/v1/ws/execution/events` — passive execution/workbench event stream (requires query `session_id`; no message/command frames)
-
-Canonical HTTP surfaces (non-exhaustive):
-
-- `/health`, `/ready`
-- `GET /api/v1/auth/me`
-- `GET /api/v1/sessions/*` — session CRUD, turns, stats, restore, and export
-- `GET/PATCH /api/v1/runtime/settings`
-- `POST /api/v1/runtime/tests/daytona`, `POST /api/v1/runtime/tests/lm`
-- `GET /api/v1/runtime/status`, `GET /api/v1/runtime/volume/*`
-- `GET /api/v1/memory` — list memory items
-- `GET /api/v1/sandboxes/*` — sandbox list, detail, delete, archive
-- `GET/POST /api/v1/optimization/*` — optimization status, runs, datasets, modules, results, compare
-- `POST /api/v1/traces/feedback`
-
-## Validation by Change Type
-
-Choose the smallest lane that matches your change, then escalate if it crosses contracts.
-
-### Backend or shared Python edits
-
-Mandatory baseline:
-
-```bash
-make format
+# from repo root
+make format-check
 make lint
 make typecheck
-```
-
-Full confidence:
-
-```bash
 make test
-make check
+make check-docs
+make quality-gate
 ```
 
-### Frontend-only edits
+Frontend-only lane:
 
 ```bash
-cd src/frontend
-pnpm install --frozen-lockfile
+# from src/frontend
 pnpm run api:check
 pnpm run type-check
 pnpm run lint:robustness
@@ -327,56 +80,46 @@ pnpm run test:unit
 pnpm run build
 ```
 
-Full confidence:
+## Generated Artifacts
+
+Do not hand-edit these files:
+
+- `openapi.yaml`
+- `src/frontend/src/lib/rlm-api/generated/openapi.ts`
+- `src/frontend/openapi/fleet-rlm.openapi.yaml`
+- `src/frontend/src/routeTree.gen.ts`
+- `src/frontend/dist`
+- `src/fleet_rlm/ui/dist`
+
+Use these commands instead:
 
 ```bash
-pnpm run check
+# from repo root
+make api-sync
+make api-check
+make build-ui
 ```
 
-### Backend or shared contract changes
+## Drift Checks
+
+Run the harness lane when docs, commands, Codex config, generated contracts, or script inventory
+change:
 
 ```bash
-make test
-make check
+# from repo root
+uv run python scripts/check_harness_engineering.py
+uv run python scripts/check_agents_md_freshness.py
+uv run python scripts/check_docs_quality.py
 ```
 
-Database connection rule:
-
-- `DATABASE_URL` is the pooled Neon runtime connection.
-- `DATABASE_ADMIN_URL` is the direct Neon connection for Alembic, schema management, and admin/debug scripts.
-
-### Release-oriented confidence
-
-```bash
-make build-release
-make release
-```
+`make check-docs` runs the docs and harness checks together.
 
 ## Maintenance Checklist
 
-When updating this repository, keep these aligned:
+When changing workflow, contracts, or architecture, update the durable docs before finishing:
 
-- `AGENTS.md`, subsystem AGENTS files (`src/fleet_rlm/AGENTS.md`, `src/frontend/AGENTS.md`), and relevant durable docs in `docs/`
-- `Makefile`, `pyproject.toml`, and `src/frontend/package.json`
-- `openapi.yaml` and generated frontend API artifacts
-- Supported route surfaces and Daytona-only runtime behavior across backend and frontend
-
-## Reading Order for Agents
-
-Before making changes, read in this order:
-
-1. This root `AGENTS.md` for repo-wide workflow and contract rules
-2. `src/fleet_rlm/AGENTS.md` for backend/runtime work
-3. `src/frontend/AGENTS.md` for frontend/UI work
-
-When instructions conflict, the closest `AGENTS.md` to the files you are editing wins.
-
-Backend reading order for understanding the runtime story:
-
-1. `src/fleet_rlm/api/main.py`
-2. `src/fleet_rlm/api/routers/ws/endpoint.py`
-3. `src/fleet_rlm/runtime/factory.py`
-4. `src/fleet_rlm/runtime/agent/agent.py`
-5. `src/fleet_rlm/runtime/agent/runtime.py`
-6. `src/fleet_rlm/integrations/daytona/interpreter.py`
-7. `src/fleet_rlm/integrations/daytona/runtime.py`
+- `AGENTS.md` and subsystem `AGENTS.md` files.
+- `docs/agent-harness/*`.
+- `docs/README.md`, `docs/index.md`, and `docs/SUMMARY.md`.
+- `scripts/README.md`, `Makefile`, `pyproject.toml`, and `src/frontend/package.json` when commands move.
+- `openapi.yaml` and frontend API artifacts when backend request or response shapes move.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+## [0.5.31] - 2026-05-17
+
+### Added
+
+- **Change:** Added a repo-local Codex focus pack with grouped environment
+  actions, bootstrap wiring, hooks, and focused subagent roles.
+  **Outcome:** Codex can bootstrap the workspace, run practical repo commands,
+  block direct `.env` edits, auto-format edited Python files, and surface
+  generated-artifact drift without relying on user-level configuration.
+- **Change:** Adopted a harness engineering documentation hub with a compact
+  root `AGENTS.md`, local feedback-loop guide, architecture invariants, quality
+  score, and drift-control guide.
+  **Outcome:** Agent instructions now point to durable docs while keeping the
+  repo operating model easier to scan and mechanically validate.
+- **Change:** Added harness engineering checks and a safe local Codex feedback
+  loop script.
+  **Outcome:** Docs, `.codex` config, script inventory, generated-artifact
+  controls, and structural boundaries are now checked by local commands and
+  `make check-docs`.
+
+### Changed
+
+- **Change:** Bumped package, OpenAPI, generated frontend API, and documentation
+  release metadata to `0.5.31`.
+  **Outcome:** Runtime health metadata, generated contracts, package metadata,
+  and release docs agree on the release being prepared.
+
 ## [0.5.3] - 2026-05-16
 
 ### Highlights (User Impact)
@@ -1001,6 +1028,7 @@ All notable changes to this project are documented in this file.
 - Removed checked-in `__pycache__` directories under `src/fleet_rlm/`.
 - Moved non-runtime memory-topology notes out of package source and into docs.
 
+[0.5.31]: https://github.com/Qredence/fleet-rlm/compare/v0.5.3...v0.5.31
 [0.5.3]: https://github.com/Qredence/fleet-rlm/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Qredence/fleet-rlm/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Qredence/fleet-rlm/compare/v0.5.0...v0.5.1

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo "Quality:"
 	@echo "  make check            - Run the primary repo quality gate"
 	@echo "  make check-release    - Run release metadata/hygiene and AGENTS.md validation"
-	@echo "  make check-docs       - Run docs quality checks"
+	@echo "  make check-docs       - Run docs quality and harness engineering checks"
 	@echo "  make check-duplicates - Detect duplicate handwritten source blocks with jscpd (requires frontend pnpm install)"
 	@echo "  make check-security   - Run pip-audit + bandit"
 	@echo "  make check-deps       - Check for unused dependencies (deptry, knip)"
@@ -112,6 +112,7 @@ check-release:
 
 check-docs:
 	uv run python scripts/check_docs_quality.py
+	uv run python scripts/check_harness_engineering.py
 
 check-duplicates:
 	./scripts/run_duplicate_check.zsh

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ Then open `http://localhost:8000`.
 - [Optimization Page Spec](specs/optimization-page.md)
 - [Wiring Analysis](explanation/wiring-analysis.md)
 - [Runtime Settings](how-to-guides/runtime-settings.md)
+- [Codex Local Environment](how-to-guides/codex-environment.md)
+- [Agent Harness](agent-harness/README.md)
 - [Deploying the API Server](how-to-guides/deploying-server.md)
 - [Frontend/Backend Integration](reference/frontend-backend-integration.md)
 
@@ -54,6 +56,7 @@ Then open `http://localhost:8000`.
 ## Understand the System
 
 - [Architecture overview](architecture.md)
+- [Agent Harness](agent-harness/README.md)
 - [Concepts](explanation/concepts.md)
 - [User interaction flows](explanation/user-flows.md)
 - [Component UML](explanation/component-uml.md)
@@ -65,6 +68,7 @@ Then open `http://localhost:8000`.
 - [Reference](reference/index.md)
 - [Explanation](explanation/index.md)
 - [Complete table of contents](SUMMARY.md)
+- [Agent Harness](agent-harness/README.md)
 
 ## Source of Truth
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,14 +3,6 @@
 * [Documentation Home](index.md)
 * [fleet-rlm Documentation](README.md)
 
-## Agent Harness
-
-* [Agent Harness](agent-harness/README.md)
-  * [Local Codex Feedback Loop](agent-harness/feedback-loop.md)
-  * [Architecture Invariants](agent-harness/architecture-invariants.md)
-  * [Harness Quality Score](agent-harness/quality-score.md)
-  * [Drift Control](agent-harness/drift-control.md)
-
 ## Tutorials
 
 * [Tutorials](tutorials/index.md)
@@ -44,6 +36,14 @@
   * [Component UML](explanation/component-uml.md)
   * [Frontend Product Surface Guide](explanation/frontend-product-surface.md)
   * [Wiring Analysis](explanation/wiring-analysis.md)
+
+## Agent Harness
+
+* [Agent Harness](agent-harness/README.md)
+  * [Local Codex Feedback Loop](agent-harness/feedback-loop.md)
+  * [Architecture Invariants](agent-harness/architecture-invariants.md)
+  * [Harness Quality Score](agent-harness/quality-score.md)
+  * [Drift Control](agent-harness/drift-control.md)
 
 ## Specs
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,6 +3,14 @@
 * [Documentation Home](index.md)
 * [fleet-rlm Documentation](README.md)
 
+## Agent Harness
+
+* [Agent Harness](agent-harness/README.md)
+  * [Local Codex Feedback Loop](agent-harness/feedback-loop.md)
+  * [Architecture Invariants](agent-harness/architecture-invariants.md)
+  * [Harness Quality Score](agent-harness/quality-score.md)
+  * [Drift Control](agent-harness/drift-control.md)
+
 ## Tutorials
 
 * [Tutorials](tutorials/index.md)
@@ -15,6 +23,7 @@
 * [How-to Guides](how-to-guides/index.md)
   * [Installation Guide](how-to-guides/installation.md)
   * [Developer Setup](how-to-guides/developer-setup.md)
+  * [Codex Local Environment](how-to-guides/codex-environment.md)
   * [Frontend Development](how-to-guides/frontend-development.md)
   * [Testing Strategy](how-to-guides/testing-strategy.md)
   * [Runtime Setup from Frontend Settings](how-to-guides/runtime-settings.md)

--- a/docs/agent-harness/README.md
+++ b/docs/agent-harness/README.md
@@ -1,0 +1,44 @@
+# Agent Harness
+
+This directory is the repo-local harness engineering hub for `fleet-rlm`. It adopts the strict
+model from OpenAI's harness engineering guidance: short root instructions, durable docs as the
+system of record, a complete local feedback loop, and mechanical drift checks.
+
+The current retrofit baseline is strong. The harness audit scored the repo at `95/100`; this work
+keeps the existing structure and tightens the remaining control surfaces rather than replacing the
+project with a scaffold.
+
+## Agent Reading Path
+
+Start here when a task spans more than one file:
+
+1. `AGENTS.md` - root table of contents and command map.
+2. `docs/agent-harness/feedback-loop.md` - local Codex loop for bootstrap, app smoke, validation,
+   trace capture, and final reporting.
+3. `docs/agent-harness/architecture-invariants.md` - boundaries that should not drift.
+4. `docs/agent-harness/drift-control.md` - checks that enforce the docs and generated contracts.
+5. `docs/reference/codebase-map.md` - source layout and owners.
+6. `src/fleet_rlm/AGENTS.md` or `src/frontend/AGENTS.md` for subsystem work.
+
+## Harness Contract
+
+- The root `AGENTS.md` stays under the agreed line budget and links to durable docs.
+- `.codex/` is the local Codex surface for actions, hooks, environment bootstrap, and subagent
+  roles.
+- Generated files are only changed by sync/build commands.
+- Script inventory is authoritative: retained top-level Python helper scripts are listed in
+  `scripts/README.md` and support `--help`.
+- Architecture boundaries are checked with targeted structural rules before broad manual review.
+
+## Local First
+
+The first complete feedback loop is local Codex, not CI. A useful local run proves:
+
+- dependencies can bootstrap,
+- the API/UI can be started or a running instance can be inspected,
+- at least one Workbench path and one secondary surface can be smoke-tested,
+- MLflow/runtime identifiers are captured when available,
+- the smallest relevant validation lane passes,
+- the final report names commands, outputs, and any unverified live surfaces.
+
+Use `docs/agent-harness/feedback-loop.md` for the exact lane.

--- a/docs/agent-harness/architecture-invariants.md
+++ b/docs/agent-harness/architecture-invariants.md
@@ -1,0 +1,85 @@
+# Architecture Invariants
+
+These rules are the fast path for agent review. If a change violates one of them, either remediate
+the code or update this document and the matching checks in the same patch.
+
+## Backend Layers
+
+Keep the backend layered from transport to runtime to substrate:
+
+- `src/fleet_rlm/api/` owns FastAPI app assembly, auth, HTTP routers, websocket endpoints, runtime
+  services, and SPA serving.
+- `src/fleet_rlm/runtime/` owns the DSPy ReAct agent, chat orchestration, execution event assembly,
+  tool registry, session state, and module construction.
+- `src/fleet_rlm/integrations/daytona/` owns Daytona interpreter lifecycle, sandbox execution,
+  volumes, diagnostics, and substrate-specific cleanup.
+- `src/fleet_rlm/integrations/database/` and `src/fleet_rlm/integrations/local_store.py` own
+  persistence.
+- `src/fleet_rlm/quality/` owns offline DSPy evaluation and optimization machinery.
+
+Transport code may call runtime services and schemas. Runtime code should not import frontend,
+FastAPI route modules, or test-only helpers. Configuration/package-root modules must not pull in
+heavy runtime providers such as DSPy, MLflow, PostHog, or Daytona at import time.
+
+## Frontend Boundaries
+
+Keep shared UI primitives reusable:
+
+- `src/frontend/src/components/ui/*`, `components/ai-elements/*`, and `components/product/*` must
+  not import from route files or feature implementation modules.
+- `src/frontend/src/lib/workspace/*` must stay UI-independent.
+- `src/frontend/src/features/layout/*` should import product surfaces through feature contracts
+  rather than reaching into deep implementation files.
+- New handwritten feature files use `kebab-case`; React components use `PascalCase`.
+- Use the canonical `cn()` import path: `@/lib/utils`.
+
+## Generated And Synced Artifacts
+
+Do not hand-edit:
+
+- `openapi.yaml`
+- `src/frontend/src/lib/rlm-api/generated/openapi.ts`
+- `src/frontend/openapi/fleet-rlm.openapi.yaml`
+- `src/frontend/src/routeTree.gen.ts`
+- `src/frontend/dist`
+- `src/fleet_rlm/ui/dist`
+
+Use these commands:
+
+```bash
+# from repo root
+make api-sync
+make api-check
+make build-ui
+```
+
+Backend API shape changes require:
+
+```bash
+# from repo root
+uv run python scripts/openapi_tools.py generate
+make api-sync
+make api-check
+```
+
+## Script Boundary
+
+`scripts/README.md` is the retained helper inventory. Top-level Python scripts under `scripts/`
+must be listed there and support:
+
+```bash
+# from repo root
+uv run python scripts/<name>.py --help
+```
+
+Daily workflows should remain on `make`, `fleet`, `fleet-rlm`, or documented `.codex` actions.
+
+## Remediation
+
+When a boundary check fails:
+
+1. Move the code back to the owning layer when possible.
+2. Prefer an existing service or feature contract over a new cross-layer import.
+3. If the invariant is obsolete, update this document, the root `AGENTS.md` map, and
+   `scripts/check_harness_engineering.py` in the same change.
+4. Run `make check-docs` before finishing.

--- a/docs/agent-harness/drift-control.md
+++ b/docs/agent-harness/drift-control.md
@@ -1,0 +1,78 @@
+# Drift Control
+
+Drift control is deliberately built on existing project checks. The harness check adds repo-specific
+structure without replacing the current validation lane.
+
+## Primary Commands
+
+```bash
+# from repo root
+make check-docs
+make check-release
+make api-check
+```
+
+`make check-docs` runs:
+
+- `uv run python scripts/check_docs_quality.py`
+- `uv run python scripts/check_harness_engineering.py`
+
+`make check-release` runs:
+
+- `uv run python scripts/validate_release.py hygiene`
+- `uv run python scripts/validate_release.py metadata`
+- `uv run python scripts/check_agents_md_freshness.py`
+
+`make api-check` runs:
+
+- `uv run python scripts/openapi_tools.py validate`
+- `cd src/frontend && pnpm run api:check`
+
+## Harness Check Coverage
+
+`uv run python scripts/check_harness_engineering.py` fails when:
+
+- root `AGENTS.md` exceeds the line budget,
+- required `docs/agent-harness/` files are missing,
+- docs indexes do not link the harness hub,
+- `.codex` TOML/JSON files are not parseable,
+- `.codex` bootstrap or hook scripts are missing,
+- generated artifacts are documented without matching `make api-sync`, `make api-check`, and
+  `make build-ui` commands,
+- top-level `scripts/*.py` helpers are missing from `scripts/README.md`,
+- retained top-level Python helpers do not respond to `--help`,
+- backend or frontend structural boundaries drift in ways that agents can remediate.
+
+## Generated Contract Drift
+
+Generated artifacts stay honest through:
+
+```bash
+# from repo root
+make api-sync
+make api-check
+make build-ui
+```
+
+Use `make api-sync` when API schemas or route metadata change. Use `make api-check` before finishing
+contract changes. Use `make build-ui` only when packaged frontend assets must be refreshed.
+
+## Docs Drift
+
+Docs must be reachable from the indexes:
+
+- `docs/README.md`
+- `docs/index.md`
+- `docs/SUMMARY.md`
+
+When adding durable docs, link them from one of those indexes and keep `docs/SUMMARY.md` as the
+complete navigation surface.
+
+## Script Drift
+
+`scripts/README.md` is the source of truth for retained helper scripts. New scripts need:
+
+- an inventory row,
+- a canonical invocation,
+- `--help` behavior that exits without performing work,
+- a `make` target or durable doc reference when they are part of routine workflows.

--- a/docs/agent-harness/feedback-loop.md
+++ b/docs/agent-harness/feedback-loop.md
@@ -1,0 +1,102 @@
+# Local Codex Feedback Loop
+
+This loop gives Codex a local, repeatable path from bootstrap to evidence. The default lane avoids
+live Daytona and live LLM requirements; use explicit live commands when testing the runtime
+substrate.
+
+## Safe Loop
+
+```bash
+# from repo root
+zsh .codex/workspace-bootstrap.zsh
+uv run python scripts/codex_feedback_loop.py --profile safe
+```
+
+The safe profile runs configuration and docs checks, confirms `.codex` syntax, verifies harness
+drift controls, and records a concise JSON report under `artifacts/codex-feedback-loop/`.
+
+Equivalent manual lane:
+
+```bash
+# from repo root
+uv run python scripts/check_harness_engineering.py
+uv run python scripts/check_agents_md_freshness.py
+uv run python scripts/check_docs_quality.py
+make format-check
+```
+
+## App Boot
+
+Start the local app in a separate terminal:
+
+```bash
+# from repo root
+uv run fleet web
+```
+
+Or run the API directly:
+
+```bash
+# from repo root
+uv run fleet-rlm serve-api --port 8000
+```
+
+For frontend-only iteration:
+
+```bash
+# from src/frontend
+pnpm run dev
+```
+
+## Browser Smoke
+
+With the app running, smoke-test:
+
+1. Workbench loads and the composer is usable.
+2. One secondary surface loads: `Settings`, `Volumes`, `Optimization`, or `History`.
+3. `GET /health` returns a healthy response.
+4. `GET /api/v1/runtime/status` returns structured runtime status, even when live Daytona or LLM
+   credentials are not configured.
+
+Use the Codex browser, Playwright, or the local browser tool already available in the session. Do
+not invent a second UI test framework for this smoke path.
+
+## Runtime And MLflow Evidence
+
+Capture these values when available:
+
+- server URL,
+- `/health` status,
+- `/api/v1/runtime/status` summary,
+- MLflow tracking URI,
+- trace IDs created by the run,
+- Daytona diagnostic result when a live lane was explicitly requested.
+
+MLflow is optional in the safe loop. Start it only when the task needs trace evidence:
+
+```bash
+# from repo root
+make mlflow
+```
+
+## Live Lane
+
+Only run live Daytona or LLM checks when the user requested them or the task changes runtime
+execution behavior:
+
+```bash
+# from repo root
+uv run python scripts/validate_env.py daytona --skip-smoke
+uv run fleet-rlm daytona-smoke
+uv run python scripts/validate_rlm_e2e_trace.py --server-url http://127.0.0.1:8000
+```
+
+## Final Report
+
+Every Codex completion should name:
+
+- changed files,
+- validation commands that ran,
+- important command failures or skips,
+- generated artifacts touched by sync commands,
+- live surfaces that were not verified.

--- a/docs/agent-harness/quality-score.md
+++ b/docs/agent-harness/quality-score.md
@@ -1,0 +1,33 @@
+# Harness Quality Score
+
+The current repo harness baseline is `95/100` from the local harness audit. Treat that score as a
+snapshot: the real quality bar is whether agents can find the right instructions, run the right
+loop, and detect drift before CI.
+
+## Current Grades
+
+| Domain | Grade | Notes |
+| --- | --- | --- |
+| Agent instructions | Strong | Root `AGENTS.md` is now a compact map; subsystem guides remain deeper sources. |
+| Repo map | Strong | `docs/reference/codebase-map.md` and this hub provide source layout and reading order. |
+| Validation lane | Strong | `Makefile`, `.codex` actions, and docs expose focused checks. |
+| CI and release hygiene | Strong | Release, docs, frontend, and security checks are wired through `make`. |
+| Observability | Strong | MLflow workflows, runtime status, and optional live traces are documented. |
+| Drift control | Improving | Harness checks now cover root budget, docs reachability, `.codex`, scripts, and boundaries. |
+
+## Current Cleanup Targets
+
+- Keep root `AGENTS.md` below the agreed line budget as the repo evolves.
+- Keep `.codex/environments/environment.toml` action names aligned with `Makefile` targets.
+- Expand structural checks only when a real drift pattern appears; avoid broad lint duplication.
+- Refresh this score after large architecture, release, or Codex-environment changes.
+
+## Quality Standard
+
+A change is harness-complete when:
+
+- the agent reading path still points to current files,
+- the local Codex feedback loop still runs without live credentials in safe mode,
+- generated artifacts have explicit sync/check commands,
+- top-level scripts are inventoried and help-safe,
+- final reports name the validation lane and any skipped live evidence.

--- a/docs/how-to-guides/codex-environment.md
+++ b/docs/how-to-guides/codex-environment.md
@@ -1,0 +1,94 @@
+# Codex Local Environment
+
+This repo ships a Codex-native focus pack under `.codex/`. It is project-local
+configuration for trusted Codex App/CLI work in `fleet-rlm`; it does not require
+or expect edits to `~/.codex/config.toml`.
+
+## Bootstrap
+
+Codex uses `.codex/environments/environment.toml` for the workspace setup entry.
+The setup delegates to:
+
+```bash
+# from repo root
+zsh .codex/workspace-bootstrap.zsh
+```
+
+The bootstrap is intentionally limited to dependency preparation:
+
+- `uv sync --all-extras --dev --frozen` when `uv.lock` is present
+- `pnpm install --frozen-lockfile` inside `src/frontend`
+
+It does not start the app, run tests, or rely on exported shell state persisting
+after setup. Use the environment actions for those workflows.
+
+## Actions
+
+`.codex/environments/environment.toml` exposes the practical repo command
+surface as Codex actions:
+
+- App runtime: `uv run fleet web`, `uv run fleet-rlm serve-api --port 8000`,
+  and terminal chat.
+- Backend validation: format, format-check, lint, typecheck, unit,
+  integration, and full quality gate.
+- Frontend validation: install, dev server, typecheck, lint, unit tests, build,
+  e2e, and full frontend check.
+- Contract and release lanes: OpenAPI check/sync, release hygiene, build UI,
+  build release artifacts, and full release check.
+- Operational lanes: security, dependency checks, Daytona diagnostics/smoke,
+  MLflow server, RLM capability benchmarks, FastAPI cloud preflight, and CLI
+  help.
+
+Prefer one responsibility per action. Keep long-running server actions separate
+from one-shot validation actions.
+
+## Hooks
+
+`.codex/config.toml` enables Codex `hooks`, and `.codex/hooks.json` declares the
+repo-owned lifecycle hooks:
+
+- `PreToolUse` on `Edit|Write`: blocks direct edits to `.env`; edit
+  `.env.example` or docs instead.
+- `PostToolUse` on `Edit|Write`: formats edited Python files with
+  `uv run ruff format` and applies quiet Ruff fixes for that file.
+- `Stop`: reports dirty generated/synced artifacts such as `openapi.yaml`,
+  frontend generated OpenAPI types, route tree output, and packaged UI assets.
+  It does not regenerate or modify these files.
+
+Hook scripts live in `.codex/hooks/` and should stay small, deterministic, and
+safe to run repeatedly.
+
+## Focused Agents
+
+`.codex/config.toml` declares project-scoped multi-agent roles backed by
+`.codex/agents/*.toml`:
+
+- `backend-runtime` for FastAPI, websocket, DSPy, persistence, and runtime work.
+- `frontend-ui` for React/TanStack/Vite+/Agent Elements work.
+- `api-contract` for OpenAPI, generated clients, and websocket payload shape.
+- `testing-strategist` for choosing the smallest meaningful validation lane.
+- `security-reviewer` for auth, tokens, middleware, settings, and secret risks.
+- `release-manager` for packaging, release hygiene, and bundled UI assets.
+- `daytona-runtime` for sandbox lifecycle, volumes, child isolation, and
+  diagnostics.
+- `docs-maintainer` for AGENTS.md, PLANS.md, README, and docs consistency.
+
+These roles are Codex-native replacements for only the useful parts of older
+`.claude`, `.agents`, and `.factory` material. Do not copy legacy prompts
+wholesale unless they match the current repo contract.
+
+## Validation
+
+After changing `.codex/`, run:
+
+```bash
+# from repo root
+uv run python -c "import json, pathlib, tomllib; [tomllib.loads(p.read_text()) for p in pathlib.Path('.codex').rglob('*.toml')]; json.loads(pathlib.Path('.codex/hooks.json').read_text()); print('codex-config-ok')"
+zsh -n .codex/workspace-bootstrap.zsh .codex/hooks/*.zsh
+uv run python scripts/check_agents_md_freshness.py
+uv run python scripts/check_docs_quality.py
+make format-check
+codex features list | grep -E '^(hooks|multi_agent)[[:space:]]'
+```
+
+Run `zsh .codex/workspace-bootstrap.zsh` when dependency refresh is acceptable.

--- a/docs/how-to-guides/deploying-server.md
+++ b/docs/how-to-guides/deploying-server.md
@@ -239,7 +239,7 @@ Response:
 ```json
 {
   "ok": true,
-  "version": "0.5.3"
+  "version": "0.5.31"
 }
 ```
 
@@ -369,7 +369,7 @@ FastAPI Cloud reads `[tool.fastapi].entrypoint`, installs from `pyproject.toml` 
 
 ```bash
 curl https://<assigned-host>/health
-# => {"ok": true, "version": "0.5.3"}
+# => {"ok": true, "version": "0.5.31"}
 
 curl https://<assigned-host>/ready
 # => {"ready": true, "planner": "ready", "database": "ready", ...}

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -6,6 +6,7 @@ Task-oriented guides for operating `fleet-rlm` in day-to-day usage.
 
 - [Installation](installation.md)
 - [Developer Setup](developer-setup.md) - Local development environment for contributors
+- [Codex Local Environment](codex-environment.md) - Repo-local Codex actions, hooks, and focused agents
 - [Frontend Development](frontend-development.md) - React/TypeScript frontend development workflow
 - [Testing Strategy](testing-strategy.md) - Pytest markers, test organization, and commands
 - [Runtime Settings](runtime-settings.md)

--- a/docs/how-to-guides/releasing.md
+++ b/docs/how-to-guides/releasing.md
@@ -11,7 +11,7 @@ Use the GitHub Actions workflow for a fully automated release:
 1. Go to **Actions** → **Release to PyPI** in the GitHub repository
 2. Click **Run workflow**
 3. Finalize the `CHANGELOG.md` section for the version you are shipping
-4. Enter the version number (for this release, `0.4.99` or `v0.4.99`)
+4. Enter the version number (for this release, `0.5.31` or `v0.5.31`)
 5. Approve the TestPyPI environment deployment
 6. Once smoke tests pass, approve the PyPI environment deployment
 
@@ -115,8 +115,8 @@ make release-artifacts
 
 Expected outputs:
 
-- `dist/fleet_rlm-0.4.99.tar.gz`
-- `dist/fleet_rlm-0.4.99-py3-none-any.whl`
+- `dist/fleet_rlm-0.5.31.tar.gz`
+- `dist/fleet_rlm-0.5.31-py3-none-any.whl`
 
 ## 3) Upload to TestPyPI
 
@@ -143,7 +143,7 @@ uv venv .venv-release-smoke
 uv pip install --python .venv-release-smoke/bin/python \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple \
-  fleet-rlm==0.4.99
+  fleet-rlm==0.5.31
 source .venv-release-smoke/bin/activate
 python -m uvicorn fleet_rlm.api.main:app --host 127.0.0.1 --port 8765 >/tmp/fleet-release-smoke.log 2>&1 &
 SERVER_PID=$!
@@ -187,8 +187,8 @@ Finalize `CHANGELOG.md` and any docs release-notes page before tagging or runnin
 
 ```bash
 # from repo root
-git tag v0.4.99
-git push origin v0.4.99
+git tag v0.5.31
+git push origin v0.5.31
 ```
 
 ## Important rules

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,9 @@
 ## Start Here (User Path)
 
 1. **[Tutorials](tutorials/index.md)** — learn by doing: basic usage, document analysis, interactive chat.
-2. **[How-to Guides](how-to-guides/index.md)** — solve specific problems: installation, deployment, DSPy integration, troubleshooting, MLflow workflows.
+2. **[How-to Guides](how-to-guides/index.md)** — solve specific problems: installation, Codex local setup, deployment, DSPy integration, troubleshooting, MLflow workflows.
 3. **[Explanation](explanation/index.md)** — understand the product: spec, concepts, user flows.
+4. **[Agent Harness](agent-harness/README.md)** — Codex operating model, local feedback loop, architecture invariants, and drift control.
 
 ## Reference
 
@@ -19,6 +20,7 @@
 Read these after you've seen the product:
 
 - **[Architecture Overview](architecture.md)** — current layer ownership model.
+- **[Agent Harness](agent-harness/README.md)** — repo-local harness engineering controls.
 - **[Wiring Analysis](explanation/wiring-analysis.md)**
 - **[Frontend Simplification Design](specs/frontend-simplification-design.md)**
 - **[Releasing to PyPI](how-to-guides/releasing.md)** — automated and manual release flow

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -43,7 +43,7 @@ Basic liveness check.
 ```json
 {
   "ok": true,
-  "version": "0.5.3"
+  "version": "0.5.31"
 }
 ```
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.5.3
+  version: 0.5.31
 paths:
   /health:
     get:
@@ -2103,7 +2103,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.5.3
+          default: 0.5.31
       type: object
       title: HealthResponse
       description: Response body for the lightweight health endpoint.
@@ -3018,7 +3018,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.5.3
+          default: 0.5.31
         app_env:
           type: string
           enum:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-rlm"
-version = "0.5.3"
+version = "0.5.31"
 description = "Recursive Language Models with DSPy + Daytona and an integrated Web UI for secure long-context code execution"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,8 @@ Support boundary:
 | `build_ui.py` | Repo wrapper around `src/fleet_rlm/ui/build.py`, which builds `src/frontend` and syncs packaged UI assets into `src/fleet_rlm/ui/dist` | `pnpm` on `PATH` | `uv run python scripts/build_ui.py` |
 | `check_agents_md_freshness.py` | Validate `AGENTS.md` files against current repo paths, commands, and links | None | `uv run python scripts/check_agents_md_freshness.py` |
 | `check_docs_quality.py` | Validate docs links, reachability, and contract sanity | None | `uv run python scripts/check_docs_quality.py` |
+| `check_harness_engineering.py` | Validate root agent-map budget, harness docs, `.codex` config, script inventory, and structural boundaries | None | `uv run python scripts/check_harness_engineering.py` |
+| `codex_feedback_loop.py` | Run the safe local Codex feedback loop and write a concise report | None for `--profile safe`; running app for `--profile app` | `uv run python scripts/codex_feedback_loop.py --profile safe` |
 | `openapi_tools.py` | Generate or validate the root OpenAPI contract | Backend dependencies | `uv run python scripts/openapi_tools.py generate` |
 | `validate_release.py` | Run release hygiene, metadata, and wheel integrity checks | Build artifacts for `wheel` mode | `uv run python scripts/validate_release.py metadata` |
 | `run_duplicate_check.zsh` | Run `jscpd` against handwritten source blocks | `src/frontend/node_modules` installed | `./scripts/run_duplicate_check.zsh` |

--- a/scripts/check_harness_engineering.py
+++ b/scripts/check_harness_engineering.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Validate the repo-local harness engineering control surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT_AGENTS_LINE_BUDGET = 140
+REQUIRED_HARNESS_DOCS = (
+    "docs/agent-harness/README.md",
+    "docs/agent-harness/feedback-loop.md",
+    "docs/agent-harness/architecture-invariants.md",
+    "docs/agent-harness/quality-score.md",
+    "docs/agent-harness/drift-control.md",
+)
+DOC_INDEXES = ("docs/README.md", "docs/index.md", "docs/SUMMARY.md")
+GENERATED_ARTIFACTS = (
+    "openapi.yaml",
+    "src/frontend/src/lib/rlm-api/generated/openapi.ts",
+    "src/frontend/openapi/fleet-rlm.openapi.yaml",
+    "src/frontend/src/routeTree.gen.ts",
+    "src/frontend/dist",
+    "src/fleet_rlm/ui/dist",
+)
+GENERATED_COMMANDS = ("make api-sync", "make api-check", "make build-ui")
+HEAVY_IMPORTS = ("dspy", "mlflow", "posthog", "daytona")
+CONFIG_MODULES = (
+    "src/fleet_rlm/__init__.py",
+    "src/fleet_rlm/integrations/config/__init__.py",
+    "src/fleet_rlm/integrations/config/settings.py",
+)
+FRONTEND_SHARED_DIRS = (
+    "src/frontend/src/components/ui",
+    "src/frontend/src/components/ai-elements",
+    "src/frontend/src/components/product",
+)
+FRONTEND_FORBIDDEN_IMPORTS = (
+    "@/features/",
+    "@/routes/",
+    "../features/",
+    "../../features/",
+    "../routes/",
+    "../../routes/",
+)
+
+
+@dataclass(frozen=True)
+class HarnessError:
+    """A single harness validation failure."""
+
+    path: str
+    detail: str
+
+
+@dataclass
+class HarnessChecker:
+    """Run repo-specific harness checks."""
+
+    repo_root: Path
+    check_script_help: bool = True
+    errors: list[HarnessError] = field(default_factory=list)
+
+    def run(self) -> list[HarnessError]:
+        """Run all checks and return collected errors."""
+        self._check_root_agents_budget()
+        self._check_required_docs()
+        self._check_docs_index_links()
+        self._check_codex_config()
+        self._check_generated_artifact_controls()
+        self._check_script_inventory()
+        self._check_backend_import_boundaries()
+        self._check_frontend_import_boundaries()
+        return self.errors
+
+    def _check_root_agents_budget(self) -> None:
+        path = self.repo_root / "AGENTS.md"
+        if not path.exists():
+            self._error("AGENTS.md", "missing root agent map")
+            return
+        line_count = len(path.read_text(encoding="utf-8").splitlines())
+        if line_count > ROOT_AGENTS_LINE_BUDGET:
+            self._error(
+                "AGENTS.md",
+                f"root guide has {line_count} lines; budget is {ROOT_AGENTS_LINE_BUDGET}",
+            )
+
+    def _check_required_docs(self) -> None:
+        for rel_path in REQUIRED_HARNESS_DOCS:
+            if not (self.repo_root / rel_path).is_file():
+                self._error(rel_path, "required harness doc is missing")
+
+    def _check_docs_index_links(self) -> None:
+        required_link = "agent-harness/README.md"
+        for rel_path in DOC_INDEXES:
+            path = self.repo_root / rel_path
+            if not path.is_file():
+                self._error(rel_path, "docs index is missing")
+                continue
+            content = path.read_text(encoding="utf-8")
+            if required_link not in content and "docs/agent-harness/README.md" not in content:
+                self._error(rel_path, "does not link docs/agent-harness/README.md")
+
+    def _check_codex_config(self) -> None:
+        codex_dir = self.repo_root / ".codex"
+        required_toml = [
+            codex_dir / "config.toml",
+            codex_dir / "environments" / "environment.toml",
+        ]
+        required_toml.extend(sorted((codex_dir / "agents").glob("*.toml")))
+        for path in required_toml:
+            self._parse_toml(path)
+        self._parse_json(codex_dir / "hooks.json")
+        for rel_path in (
+            ".codex/workspace-bootstrap.zsh",
+            ".codex/hooks/block-env-edit.zsh",
+            ".codex/hooks/generated-artifact-check.zsh",
+            ".codex/hooks/python-format.zsh",
+        ):
+            if not (self.repo_root / rel_path).is_file():
+                self._error(rel_path, "required Codex hook/bootstrap script is missing")
+
+    def _check_generated_artifact_controls(self) -> None:
+        docs = "\n".join(
+            (self.repo_root / rel_path).read_text(encoding="utf-8")
+            for rel_path in REQUIRED_HARNESS_DOCS
+            if (self.repo_root / rel_path).is_file()
+        )
+        for artifact in GENERATED_ARTIFACTS:
+            if artifact not in docs:
+                self._error("docs/agent-harness", f"generated artifact not documented: {artifact}")
+        for command in GENERATED_COMMANDS:
+            if command not in docs:
+                self._error("docs/agent-harness", f"generated artifact command not documented: {command}")
+
+    def _check_script_inventory(self) -> None:
+        inventory_path = self.repo_root / "scripts" / "README.md"
+        if not inventory_path.is_file():
+            self._error("scripts/README.md", "script inventory is missing")
+            return
+        inventory = inventory_path.read_text(encoding="utf-8")
+        for script in sorted((self.repo_root / "scripts").glob("*.py")):
+            rel_path = script.relative_to(self.repo_root).as_posix()
+            if script.name not in inventory and rel_path not in inventory:
+                self._error(rel_path, "top-level Python helper is missing from scripts/README.md")
+            if self.check_script_help:
+                self._check_script_help(script)
+
+    def _check_script_help(self, script: Path) -> None:
+        rel_path = script.relative_to(self.repo_root).as_posix()
+        result = subprocess.run(
+            [sys.executable, str(script), "--help"],
+            cwd=self.repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip().splitlines()
+            detail = stderr[-1] if stderr else f"exited with {result.returncode}"
+            self._error(rel_path, f"--help failed: {detail}")
+
+    def _check_backend_import_boundaries(self) -> None:
+        for rel_path in CONFIG_MODULES:
+            path = self.repo_root / rel_path
+            if not path.is_file():
+                continue
+            for module in self._extract_import_roots(path):
+                if module in HEAVY_IMPORTS:
+                    self._error(rel_path, f"config/package-root module imports heavy runtime provider: {module}")
+
+    def _check_frontend_import_boundaries(self) -> None:
+        for rel_dir in FRONTEND_SHARED_DIRS:
+            root = self.repo_root / rel_dir
+            if not root.is_dir():
+                continue
+            for path in sorted(root.rglob("*")):
+                if path.suffix not in {".ts", ".tsx"}:
+                    continue
+                content = path.read_text(encoding="utf-8", errors="ignore")
+                for forbidden in FRONTEND_FORBIDDEN_IMPORTS:
+                    if forbidden in content:
+                        rel_path = path.relative_to(self.repo_root).as_posix()
+                        self._error(rel_path, f"shared frontend component imports forbidden boundary: {forbidden}")
+
+    def _parse_toml(self, path: Path) -> None:
+        rel_path = path.relative_to(self.repo_root).as_posix()
+        if not path.is_file():
+            self._error(rel_path, "required TOML file is missing")
+            return
+        try:
+            tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            self._error(rel_path, f"TOML parse failed: {exc}")
+
+    def _parse_json(self, path: Path) -> None:
+        rel_path = path.relative_to(self.repo_root).as_posix()
+        if not path.is_file():
+            self._error(rel_path, "required JSON file is missing")
+            return
+        try:
+            json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            self._error(rel_path, f"JSON parse failed: {exc}")
+
+    def _extract_import_roots(self, path: Path) -> set[str]:
+        content = path.read_text(encoding="utf-8", errors="ignore")
+        roots: set[str] = set()
+        for match in re.finditer(r"^\s*(?:from|import)\s+([a-zA-Z_][\w.]*)", content, re.MULTILINE):
+            roots.add(match.group(1).split(".")[0])
+        return roots
+
+    def _error(self, path: str, detail: str) -> None:
+        self.errors.append(HarnessError(path=path, detail=detail))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root to validate.",
+    )
+    parser.add_argument(
+        "--skip-script-help",
+        action="store_true",
+        help="Skip executing top-level scripts with --help.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    checker = HarnessChecker(
+        repo_root=args.repo_root.resolve(),
+        check_script_help=not args.skip_script_help,
+    )
+    errors = checker.run()
+    if errors:
+        print("Harness engineering checks failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error.path}: {error.detail}", file=sys.stderr)
+        return 1
+    print("OK: harness engineering checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_harness_engineering.py
+++ b/scripts/check_harness_engineering.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
-import re
 import subprocess
 import sys
 import tomllib
@@ -154,15 +154,19 @@ class HarnessChecker:
 
     def _check_script_help(self, script: Path) -> None:
         rel_path = script.relative_to(self.repo_root).as_posix()
-        result = subprocess.run(
-            [sys.executable, str(script), "--help"],
-            cwd=self.repo_root,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            text=True,
-            timeout=30,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [sys.executable, str(script), "--help"],
+                cwd=self.repo_root,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            self._error(rel_path, f"--help timed out after {exc.timeout} seconds")
+            return
         if result.returncode != 0:
             stderr = result.stderr.strip().splitlines()
             detail = stderr[-1] if stderr else f"exited with {result.returncode}"
@@ -214,8 +218,15 @@ class HarnessChecker:
     def _extract_import_roots(self, path: Path) -> set[str]:
         content = path.read_text(encoding="utf-8", errors="ignore")
         roots: set[str] = set()
-        for match in re.finditer(r"^\s*(?:from|import)\s+([a-zA-Z_][\w.]*)", content, re.MULTILINE):
-            roots.add(match.group(1).split(".")[0])
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
+            return roots
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                roots.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                roots.add(node.module.split(".")[0])
         return roots
 
     def _error(self, path: str, detail: str) -> None:

--- a/scripts/codex_feedback_loop.py
+++ b/scripts/codex_feedback_loop.py
@@ -71,14 +71,36 @@ class HttpProbe:
 def run_command(name: str, command: list[str], repo_root: Path) -> CommandResult:
     """Run a command and keep bounded output for the report."""
     start = time.monotonic()
-    result = subprocess.run(
-        command,
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        timeout=180,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            timeout=180,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        return CommandResult(
+            name=name,
+            command=command,
+            returncode=124,
+            duration_seconds=round(time.monotonic() - start, 2),
+            stdout_tail=tail(stdout),
+            stderr_tail=tail(f"command timed out after {exc.timeout} seconds"),
+        )
+    except OSError as exc:
+        return CommandResult(
+            name=name,
+            command=command,
+            returncode=127,
+            duration_seconds=round(time.monotonic() - start, 2),
+            stdout_tail="",
+            stderr_tail=tail(str(exc)),
+        )
     return CommandResult(
         name=name,
         command=command,

--- a/scripts/codex_feedback_loop.py
+++ b/scripts/codex_feedback_loop.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Run the local Codex feedback loop and emit a concise report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SAFE_COMMANDS = (
+    (
+        "codex-config",
+        [
+            sys.executable,
+            "-c",
+            "import json, pathlib, tomllib; "
+            "root=pathlib.Path('.codex'); "
+            "[tomllib.loads(p.read_text()) for p in root.rglob('*.toml')]; "
+            "json.loads((root/'hooks.json').read_text()); "
+            "print('codex-config-ok')",
+        ],
+    ),
+    (
+        "codex-hooks-syntax",
+        [
+            "zsh",
+            "-n",
+            ".codex/workspace-bootstrap.zsh",
+            ".codex/hooks/block-env-edit.zsh",
+            ".codex/hooks/generated-artifact-check.zsh",
+            ".codex/hooks/python-format.zsh",
+        ],
+    ),
+    ("harness", [sys.executable, "scripts/check_harness_engineering.py"]),
+    ("agents-freshness", [sys.executable, "scripts/check_agents_md_freshness.py"]),
+    ("docs-quality", [sys.executable, "scripts/check_docs_quality.py"]),
+    ("format-check", ["make", "format-check"]),
+)
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """A single command execution result."""
+
+    name: str
+    command: list[str]
+    returncode: int
+    duration_seconds: float
+    stdout_tail: str
+    stderr_tail: str
+
+
+@dataclass(frozen=True)
+class HttpProbe:
+    """A lightweight HTTP probe result."""
+
+    url: str
+    ok: bool
+    status: int | None
+    body_tail: str
+    error: str | None = None
+
+
+def run_command(name: str, command: list[str], repo_root: Path) -> CommandResult:
+    """Run a command and keep bounded output for the report."""
+    start = time.monotonic()
+    result = subprocess.run(
+        command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        timeout=180,
+        check=False,
+    )
+    return CommandResult(
+        name=name,
+        command=command,
+        returncode=result.returncode,
+        duration_seconds=round(time.monotonic() - start, 2),
+        stdout_tail=tail(result.stdout),
+        stderr_tail=tail(result.stderr),
+    )
+
+
+def probe_url(url: str, timeout: float = 5.0) -> HttpProbe:
+    """Probe a local URL without requiring third-party dependencies."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310
+            body = response.read(4096).decode("utf-8", errors="replace")
+            status = response.status
+            return HttpProbe(url=url, ok=200 <= status < 400, status=status, body_tail=tail(body))
+    except urllib.error.HTTPError as exc:
+        body = exc.read(2048).decode("utf-8", errors="replace")
+        return HttpProbe(url=url, ok=False, status=exc.code, body_tail=tail(body), error=str(exc))
+    except OSError as exc:
+        return HttpProbe(url=url, ok=False, status=None, body_tail="", error=str(exc))
+
+
+def tail(value: str, max_chars: int = 1600) -> str:
+    """Return a bounded tail string."""
+    value = value.strip()
+    if len(value) <= max_chars:
+        return value
+    return value[-max_chars:]
+
+
+def write_report(report: dict[str, Any], output: Path) -> None:
+    """Write the JSON report."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile",
+        choices=("safe", "app"),
+        default="safe",
+        help="safe runs static/local checks; app also probes a running local API.",
+    )
+    parser.add_argument(
+        "--server-url",
+        default="http://127.0.0.1:8000",
+        help="Local API server URL for the app profile.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/codex-feedback-loop/report.json"),
+        help="Report path.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    command_results = [run_command(name, command, repo_root) for name, command in SAFE_COMMANDS]
+    probes: list[HttpProbe] = []
+    if args.profile == "app":
+        base = args.server_url.rstrip("/")
+        probes = [
+            probe_url(f"{base}/health"),
+            probe_url(f"{base}/api/v1/runtime/status"),
+        ]
+
+    report = {
+        "profile": args.profile,
+        "commands": [asdict(result) for result in command_results],
+        "http_probes": [asdict(probe) for probe in probes],
+    }
+    output_path = repo_root / args.output
+    write_report(report, output_path)
+
+    failed_commands = [result for result in command_results if result.returncode != 0]
+    failed_probes = [probe for probe in probes if not probe.ok]
+    print(f"Codex feedback loop report: {output_path}")
+    if failed_commands or failed_probes:
+        for result in failed_commands:
+            print(f"FAIL command {result.name}: exit {result.returncode}", file=sys.stderr)
+        for probe in failed_probes:
+            print(f"FAIL probe {probe.url}: {probe.error or probe.status}", file=sys.stderr)
+        return 1
+    print("OK: Codex feedback loop completed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/frontend/openapi/fleet-rlm.openapi.yaml
+++ b/src/frontend/openapi/fleet-rlm.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.5.3
+  version: 0.5.31
 paths:
   /health:
     get:
@@ -2103,7 +2103,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.5.3
+          default: 0.5.31
       type: object
       title: HealthResponse
       description: Response body for the lightweight health endpoint.
@@ -3018,7 +3018,7 @@ components:
           type: string
           title: Version
           description: Package version currently serving the API.
-          default: 0.5.3
+          default: 0.5.31
         app_env:
           type: string
           enum:

--- a/src/frontend/src/lib/rlm-api/generated/openapi.ts
+++ b/src/frontend/src/lib/rlm-api/generated/openapi.ts
@@ -722,7 +722,7 @@ export interface components {
       /**
        * Version
        * @description Package version currently serving the API.
-       * @default 0.5.3
+       * @default 0.5.31
        */
       version?: string;
     };
@@ -1591,7 +1591,7 @@ export interface components {
       /**
        * Version
        * @description Package version currently serving the API.
-       * @default 0.5.3
+       * @default 0.5.31
        */
       version?: string;
       /**

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const isCi = process.env.CI === "true";
 
 export default defineConfig({
   lint: {
@@ -200,7 +201,7 @@ export default defineConfig({
       vite: { installDevServerMiddleware: true },
       pages: [{ path: "/" }],
       prerender: {
-        enabled: true,
+        enabled: !isCi,
         crawlLinks: false,
       },
     }),

--- a/tests/unit/scripts/test_check_harness_engineering.py
+++ b/tests/unit/scripts/test_check_harness_engineering.py
@@ -1,0 +1,112 @@
+"""Tests for harness engineering validation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scripts.check_harness_engineering import HarnessChecker
+
+
+def write_valid_repo(root: Path) -> None:
+    """Create the smallest repo shape accepted by the harness checker."""
+    (root / ".codex" / "agents").mkdir(parents=True)
+    (root / ".codex" / "environments").mkdir(parents=True)
+    (root / ".codex" / "hooks").mkdir(parents=True)
+    (root / "docs" / "agent-harness").mkdir(parents=True)
+    (root / "scripts").mkdir()
+    (root / "src" / "fleet_rlm" / "integrations" / "config").mkdir(parents=True)
+    (root / "src" / "frontend" / "src" / "components" / "ui").mkdir(parents=True)
+
+    (root / "AGENTS.md").write_text("# Root\n\nSee docs/agent-harness/README.md\n", encoding="utf-8")
+    for index in ("README.md", "index.md", "SUMMARY.md"):
+        (root / "docs" / index).write_text("[Harness](agent-harness/README.md)\n", encoding="utf-8")
+
+    docs_text = "\n".join(
+        [
+            "openapi.yaml",
+            "src/frontend/src/lib/rlm-api/generated/openapi.ts",
+            "src/frontend/openapi/fleet-rlm.openapi.yaml",
+            "src/frontend/src/routeTree.gen.ts",
+            "src/frontend/dist",
+            "src/fleet_rlm/ui/dist",
+            "make api-sync",
+            "make api-check",
+            "make build-ui",
+        ]
+    )
+    for name in ("README.md", "feedback-loop.md", "architecture-invariants.md", "quality-score.md", "drift-control.md"):
+        (root / "docs" / "agent-harness" / name).write_text(docs_text, encoding="utf-8")
+
+    (root / ".codex" / "config.toml").write_text("[features]\nhooks = true\n", encoding="utf-8")
+    (root / ".codex" / "environments" / "environment.toml").write_text("version = 1\n", encoding="utf-8")
+    (root / ".codex" / "agents" / "backend.toml").write_text("name = 'backend'\n", encoding="utf-8")
+    (root / ".codex" / "hooks.json").write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+    for name in ("workspace-bootstrap.zsh",):
+        (root / ".codex" / name).write_text("#!/usr/bin/env zsh\n", encoding="utf-8")
+    for name in ("block-env-edit.zsh", "generated-artifact-check.zsh", "python-format.zsh"):
+        (root / ".codex" / "hooks" / name).write_text("#!/usr/bin/env zsh\n", encoding="utf-8")
+
+    helper = root / "scripts" / "tool.py"
+    helper.write_text(
+        "import argparse\nargparse.ArgumentParser().parse_args()\n",
+        encoding="utf-8",
+    )
+    (root / "scripts" / "README.md").write_text("`tool.py`\n", encoding="utf-8")
+    (root / "src" / "fleet_rlm" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "src" / "fleet_rlm" / "integrations" / "config" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "src" / "fleet_rlm" / "integrations" / "config" / "settings.py").write_text("", encoding="utf-8")
+
+
+def run_checker(root: Path, *, check_script_help: bool = True) -> list[str]:
+    """Return formatted checker failures."""
+    errors = HarnessChecker(repo_root=root, check_script_help=check_script_help).run()
+    return [f"{error.path}: {error.detail}" for error in errors]
+
+
+def test_valid_minimal_repo_passes(tmp_path: Path) -> None:
+    """A minimal valid repo has no harness errors."""
+    write_valid_repo(tmp_path)
+
+    assert run_checker(tmp_path) == []
+
+
+def test_root_agents_line_budget_fails(tmp_path: Path) -> None:
+    """Root AGENTS.md must stay within the line budget."""
+    write_valid_repo(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("\n".join(["line"] * 141), encoding="utf-8")
+
+    errors = run_checker(tmp_path, check_script_help=False)
+
+    assert any("root guide has 141 lines" in error for error in errors)
+
+
+def test_malformed_codex_config_fails(tmp_path: Path) -> None:
+    """Malformed TOML is reported as a harness error."""
+    write_valid_repo(tmp_path)
+    (tmp_path / ".codex" / "config.toml").write_text("[broken\n", encoding="utf-8")
+
+    errors = run_checker(tmp_path, check_script_help=False)
+
+    assert any(".codex/config.toml" in error and "TOML parse failed" in error for error in errors)
+
+
+def test_script_inventory_fails_for_unlisted_helper(tmp_path: Path) -> None:
+    """Top-level Python helpers must be listed in scripts/README.md."""
+    write_valid_repo(tmp_path)
+    (tmp_path / "scripts" / "README.md").write_text("", encoding="utf-8")
+
+    errors = run_checker(tmp_path, check_script_help=False)
+
+    assert any("scripts/tool.py" in error and "missing from scripts/README.md" in error for error in errors)
+
+
+def test_script_help_failure_is_reported(tmp_path: Path) -> None:
+    """Retained Python helpers must support --help without side effects."""
+    write_valid_repo(tmp_path)
+    (tmp_path / "scripts" / "tool.py").write_text(f"import sys\nsys.exit(3)\n# {sys.executable}\n", encoding="utf-8")
+
+    errors = run_checker(tmp_path)
+
+    assert any("scripts/tool.py" in error and "--help failed" in error for error in errors)

--- a/uv.lock
+++ b/uv.lock
@@ -1362,7 +1362,7 @@ wheels = [
 
 [[package]]
 name = "fleet-rlm"
-version = "0.5.3"
+version = "0.5.31"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- add the repo-local Codex harness engineering setup and docs
- bump release metadata from 0.5.3 to 0.5.31
- sync OpenAPI and generated frontend API artifacts for 0.5.31

## Validation
- uv run python -c '<parse .codex TOML/JSON>'
- zsh -n .codex/workspace-bootstrap.zsh .codex/hooks/block-env-edit.zsh .codex/hooks/generated-artifact-check.zsh .codex/hooks/python-format.zsh
- uv run python scripts/check_harness_engineering.py
- uv run python scripts/check_agents_md_freshness.py
- uv run python scripts/check_docs_quality.py
- make api-check
- uv run python scripts/validate_release.py metadata
- make format-check
- make lint
- make check-security
- make release-check: partial; passed backend lint/format/typecheck/tests, release metadata, AGENTS/docs/harness checks, duplicate check, frontend api-check/type-check/lint/unit tests; frontend build reached successful client/SSR build and prerendered 11 pages, then local Vite/TanStack build process hung instead of exiting

## Notes
- This PR intentionally includes the existing Codex harness commit plus the 0.5.31 release-prep commit.
- CI remains the final authority for release packaging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Agent Harness docs (feedback loop, architecture invariants, drift control, quality score) and Codex Local Environment guides; updated deployment/API docs to 0.5.31.

* **Chores**
  * Bumped version to 0.5.31; added Codex agent and environment configs, workspace bootstrap, hooks, and refined .gitignore; updated Makefile help.

* **Scripts**
  * Added harness validation and local feedback-loop CLI tools.

* **Tests**
  * Added unit tests for harness validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Qredence/fleet-rlm/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->