### PR TITLE
fix(security): GEPA remediation PR1 — trace paths and export auth

### DIFF
--- a/.codex/hooks/block-env-edit.zsh
+++ b/.codex/hooks/block-env-edit.zsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env zsh
 set -euo pipefail
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
 payload="$(cat)"
 
 if command -v jq >/dev/null 2>&1; then
@@ -13,9 +15,9 @@ if command -v jq >/dev/null 2>&1; then
       empty
     ' 2>/dev/null || true
   )"
-elif command -v python3 >/dev/null 2>&1; then
+elif command -v uv >/dev/null 2>&1; then
   file_path="$(
-    printf '%s' "$payload" | python3 -c '
+    printf '%s' "$payload" | uv run python -c '
 import json
 import sys
 
@@ -38,8 +40,8 @@ else
 fi
 
 if [[ "$file_path" == ".env" || "$file_path" == */.env ]]; then
-  printf '{"decision":"block","reason":"Direct edits to .env are blocked. Edit .env.example or document required variables instead."}\n'
-  exit 2
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Direct edits to .env are blocked. Edit .env.example or document required variables instead."}}\n'
+  exit 0
 fi
 
 exit 0

--- a/.codex/hooks/generated-artifact-check.zsh
+++ b/.codex/hooks/generated-artifact-check.zsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env zsh
 set -euo pipefail
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
 generated_paths=(
   "openapi.yaml"
   "src/frontend/openapi/fleet-rlm.openapi.yaml"
@@ -12,7 +14,8 @@ generated_paths=(
 
 dirty=()
 for path in "${generated_paths[@]}"; do
-  if git status --short -- "$path" 2>/dev/null | grep -q .; then
+  status_output="$(git status --short -- "$path" 2>/dev/null || true)"
+  if [[ -n "$status_output" ]]; then
     dirty+=("$path")
   fi
 done

--- a/.codex/hooks/python-format.zsh
+++ b/.codex/hooks/python-format.zsh
@@ -1,6 +1,8 @@
 #!/usr/bin/env zsh
 set -euo pipefail
 
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
 payload="$(cat)"
 
 if command -v jq >/dev/null 2>&1; then
@@ -13,9 +15,9 @@ if command -v jq >/dev/null 2>&1; then
       empty
     ' 2>/dev/null || true
   )"
-elif command -v python3 >/dev/null 2>&1; then
+elif command -v uv >/dev/null 2>&1; then
   file_path="$(
-    printf '%s' "$payload" | python3 -c '
+    printf '%s' "$payload" | uv run python -c '
 import json
 import sys
 

--- a/src/fleet_rlm/api/routers/optimization/_deps.py
+++ b/src/fleet_rlm/api/routers/optimization/_deps.py
@@ -42,6 +42,7 @@ __all__ = [
     "PersistedIdentityDep",
     "PersistenceDep",
     "_resolve_persisted_identity",
+    "parse_run_uuid",
 ]
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,17 @@ def _resolve_optimization_timeout_seconds() -> int:
 OPTIMIZATION_TIMEOUT_SECONDS = _resolve_optimization_timeout_seconds()
 
 OPTIMIZATION_DATA_ROOT = Path(os.environ.get("FLEET_RLM_OPTIMIZATION_DATA_ROOT", os.getcwd())).resolve()
+
+
+def parse_run_uuid(run_id: str) -> uuid.UUID:
+    """Parse the canonical optimization run UUID."""
+    normalized = run_id.strip()
+    if normalized.isdecimal():
+        return uuid.UUID(int=int(normalized))
+    try:
+        return uuid.UUID(normalized)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Run not found.") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/fleet_rlm/api/routers/optimization/orchestration.py
+++ b/src/fleet_rlm/api/routers/optimization/orchestration.py
@@ -1,0 +1,528 @@
+"""Request orchestration helpers for GEPA optimization endpoints."""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import BackgroundTasks, HTTPException
+
+from fleet_rlm.integrations.database.repository_identity import IdentityUpsertResult
+from fleet_rlm.integrations.database.repository_optimization import OptimizationRunCreateRequest
+from fleet_rlm.integrations.llm_profiles.resolver import (
+    build_lm_kwargs_from_resolved,
+    resolve_role_config,
+)
+from fleet_rlm.integrations.llm_profiles.store import resolve_profile_store
+from fleet_rlm.integrations.llm_profiles.types import LlmRoleBindingRecord
+
+from ...runtime_services.common import run_blocking
+from ...schemas.optimization import (
+    GEPAOptimizationRequest,
+    GEPAOptimizationResponse,
+    OptimizationRunCreatedResponse,
+)
+from ._deps import (
+    OPTIMIZATION_DATA_ROOT,
+    OPTIMIZATION_TIMEOUT_SECONDS,
+    _check_gepa_available,
+    _parse_uuid_id,
+    _require_workspace_id,
+    _resolve_dataset_request,
+    parse_run_uuid,
+)
+
+logger = logging.getLogger(__name__)
+GEPA_OPTIMIZER_LABEL = "GEPA"
+
+
+@dataclass(frozen=True)
+class PreparedOptimizationRequest:
+    """Resolved execution inputs shared by blocking and async optimization requests."""
+
+    program_spec: str
+    dataset_path: Path
+    dataset_ref: str
+    output_path: Path | None
+    skill_path: str | None
+    trace_bundle_paths: list[str]
+    reflection_lm_config: dict[str, Any] | None
+
+
+def ensure_optimizer_runtime_available() -> None:
+    """Raise an HTTP error when the GEPA optimizer runtime is unavailable."""
+    if not _check_gepa_available():
+        raise HTTPException(
+            status_code=503,
+            detail="GEPA teleprompt module is not available.",
+        )
+
+
+def ensure_skill_optimization_runtime_available(request: GEPAOptimizationRequest) -> None:
+    """Raise when skill optimization is requested without Daytona credentials."""
+    if not request.skill_name and not request.skill_path:
+        return
+    if not os.environ.get("DAYTONA_API_KEY", "").strip():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Skill optimization requires Daytona because the RLM instruction proposer "
+                "runs in an isolated sandbox. Configure DAYTONA_API_KEY or optimize a "
+                "registered module instead."
+            ),
+        )
+
+
+def resolve_effective_program_spec(request: GEPAOptimizationRequest) -> str:
+    """Resolve the persisted run target label from a GEPA request."""
+    if request.skill_name:
+        return f"skill:{request.skill_name}"
+    if request.skill_path:
+        return f"skill:{request.skill_path}"
+    if request.module_slug:
+        from fleet_rlm.quality import module_registry
+
+        spec = module_registry.get_module_spec(request.module_slug)
+        if spec is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unknown module slug: {request.module_slug!r}",
+            )
+        return spec.program_spec
+    if not request.program_spec:
+        raise HTTPException(
+            status_code=400,
+            detail="Either module_slug, program_spec, skill_name, or skill_path must be provided.",
+        )
+    return request.program_spec
+
+
+def resolve_output_path(output_path: str | None) -> Path | None:
+    """Resolve an optional output path under the optimization artifact root."""
+    if not output_path:
+        return None
+    if os.path.isabs(output_path):
+        raise HTTPException(
+            status_code=400,
+            detail="Absolute paths are not allowed. Use a relative path.",
+        )
+    base_root = os.path.realpath(os.fspath(OPTIMIZATION_DATA_ROOT))
+    safe_root = os.path.join(base_root, "")
+    resolved_output = os.path.realpath(os.path.join(safe_root, output_path))
+    if resolved_output != base_root and not resolved_output.startswith(safe_root):
+        raise HTTPException(
+            status_code=400,
+            detail="Path escapes the allowed data directory.",
+        )
+    return Path(resolved_output)
+
+
+def resolve_skill_path(skill_path: str | None) -> str | None:
+    """Resolve a skill path with the same artifact-root policy as output paths."""
+    resolved = resolve_output_path(skill_path)
+    return str(resolved) if resolved is not None else None
+
+
+def resolve_trace_bundle_paths(paths: list[str] | None) -> list[str]:
+    """Resolve trace bundle paths under the optimization artifact root."""
+    if not paths:
+        return []
+    resolved_paths: list[str] = []
+    for raw_path in paths:
+        normalized = str(raw_path or "").strip()
+        if not normalized:
+            raise HTTPException(
+                status_code=400,
+                detail="trace_bundle_paths entries must be non-empty relative paths.",
+            )
+        resolved = resolve_output_path(normalized)
+        if resolved is None:
+            raise HTTPException(
+                status_code=400,
+                detail="trace_bundle_paths entries must be non-empty relative paths.",
+            )
+        resolved_paths.append(str(resolved))
+    return resolved_paths
+
+
+async def resolve_reflection_lm_config(
+    request: GEPAOptimizationRequest,
+    persistence_deps: Any,
+) -> dict[str, Any] | None:
+    """Resolve an optional saved provider/model selection into DSPy LM kwargs."""
+    if not request.reflection_profile_id and not request.reflection_model_id:
+        return None
+    if not request.reflection_profile_id or not request.reflection_model_id:
+        raise HTTPException(
+            status_code=400,
+            detail="reflection_profile_id and reflection_model_id must be provided together.",
+        )
+    try:
+        profile_uuid = uuid.UUID(request.reflection_profile_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid reflection_profile_id.") from exc
+
+    store = resolve_profile_store(persistence_deps.db_manager)
+    profile = await store.get_profile(profile_uuid)
+    if profile is None:
+        raise HTTPException(status_code=404, detail=f"Reflection profile {request.reflection_profile_id} not found.")
+
+    resolved = resolve_role_config(
+        role="delegate",
+        binding=LlmRoleBindingRecord(
+            role="delegate",
+            profile_id=profile.id,
+            model_id=request.reflection_model_id,
+        ),
+        profile=profile,
+    )
+    if resolved is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Selected reflection profile is missing credentials or model configuration.",
+        )
+    return {
+        "profile_id": str(profile.id),
+        "profile_name": profile.name,
+        "model_id": request.reflection_model_id,
+        "litellm_model": resolved.litellm_model,
+        "lm_kwargs": build_lm_kwargs_from_resolved(resolved, max_tokens=32_000),
+    }
+
+
+def build_run_metadata(
+    *,
+    request: GEPAOptimizationRequest,
+    dataset_ref: str,
+    reflection_lm_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the persistent metadata shared by blocking and async GEPA runs."""
+    trace_bundle_paths = resolve_trace_bundle_paths(list(request.trace_bundle_paths))
+    metadata: dict[str, Any] = {
+        "dataset_path": dataset_ref,
+        "skill_name": request.skill_name,
+        "skill_path": request.skill_path,
+        "max_metric_calls": request.max_metric_calls,
+        "trace_bundle_paths": trace_bundle_paths,
+        "distilled_trace_bundle_path": trace_bundle_paths[0] if trace_bundle_paths else None,
+    }
+    if reflection_lm_config:
+        metadata.update(
+            {
+                "reflection_profile_id": reflection_lm_config.get("profile_id"),
+                "reflection_profile_name": reflection_lm_config.get("profile_name"),
+                "reflection_model_id": reflection_lm_config.get("model_id"),
+                "reflection_litellm_model": reflection_lm_config.get("litellm_model"),
+            }
+        )
+    return metadata
+
+
+async def prepare_optimization_request(
+    *,
+    request: GEPAOptimizationRequest,
+    persistence: Any,
+    persistence_deps: Any,
+    persisted_identity: IdentityUpsertResult,
+) -> PreparedOptimizationRequest:
+    """Resolve all execution inputs for one GEPA optimization request."""
+    ensure_skill_optimization_runtime_available(request)
+    program_spec = resolve_effective_program_spec(request)
+    dataset_path, dataset_ref = await _resolve_dataset_request(
+        request,
+        persistence=persistence,
+        persisted_identity=persisted_identity,
+    )
+    return PreparedOptimizationRequest(
+        program_spec=program_spec,
+        dataset_path=dataset_path,
+        dataset_ref=dataset_ref,
+        output_path=resolve_output_path(request.output_path),
+        skill_path=resolve_skill_path(request.skill_path),
+        trace_bundle_paths=resolve_trace_bundle_paths(list(request.trace_bundle_paths)),
+        reflection_lm_config=await resolve_reflection_lm_config(request, persistence_deps),
+    )
+
+
+def _run_optimization(
+    *,
+    module_slug: str | None,
+    program_spec: str,
+    dataset_path: Path,
+    output_path: Path | None,
+    default_output_root: Path | None,
+    auto: Literal["light", "medium", "heavy"],
+    train_ratio: float,
+    optimizer: Literal["gepa"],
+    run_id: int | None = None,
+    max_metric_calls: int | None = None,
+    skill_name: str | None = None,
+    skill_path: str | None = None,
+    trace_bundle_paths: list[str] | None = None,
+    reflection_lm_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Blocking wrapper around the unified optimization pipeline."""
+    from fleet_rlm.quality.optimization_dispatch import (
+        resolve_optimization_spec,
+        run_optimization_for_spec,
+    )
+
+    spec = resolve_optimization_spec(
+        module_slug=module_slug,
+        skill_name=skill_name,
+        skill_path=skill_path,
+        program_spec=program_spec,
+        trace_bundle_paths=trace_bundle_paths,
+    )
+    return run_optimization_for_spec(
+        spec,
+        dataset_path=dataset_path,
+        output_path=output_path,
+        default_output_root=default_output_root,
+        train_ratio=train_ratio,
+        auto=auto,
+        max_metric_calls=max_metric_calls,
+        optimizer=optimizer,
+        run_id=run_id,
+        reflection_lm_config=reflection_lm_config,
+        trace_bundle_paths=trace_bundle_paths,
+    )
+
+
+async def create_blocking_run_record(
+    *,
+    request: GEPAOptimizationRequest,
+    persistence: Any,
+    persisted_identity: IdentityUpsertResult,
+    program_spec: str,
+    dataset_ref: str,
+    reflection_lm_config: dict[str, Any] | None,
+) -> str | None:
+    """Best-effort persistence record creation for the blocking endpoint."""
+    workspace_id = _require_workspace_id(persisted_identity)
+    dataset_uuid = (
+        _parse_uuid_id(
+            request.dataset_id,
+            detail=f"Dataset {request.dataset_id} not found.",
+        )
+        if request.dataset_id is not None
+        else None
+    )
+    try:
+        created_run = await persistence.create_optimization_run(
+            OptimizationRunCreateRequest(
+                tenant_id=persisted_identity.tenant_id,
+                workspace_id=workspace_id,
+                created_by_user_id=persisted_identity.user_id,
+                optimizer=GEPA_OPTIMIZER_LABEL,
+                program_spec=program_spec,
+                module_slug=request.module_slug,
+                dataset_id=dataset_uuid,
+                auto=request.auto,
+                train_ratio=request.train_ratio,
+                metadata_json=build_run_metadata(
+                    request=request,
+                    dataset_ref=dataset_ref,
+                    reflection_lm_config=reflection_lm_config,
+                ),
+            )
+        )
+        return str(created_run.id)
+    except Exception as exc:
+        logger.exception("Failed to create optimization run record", exc_info=exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to create optimization run record.",
+        ) from exc
+
+
+async def execute_blocking_optimization(
+    *,
+    request: GEPAOptimizationRequest,
+    dataset: Path,
+    output_path: Path | None,
+    resolved_skill_path: str | None,
+    program_spec: str,
+    reflection_lm_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Run one blocking optimization request through the worker pool."""
+    return await run_blocking(
+        partial(
+            _run_optimization,
+            module_slug=request.module_slug,
+            program_spec=program_spec,
+            dataset_path=dataset,
+            output_path=output_path,
+            default_output_root=OPTIMIZATION_DATA_ROOT,
+            auto=request.auto,
+            max_metric_calls=request.max_metric_calls,
+            train_ratio=request.train_ratio,
+            optimizer=request.optimizer,
+            run_id=None,
+            skill_name=request.skill_name,
+            skill_path=resolved_skill_path,
+            trace_bundle_paths=resolve_trace_bundle_paths(list(request.trace_bundle_paths)),
+            reflection_lm_config=reflection_lm_config,
+        ),
+        timeout=OPTIMIZATION_TIMEOUT_SECONDS,
+    )
+
+
+async def mark_blocking_run_failed(
+    *,
+    db_run_id: str | None,
+    persistence: Any,
+    persisted_identity: IdentityUpsertResult,
+    error: str,
+) -> None:
+    """Best-effort failure persistence for a blocking endpoint run."""
+    if db_run_id is None:
+        return
+    try:
+        from .run_persistence import persist_optimization_run_failure
+
+        run_uuid = parse_run_uuid(db_run_id)
+        await persist_optimization_run_failure(
+            persistence=persistence,
+            persisted_identity=persisted_identity,
+            run_uuid=run_uuid,
+            error=error,
+        )
+    except Exception:
+        logger.exception("Failed to mark GEPA optimization run %s as failed", db_run_id)
+
+
+async def mark_blocking_run_complete(
+    *,
+    db_run_id: str | None,
+    persistence: Any,
+    persisted_identity: IdentityUpsertResult,
+    result: dict[str, Any],
+) -> None:
+    """Best-effort completion persistence for a blocking endpoint run."""
+    if db_run_id is None:
+        return
+    try:
+        from .run_persistence import persist_optimization_run_success
+
+        run_uuid = parse_run_uuid(db_run_id)
+        await persist_optimization_run_success(
+            persistence=persistence,
+            persisted_identity=persisted_identity,
+            run_uuid=run_uuid,
+            result=result,
+        )
+    except Exception:
+        logger.exception("Failed to mark GEPA optimization run %s as complete", db_run_id)
+
+
+def blocking_optimization_response(
+    *,
+    result: dict[str, Any],
+    request: GEPAOptimizationRequest,
+    program_spec: str,
+) -> GEPAOptimizationResponse:
+    """Convert a successful blocking run result to the public response schema."""
+    return GEPAOptimizationResponse(
+        ok=True,
+        optimizer=result.get("optimizer", "GEPA"),
+        program_spec=result.get("program_spec", program_spec),
+        train_examples=result.get("train_examples", 0),
+        validation_examples=result.get("validation_examples", 0),
+        validation_score=result.get("validation_score"),
+        output_path=result.get("output_path"),
+        manifest_path=result.get("manifest_path"),
+        feedback_summary=result.get("feedback_summary"),
+        module_slug=request.module_slug,
+        reflection_profile_id=result.get("run_metadata", {}).get("reflection_profile_id"),
+        reflection_model_id=result.get("run_metadata", {}).get("reflection_model_id"),
+        distilled_trace_bundle_path=result.get("run_metadata", {}).get("distilled_trace_bundle_path"),
+    )
+
+
+def failed_blocking_optimization_response(
+    *,
+    exc: Exception,
+    request: GEPAOptimizationRequest,
+    program_spec: str,
+) -> GEPAOptimizationResponse:
+    """Convert a blocking run exception to the public failure response schema."""
+    return GEPAOptimizationResponse(
+        ok=False,
+        program_spec=program_spec,
+        train_examples=0,
+        validation_examples=0,
+        module_slug=request.module_slug,
+        error=str(exc),
+    )
+
+
+async def create_async_run_and_enqueue(
+    *,
+    request: GEPAOptimizationRequest,
+    background_tasks: BackgroundTasks,
+    persistence: Any,
+    persistence_deps: Any,
+    persisted_identity: IdentityUpsertResult,
+) -> OptimizationRunCreatedResponse:
+    """Create an async optimization run and enqueue its background task."""
+    prepared = await prepare_optimization_request(
+        request=request,
+        persistence=persistence,
+        persistence_deps=persistence_deps,
+        persisted_identity=persisted_identity,
+    )
+
+    db_row = await persistence.create_optimization_run(
+        OptimizationRunCreateRequest(
+            tenant_id=persisted_identity.tenant_id,
+            workspace_id=_require_workspace_id(persisted_identity),
+            created_by_user_id=persisted_identity.user_id,
+            optimizer=GEPA_OPTIMIZER_LABEL,
+            program_spec=prepared.program_spec,
+            module_slug=request.module_slug,
+            dataset_id=(
+                _parse_uuid_id(
+                    request.dataset_id,
+                    detail=f"Dataset {request.dataset_id} not found.",
+                )
+                if request.dataset_id is not None
+                else None
+            ),
+            auto=request.auto,
+            train_ratio=request.train_ratio,
+            metadata_json=build_run_metadata(
+                request=request,
+                dataset_ref=prepared.dataset_ref,
+                reflection_lm_config=prepared.reflection_lm_config,
+            ),
+        )
+    )
+    run_id = str(db_row.id)
+    from .background import run_optimization_background
+
+    background_tasks.add_task(
+        run_optimization_background,
+        run_id=run_id,
+        persistence=persistence,
+        persisted_identity=persisted_identity,
+        module_slug=request.module_slug,
+        dataset_path=prepared.dataset_path,
+        program_spec=prepared.program_spec,
+        output_path=prepared.output_path,
+        default_output_root=OPTIMIZATION_DATA_ROOT,
+        auto=request.auto,
+        max_metric_calls=request.max_metric_calls,
+        train_ratio=request.train_ratio,
+        optimizer=request.optimizer,
+        skill_name=request.skill_name,
+        skill_path=prepared.skill_path,
+        trace_bundle_paths=prepared.trace_bundle_paths,
+        reflection_lm_config=prepared.reflection_lm_config,
+    )
+    return OptimizationRunCreatedResponse(run_id=run_id, status="running")

--- a/src/fleet_rlm/api/routers/sessions.py
+++ b/src/fleet_rlm/api/routers/sessions.py
@@ -27,6 +27,8 @@ from ..schemas.sessions import (
     SessionRestoreResponse,
     SessionStateResponse,
     SessionStatsResponse,
+    SessionTraceExportRequest,
+    SessionTraceExportResponse,
     SessionTraceListResponse,
     TurnListResponse,
 )
@@ -197,6 +199,28 @@ async def get_session_traces(
         session_id=session_id,
         limit=limit,
         offset=offset,
+    )
+
+
+@router.post(
+    "/{session_id}/trace-export",
+    response_model=SessionTraceExportResponse,
+    responses=SESSION_DETAIL_RESPONSES,
+    summary="Export session MLflow traces",
+    description="Write full MLflow trace JSON/JSONL artifacts and a distilled GEPA evidence bundle.",
+)
+async def export_session_traces_endpoint(
+    body: SessionTraceExportRequest,
+    identity: HTTPIdentityDep,
+    persistence: PersistenceDep,
+    persisted_identity: PersistedIdentityDep,
+    session_id: Annotated[str, Path(description="Identifier of the session whose traces to export.")],
+) -> SessionTraceExportResponse:
+    """Export linked MLflow traces for offline GEPA optimization."""
+    return await SessionService(persistence).export_session_traces(
+        persisted_identity=persisted_identity,
+        session_id=session_id,
+        body=body,
     )
 
 

--- a/src/fleet_rlm/api/runtime_services/session_helpers.py
+++ b/src/fleet_rlm/api/runtime_services/session_helpers.py
@@ -20,8 +20,11 @@ def optional_string(value: object) -> str | None:
 
 def parse_session_uuid(session_id: str) -> uuid.UUID:
     """Parse the canonical repository-backed session UUID."""
+    normalized = session_id.strip()
+    if normalized.isdecimal():
+        return uuid.UUID(int=int(normalized))
     try:
-        return uuid.UUID(session_id)
+        return uuid.UUID(normalized)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
 

--- a/src/fleet_rlm/api/runtime_services/session_service.py
+++ b/src/fleet_rlm/api/runtime_services/session_service.py
@@ -28,6 +28,8 @@ from ..schemas.sessions import (
     SessionStateResponse,
     SessionStateSummary,
     SessionStatsResponse,
+    SessionTraceExportRequest,
+    SessionTraceExportResponse,
     SessionTraceItem,
     SessionTraceListResponse,
     TurnItem,
@@ -39,6 +41,7 @@ from .session_helpers import (
     session_external_id,
     string_or_default,
 )
+from .session_trace_export import export_owned_session_traces
 
 _TURN_COUNT_QUERY_LIMIT = 1
 _TRANSCRIPT_EXPORT_MAX_TURNS = 10_000
@@ -61,6 +64,12 @@ def _canonical_id(value: object) -> str:
     if isinstance(value, int):
         return str(uuid.UUID(int=value))
     return str(value)
+
+
+def _session_external_id_from_row(session: Any) -> str | None:
+    return session_external_id(getattr(session, "metadata_json", None)) or optional_string(
+        getattr(session, "external_session_id", None)
+    )
 
 
 async def _resolve_session_title(
@@ -423,6 +432,21 @@ class SessionService:
             offset=offset,
             limit=limit,
             has_more=(offset + limit) < total,
+        )
+
+    async def export_session_traces(
+        self,
+        *,
+        persisted_identity: IdentityUpsertResult,
+        session_id: str,
+        body: SessionTraceExportRequest,
+    ) -> SessionTraceExportResponse:
+        """Export full MLflow traces and a distilled GEPA evidence bundle."""
+        return await export_owned_session_traces(
+            persistence=self._persistence,
+            persisted_identity=persisted_identity,
+            session_id=session_id,
+            body=body,
         )
 
     async def get_session_stats(

--- a/src/fleet_rlm/api/runtime_services/session_trace_export.py
+++ b/src/fleet_rlm/api/runtime_services/session_trace_export.py
@@ -1,0 +1,225 @@
+"""Trace export orchestration for owned chat sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+
+from fleet_rlm.integrations.database.repository_identity import IdentityUpsertResult
+from fleet_rlm.integrations.persistence_protocol import UnsupportedLocalCapabilityError
+
+from ..schemas.sessions import SessionTraceExportRequest, SessionTraceExportResponse
+from .session_helpers import optional_string, parse_session_uuid, session_external_id
+
+__all__ = [
+    "export_owned_session_traces",
+    "ordered_runtime_session_ids",
+    "resolve_owned_chat_session",
+    "runtime_session_id_candidates",
+]
+
+
+def runtime_session_id_candidates(
+    *,
+    session: Any,
+    persisted_identity: IdentityUpsertResult,
+) -> list[str]:
+    external_id = session_external_id(getattr(session, "metadata_json", None)) or optional_string(
+        getattr(session, "external_session_id", None)
+    )
+    if not external_id:
+        return []
+    candidates = [
+        f"default:anonymous:{external_id}",
+        f"{getattr(session, 'workspace_id', '')}:{getattr(session, 'owner_user', '')}:{external_id}",
+        f"{persisted_identity.workspace_id}:{persisted_identity.user_id}:{external_id}",
+    ]
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for candidate in candidates:
+        value = str(candidate or "").strip()
+        if value and value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered
+
+
+def ordered_runtime_session_ids(
+    *,
+    session: Any,
+    persisted_identity: IdentityUpsertResult,
+    mlflow_session_id_hint: str | None,
+) -> list[str]:
+    """Return MLflow session ids authorized for export, optionally prioritizing a validated hint."""
+    candidates = runtime_session_id_candidates(
+        session=session,
+        persisted_identity=persisted_identity,
+    )
+    hint = optional_string(mlflow_session_id_hint)
+    if hint is None:
+        return candidates
+    if hint not in candidates:
+        raise HTTPException(
+            status_code=403,
+            detail="mlflow_session_id is not authorized for this session.",
+        )
+    return [hint, *[candidate for candidate in candidates if candidate != hint]]
+
+
+async def resolve_owned_chat_session(
+    *,
+    persistence: Any,
+    persisted_identity: IdentityUpsertResult,
+    session_id: str,
+) -> Any:
+    """Resolve a durable chat session owned by the caller."""
+    normalized = str(session_id or "").strip()
+    if not normalized:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    session_uuid: uuid.UUID | None = None
+    try:
+        session_uuid = parse_session_uuid(normalized)
+    except HTTPException:
+        session_uuid = None
+
+    session = None
+    if session_uuid is not None:
+        session = await persistence.get_chat_session(
+            tenant_id=persisted_identity.tenant_id,
+            session_id=session_uuid,
+            user_id=persisted_identity.user_id,
+            workspace_id=persisted_identity.workspace_id,
+        )
+
+    if session is None:
+        get_by_external = getattr(persistence, "get_chat_session_by_external_id", None)
+        if callable(get_by_external):
+            session = await get_by_external(
+                tenant_id=persisted_identity.tenant_id,
+                external_session_id=normalized,
+                user_id=persisted_identity.user_id,
+                workspace_id=persisted_identity.workspace_id,
+            )
+
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return session
+
+
+async def export_owned_session_traces(
+    *,
+    persistence: Any,
+    persisted_identity: IdentityUpsertResult,
+    session_id: str,
+    body: SessionTraceExportRequest,
+) -> SessionTraceExportResponse:
+    """Export full MLflow traces and a distilled GEPA evidence bundle for an owned session."""
+    from fleet_rlm.integrations.observability.mlflow_traces import (
+        resolve_trace,
+        search_traces_by_session_id,
+        trace_to_full_payload,
+    )
+    from fleet_rlm.quality.trace_bundles import write_session_trace_artifacts
+
+    session = await resolve_owned_chat_session(
+        persistence=persistence,
+        persisted_identity=persisted_identity,
+        session_id=session_id,
+    )
+    session_uuid = session.id
+    runtime_session_ids = ordered_runtime_session_ids(
+        session=session,
+        persisted_identity=persisted_identity,
+        mlflow_session_id_hint=body.mlflow_session_id,
+    )
+
+    traces: list[Any] = []
+    offset = 0
+    page_size = 200
+    external_trace_lookup_supported = True
+    try:
+        while True:
+            page, total = await persistence.list_external_traces_for_session(
+                tenant_id=persisted_identity.tenant_id,
+                session_id=session_uuid,
+                workspace_id=persisted_identity.workspace_id,
+                limit=page_size,
+                offset=offset,
+            )
+            traces.extend(page)
+            offset += len(page)
+            if offset >= total or not page:
+                break
+    except (UnsupportedLocalCapabilityError, NotImplementedError):
+        external_trace_lookup_supported = False
+
+    payloads: list[dict[str, Any]] = []
+    skipped_trace_ids: list[str] = []
+    errors: list[str] = []
+    for trace_row in traces:
+        trace_id = optional_string(getattr(trace_row, "trace_id", None))
+        client_request_id = optional_string(getattr(trace_row, "client_request_id", None))
+        try:
+            resolved = await asyncio.to_thread(
+                resolve_trace,
+                trace_id=trace_id,
+                client_request_id=client_request_id,
+            )
+        except Exception as exc:
+            skipped_trace_ids.append(trace_id or client_request_id or "unknown")
+            errors.append(f"{trace_id or client_request_id}: {exc}")
+            continue
+        if resolved is None:
+            skipped_trace_ids.append(trace_id or client_request_id or "unknown")
+            continue
+        payload = trace_to_full_payload(
+            resolved,
+            session_id=str(session_uuid),
+            turn_id=(str(trace_row.turn_id) if getattr(trace_row, "turn_id", None) is not None else None),
+            external_trace_metadata=dict(getattr(trace_row, "metadata_json", None) or {}),
+        )
+        payloads.append(payload)
+
+    if not payloads and not external_trace_lookup_supported:
+        for runtime_session_id in runtime_session_ids:
+            direct_traces = await asyncio.to_thread(
+                search_traces_by_session_id,
+                runtime_session_id,
+                allow_unfiltered_fallback=False,
+            )
+            if not direct_traces:
+                continue
+            for trace in direct_traces:
+                payloads.append(
+                    trace_to_full_payload(
+                        trace,
+                        session_id=str(session_uuid),
+                        turn_id=None,
+                        external_trace_metadata={
+                            "runtime_session_id": runtime_session_id,
+                            "trace_lookup": "mlflow_session_id",
+                        },
+                    )
+                )
+            break
+
+    artifacts = await asyncio.to_thread(
+        write_session_trace_artifacts,
+        session_id=str(session_uuid),
+        payloads=payloads,
+        export_format=body.format,
+    )
+    return SessionTraceExportResponse(
+        session_id=str(session_uuid),
+        trace_count=len(payloads),
+        json_path=artifacts["json_path"],
+        jsonl_path=artifacts["jsonl_path"],
+        distilled_bundle_path=artifacts["distilled_bundle_path"],
+        skipped_trace_ids=skipped_trace_ids,
+        errors=errors,
+        summary=artifacts["summary"],
+    )

--- a/src/fleet_rlm/api/schemas/sessions.py
+++ b/src/fleet_rlm/api/schemas/sessions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -207,6 +207,47 @@ class SessionExportRequest(BaseModel):
 
     module_slug: str = Field(
         description="Target GEPA module slug whose dataset keys determine the export column mapping."
+    )
+
+
+class SessionTraceExportRequest(BaseModel):
+    """Request body for exporting a session's linked MLflow traces."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    format: Literal["json", "jsonl", "both"] = Field(
+        default="both",
+        description="Trace artifact format to write.",
+    )
+    mlflow_session_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional MLflow trace session id hint. The server validates the hint against "
+            "authorized runtime session ids for the resolved durable session before export."
+        ),
+    )
+
+
+class SessionTraceExportResponse(BaseModel):
+    """Trace export artifact paths for a session."""
+
+    ok: bool = Field(default=True, description="Whether trace export completed.")
+    session_id: str = Field(description="Durable session identifier.")
+    trace_count: int = Field(description="Number of MLflow traces exported.")
+    json_path: str | None = Field(default=None, description="Path to the full JSON trace artifact.")
+    jsonl_path: str | None = Field(default=None, description="Path to the full JSONL trace artifact.")
+    distilled_bundle_path: str | None = Field(
+        default=None,
+        description="Path to the distilled GEPA evidence bundle.",
+    )
+    skipped_trace_ids: list[str] = Field(
+        default_factory=list,
+        description="Trace identifiers that could not be resolved/exported.",
+    )
+    errors: list[str] = Field(default_factory=list, description="Non-fatal export errors.")
+    summary: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Distilled trace export summary.",
     )
 
 

--- a/src/fleet_rlm/integrations/database/repository_chat.py
+++ b/src/fleet_rlm/integrations/database/repository_chat.py
@@ -363,6 +363,32 @@ class ChatRepository(RepositoryContextMixin):
             result = await session.execute(stmt)
             return result.scalar_one_or_none()
 
+    async def get_chat_session_by_external_id(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        external_session_id: str,
+        user_id: uuid.UUID | None = None,
+        workspace_id: uuid.UUID | None = None,
+    ) -> ChatSession | None:
+        normalized = str(external_session_id or "").strip()
+        if not normalized:
+            return None
+        async with self._db.session() as session, session.begin():
+            await self._set_request_context(session, tenant_id, user_id, workspace_id)
+            stmt: Select[tuple[ChatSession]] = select(ChatSession).where(
+                and_(
+                    ChatSession.tenant_id == tenant_id,
+                    ChatSession.metadata_json["external_session_id"].as_string() == normalized,
+                )
+            )
+            if user_id is not None:
+                stmt = stmt.where(ChatSession.user_id == user_id)
+            if workspace_id is not None:
+                stmt = stmt.where(ChatSession.workspace_id == workspace_id)
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
+
     async def list_chat_turns(
         self,
         *,

--- a/src/fleet_rlm/integrations/local_store.py
+++ b/src/fleet_rlm/integrations/local_store.py
@@ -649,6 +649,26 @@ def get_chat_session(
         return row
 
 
+def get_chat_session_by_external_id(
+    external_session_id: str,
+    *,
+    owner_tenant: str | None = None,
+    owner_user: str | None = None,
+) -> ChatSession | None:
+    """Return a session by runtime websocket id with ownership check."""
+    normalized = str(external_session_id or "").strip()
+    if not normalized:
+        return None
+    with get_session() as db:
+        stmt = select(ChatSession).where(ChatSession.external_session_id == normalized)
+        if owner_tenant is not None:
+            stmt = stmt.where(ChatSession.owner_tenant == owner_tenant)
+        if owner_user is not None:
+            stmt = stmt.where(ChatSession.owner_user == owner_user)
+        row = db.exec(stmt).first()
+        return row
+
+
 def update_chat_session(
     session_id: int,
     *,
@@ -1128,6 +1148,23 @@ class LocalStore(PersistenceProtocol):
         result = await asyncio.to_thread(
             get_chat_session,
             session_id_int,
+            owner_tenant=str(tenant_id),
+            owner_user=str(user_id) if user_id is not None else None,
+        )
+        return cast(DbChatSession | None, result)
+
+    async def get_chat_session_by_external_id(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        external_session_id: str,
+        user_id: uuid.UUID | None = None,
+        workspace_id: uuid.UUID | None = None,
+    ) -> DbChatSession | None:
+        _ = workspace_id
+        result = await asyncio.to_thread(
+            get_chat_session_by_external_id,
+            external_session_id,
             owner_tenant=str(tenant_id),
             owner_user=str(user_id) if user_id is not None else None,
         )

--- a/src/fleet_rlm/integrations/observability/mlflow_traces.py
+++ b/src/fleet_rlm/integrations/observability/mlflow_traces.py
@@ -95,6 +95,100 @@ def resolve_trace_by_client_request_id(
     return matches[0]
 
 
+def _trace_session_id(trace: Trace) -> str | None:
+    payload = trace.to_dict() if hasattr(trace, "to_dict") else {}
+    info_payload = payload.get("info") if isinstance(payload, dict) else None
+    info_dict = info_payload if isinstance(info_payload, dict) else _object_to_dict(getattr(trace, "info", None)) or {}
+    candidates = [
+        info_dict.get("session_id"),
+        info_dict.get("trace_session_id"),
+        info_dict.get("mlflow.trace.session_id"),
+        getattr(getattr(trace, "info", None), "session_id", None),
+    ]
+    trace_metadata = info_dict.get("trace_metadata")
+    if isinstance(trace_metadata, dict):
+        candidates.extend(
+            [
+                trace_metadata.get("mlflow.trace.session"),
+                trace_metadata.get("mlflow.traceSessionId"),
+                trace_metadata.get("mlflow.trace.session_id"),
+                trace_metadata.get("fleet_rlm.session_id"),
+            ]
+        )
+    for candidate in candidates:
+        value = str(candidate or "").strip()
+        if value:
+            return value
+    return None
+
+
+def search_traces_by_session_id(
+    session_id: str,
+    *,
+    config: MlflowConfig | None = None,
+    max_results: int = 5000,
+    allow_unfiltered_fallback: bool = True,
+) -> list[Trace]:
+    """Return MLflow traces whose trace session id matches a runtime session."""
+    mlflow = runtime._import_mlflow()
+    if mlflow is None:
+        return []
+
+    resolved = config or runtime.get_mlflow_config()
+    experiment_ids = _trace_experiment_ids(resolved)
+    if not experiment_ids:
+        return []
+
+    literal = runtime._mlflow_string_literal(session_id)
+    traces: list[Trace] = []
+    for filter_string in (
+        f"metadata.`mlflow.trace.session` = '{literal}'",
+        f"trace.session_id = '{literal}'",
+        f"metadata.`mlflow.traceSessionId` = '{literal}'",
+        f"metadata.`mlflow.trace.session_id` = '{literal}'",
+    ):
+        try:
+            traces = list(
+                _search_traces(
+                    mlflow,
+                    experiment_ids=experiment_ids,
+                    filter_string=filter_string,
+                    max_results=max_results,
+                    return_type="list",
+                    include_spans=True,
+                )
+            )
+        except Exception:
+            traces = []
+        if traces:
+            break
+    if not traces and allow_unfiltered_fallback:
+        try:
+            traces = list(
+                _search_traces(
+                    mlflow,
+                    experiment_ids=experiment_ids,
+                    max_results=max_results,
+                    return_type="list",
+                    include_spans=True,
+                )
+            )
+        except Exception:
+            runtime.logger.warning(
+                "Failed to search MLflow traces for session id '%s'.",
+                runtime._sanitize_log_field(session_id),
+                exc_info=True,
+            )
+            return []
+
+    matches = [trace for trace in traces if _trace_session_id(trace) == session_id]
+    matches.sort(
+        key=lambda trace: int(getattr(getattr(trace, "info", None), "timestamp_ms", 0) or 0),
+        reverse=True,
+    )
+    return matches
+
+
 def resolve_trace(
     *,
     trace_id: str | None = None,
@@ -205,21 +299,109 @@ def _trace_assessment_dicts(trace: Trace) -> list[dict[str, Any]]:
     return assessments
 
 
-def _trace_span_types(trace: Trace) -> list[str]:
-    span_types: list[str] = []
-    seen: set[str] = set()
+def _object_to_dict(value: Any) -> dict[str, Any] | None:
+    """Best-effort conversion for MLflow trace/span objects."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    for method_name in ("to_dictionary", "to_dict"):
+        method = getattr(value, method_name, None)
+        if callable(method):
+            try:
+                result = method()
+            except Exception:
+                continue
+            if isinstance(result, dict):
+                return result
+    data: dict[str, Any] = {}
+    for attr_name in (
+        "trace_id",
+        "client_request_id",
+        "request_id",
+        "span_id",
+        "parent_id",
+        "name",
+        "status",
+        "span_type",
+        "type",
+        "start_time_ns",
+        "end_time_ns",
+        "inputs",
+        "outputs",
+        "attributes",
+    ):
+        if hasattr(value, attr_name):
+            data[attr_name] = getattr(value, attr_name)
+    return data or None
+
+
+def _trace_span_dicts(trace: Trace) -> list[dict[str, Any]]:
+    spans: list[dict[str, Any]] = []
     try:
         raw_spans = trace.search_spans()
     except Exception:
         raw_spans = []
-
     for span in raw_spans or []:
-        candidate = str(getattr(span, "span_type", None) or getattr(span, "type", None) or "").strip()
+        data = _object_to_dict(span)
+        if data is not None:
+            spans.append(data)
+    return spans
+
+
+def _trace_span_types(trace: Trace) -> list[str]:
+    span_types: list[str] = []
+    seen: set[str] = set()
+    for span in _trace_span_dicts(trace):
+        candidate = str(span.get("span_type") or span.get("type") or "").strip()
         if not candidate or candidate in seen:
             continue
         seen.add(candidate)
         span_types.append(candidate)
     return span_types
+
+
+def trace_to_full_payload(
+    trace: Trace,
+    *,
+    session_id: str | None = None,
+    turn_id: str | None = None,
+    external_trace_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Serialize a full MLflow trace for audit and offline GEPA distillation."""
+    payload = trace.to_dict() if hasattr(trace, "to_dict") else {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    info_payload = payload.get("info")
+    if not isinstance(info_payload, dict):
+        info_payload = _object_to_dict(getattr(trace, "info", None)) or {}
+        payload["info"] = info_payload
+
+    data_payload = payload.get("data")
+    if not isinstance(data_payload, dict):
+        data_payload = _object_to_dict(getattr(trace, "data", None)) or {}
+        if data_payload:
+            payload["data"] = data_payload
+
+    metadata = dict(external_trace_metadata or {})
+    trace_metadata = info_payload.get("trace_metadata")
+    if isinstance(trace_metadata, dict):
+        metadata.update(trace_metadata)
+
+    payload.update(
+        {
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "trace_id": info_payload.get("trace_id") or getattr(getattr(trace, "info", None), "trace_id", None),
+            "client_request_id": info_payload.get("client_request_id")
+            or getattr(getattr(trace, "info", None), "client_request_id", None),
+            "metadata": metadata,
+            "spans": _trace_span_dicts(trace),
+            "assessments": _trace_assessment_dicts(trace),
+        }
+    )
+    return payload
 
 
 def _assessment_source_field(assessment: dict[str, Any], key: str) -> str:
@@ -369,6 +551,8 @@ __all__ = [
     "log_trace_feedback",
     "resolve_trace",
     "resolve_trace_by_client_request_id",
+    "search_traces_by_session_id",
     "search_annotated_trace_rows",
+    "trace_to_full_payload",
     "trace_to_dataset_row",
 ]

--- a/src/fleet_rlm/integrations/persistence_protocol.py
+++ b/src/fleet_rlm/integrations/persistence_protocol.py
@@ -142,6 +142,17 @@ class PersistenceProtocol(Protocol):
         """Return a single chat session or None if not found."""
         pass
 
+    async def get_chat_session_by_external_id(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        external_session_id: str,
+        user_id: uuid.UUID | None = None,
+        workspace_id: uuid.UUID | None = None,
+    ) -> ChatSession | None:
+        """Return a chat session linked to a runtime websocket session id."""
+        pass
+
     async def list_chat_turns(
         self,
         *,

--- a/src/fleet_rlm/quality/optimize_longcot.py
+++ b/src/fleet_rlm/quality/optimize_longcot.py
@@ -9,6 +9,8 @@ The module uses :class:`~fleet_rlm.runtime.agent.signatures.LongCoTQASignature`
 
 from __future__ import annotations
 
+import ast
+import json
 import re
 from collections import Counter
 from difflib import SequenceMatcher
@@ -38,6 +40,7 @@ _VERIFY_RE = re.compile(
     r"\b(check|verify|verified|confirm|double-check|sanity check)\b",
     re.IGNORECASE,
 )
+_SOLUTION_RE = re.compile(r"\bsolution\s*=\s*(?P<payload>.+)", re.IGNORECASE | re.DOTALL)
 
 
 def _normalize_text(value: Any) -> str:
@@ -57,6 +60,47 @@ def _clip_text(text: str, limit: int = 80) -> str:
     return f"{text[: limit - 3]}..."
 
 
+def _extract_solution_payload(text: str) -> tuple[str | None, bool]:
+    """Extract the verifier-facing solution payload when a marker is present."""
+    match = _SOLUTION_RE.search(text)
+    if not match:
+        return None, False
+    return match.group("payload").strip(), True
+
+
+def _parse_answer_payload(payload: str) -> Any:
+    """Parse structured answer payloads without executing arbitrary code."""
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        pass
+    if len(payload) > 1000:
+        return None
+    try:
+        return ast.literal_eval(payload)
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+        return None
+
+
+def _structured_mismatch_feedback(expected_value: Any, actual_value: Any, expected: str) -> str:
+    """Describe verifier-visible structured answer mismatches."""
+    missing_detail = ""
+    if isinstance(expected_value, dict) and isinstance(actual_value, dict):
+        missing_keys = sorted(str(key) for key in set(expected_value) - set(actual_value))
+        if missing_keys:
+            missing_detail = f" Missing required keys: {', '.join(missing_keys)}."
+    elif isinstance(expected_value, (list, tuple)) and isinstance(actual_value, (list, tuple)):
+        if len(actual_value) < len(expected_value):
+            missing_detail = " Missing required list entries."
+
+    if missing_detail:
+        return (
+            "Structured solution is incomplete and incorrect for the verifier."
+            f"{missing_detail} Replace it with '{_clip_text(expected)}'."
+        )
+    return f"Structured solution is incorrect. Replace it with '{_clip_text(expected)}'."
+
+
 def _score_answer(expected: str, actual: str) -> tuple[float, str]:
     """Score final-answer quality with exact, partial, related, and failed tiers."""
     expected_normalized = _normalize_text(expected)
@@ -71,6 +115,35 @@ def _score_answer(expected: str, actual: str) -> tuple[float, str]:
     actual_lower = actual_normalized.lower()
     if expected_lower == actual_lower:
         return 1.0, "Answer exactly matches the reference."
+
+    expected_payload, expected_has_solution = _extract_solution_payload(expected_normalized)
+    actual_payload, actual_has_solution = _extract_solution_payload(actual_normalized)
+    if expected_has_solution:
+        if not actual_has_solution or actual_payload is None:
+            return (
+                0.0,
+                "Missing solution = marker, so the final answer is verifier-incompatible.",
+            )
+        if expected_payload is None:
+            return 0.0, "Reference solution marker did not include a comparable payload."
+
+        expected_value = _parse_answer_payload(expected_payload)
+        actual_value = _parse_answer_payload(actual_payload)
+        if expected_value is not None and actual_value is not None:
+            if expected_value == actual_value:
+                return 1.0, "Answer solution payload exactly matches the reference."
+            return 0.0, _structured_mismatch_feedback(
+                expected_value,
+                actual_value,
+                expected_normalized,
+            )
+
+        if expected_payload.lower() == actual_payload.lower():
+            return 1.0, "Answer solution payload exactly matches the reference."
+        return (
+            0.0,
+            f"Solution payload is incorrect. Replace it with '{_clip_text(expected_normalized)}'.",
+        )
 
     expected_tokens = set(_tokenize(expected_normalized))
     actual_tokens = set(_tokenize(actual_normalized))
@@ -250,6 +323,8 @@ def _metric_builder() -> Any:
             (_ANSWER_WEIGHT * answer_score) + (_REASONING_WEIGHT * reasoning_score),
             4,
         )
+        if answer_score <= 0.0:
+            score = min(score, 0.35 if actual_answer else 0.25)
         tier, next_step = _score_tier(score)
         feedback = (
             f"Tier: {tier}. "

--- a/src/fleet_rlm/quality/trace_bundles.py
+++ b/src/fleet_rlm/quality/trace_bundles.py
@@ -1,0 +1,171 @@
+"""Trace bundle export and distillation helpers for offline GEPA runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any, Literal, TypedDict
+
+TraceExportFormat = Literal["json", "jsonl", "both"]
+
+
+class TraceExportArtifacts(TypedDict):
+    json_path: str | None
+    jsonl_path: str | None
+    distilled_bundle_path: str
+    summary: dict[str, Any]
+
+
+def _artifact_root(root: str | Path | None = None) -> Path:
+    return Path(root or os.environ.get("FLEET_RLM_OPTIMIZATION_DATA_ROOT", os.getcwd())).resolve()
+
+
+def _safe_segment(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-") or "session"
+
+
+def session_trace_export_dir(session_id: str, *, root: str | Path | None = None) -> Path:
+    """Return the artifact directory for one session trace export."""
+    return _artifact_root(root) / "traces" / "sessions" / _safe_segment(session_id)
+
+
+def _text_blob(payload: dict[str, Any]) -> str:
+    pieces: list[str] = []
+    info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    for source in (info, data, payload.get("metadata")):
+        if isinstance(source, dict):
+            pieces.append(json.dumps(source, default=str, sort_keys=True))
+    for key in ("spans", "assessments"):
+        raw = payload.get(key)
+        if isinstance(raw, list):
+            pieces.append(json.dumps(raw[:20], default=str, sort_keys=True))
+    return "\n".join(pieces).lower()
+
+
+def _classify_failure_categories(payload: dict[str, Any]) -> list[str]:
+    blob = _text_blob(payload)
+    categories: list[str] = []
+    if any(token in blob for token in ("exception", "traceback", "failed", "error", "status_code")):
+        categories.append("interface_failures")
+    if any(token in blob for token in ("missing evidence", "citation", "unsupported", "not enough evidence")):
+        categories.append("missing_evidence")
+    if any(token in blob for token in ("tool", "function_call", "bad tool", "invalid tool")):
+        categories.append("bad_tool_use")
+    if any(token in blob for token in ("unsafe", "policy", "credential", "secret", "injection")):
+        categories.append("unsafe_behavior")
+    if any(token in blob for token in ("format", "json", "schema", "parse", "malformed")):
+        categories.append("formatting_issues")
+    if any(token in blob for token in ("loop", "iteration", "timeout", "budget", "token limit", "max_llm_calls")):
+        categories.append("loop_inefficiency")
+    return categories or ["needs_review"]
+
+
+def _prompt_recommendations(categories: list[str]) -> list[str]:
+    recommendations: list[str] = []
+    if "interface_failures" in categories:
+        recommendations.append("Add explicit recovery instructions for interface errors and failed calls.")
+    if "missing_evidence" in categories:
+        recommendations.append("Require cited evidence before final answers and mark unsupported claims.")
+    if "bad_tool_use" in categories:
+        recommendations.append("Clarify when to use tools, when to inspect outputs, and when to stop.")
+    if "unsafe_behavior" in categories:
+        recommendations.append("Strengthen safety, credential handling, and prompt-injection constraints.")
+    if "formatting_issues" in categories:
+        recommendations.append("Tighten output-format requirements and schema validation steps.")
+    if "loop_inefficiency" in categories:
+        recommendations.append("Add loop budget discipline and early-stop criteria.")
+    if not recommendations:
+        recommendations.append("Compare expected and actual behavior, then make the smallest prompt change.")
+    return recommendations
+
+
+def trace_payload_to_distilled_row(payload: dict[str, Any]) -> dict[str, Any]:
+    """Distill a full trace payload into one GEPA proposer evidence row."""
+    raw_info = payload.get("info")
+    info: dict[str, Any] = raw_info if isinstance(raw_info, dict) else {}
+    categories = _classify_failure_categories(payload)
+    raw_assessments = payload.get("assessments")
+    assessments: list[Any] = raw_assessments if isinstance(raw_assessments, list) else []
+    raw_spans = payload.get("spans")
+    spans: list[Any] = raw_spans if isinstance(raw_spans, list) else []
+    raw_metadata = payload.get("metadata")
+    metadata: dict[str, Any] = raw_metadata if isinstance(raw_metadata, dict) else {}
+    return {
+        "kind": "trace_evidence",
+        "trace_id": info.get("trace_id") or payload.get("trace_id"),
+        "client_request_id": info.get("client_request_id") or payload.get("client_request_id"),
+        "session_id": payload.get("session_id"),
+        "turn_id": payload.get("turn_id"),
+        "failure_categories": categories,
+        "assessment_count": len(assessments),
+        "span_count": len(spans),
+        "span_types": sorted(
+            {
+                str(span.get("span_type") or span.get("type"))
+                for span in spans
+                if isinstance(span, dict) and (span.get("span_type") or span.get("type"))
+            }
+        ),
+        "metadata_keys": sorted(metadata.keys()),
+        "prompt_change_recommendations": _prompt_recommendations(categories),
+        "supporting_trace_path": payload.get("source_trace_path"),
+    }
+
+
+def distill_trace_payloads(payloads: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Return distilled rows and a compact run-level summary."""
+    rows = [trace_payload_to_distilled_row(payload) for payload in payloads]
+    category_counts = Counter(category for row in rows for category in row.get("failure_categories", []))
+    summary = {
+        "version": 1,
+        "trace_count": len(payloads),
+        "failure_clusters": [
+            {"category": category, "count": count} for category, count in sorted(category_counts.items())
+        ],
+    }
+    return rows, summary
+
+
+def write_session_trace_artifacts(
+    *,
+    session_id: str,
+    payloads: list[dict[str, Any]],
+    export_format: TraceExportFormat = "both",
+    root: str | Path | None = None,
+) -> TraceExportArtifacts:
+    """Write full trace artifacts and the distilled GEPA evidence bundle."""
+    export_dir = session_trace_export_dir(session_id, root=root)
+    export_dir.mkdir(parents=True, exist_ok=True)
+    base = export_dir / "mlflow-traces"
+
+    json_path: Path | None = None
+    jsonl_path: Path | None = None
+    if export_format in ("json", "both"):
+        json_path = base.with_suffix(".json")
+        json_path.write_text(json.dumps(payloads, indent=2, sort_keys=True, default=str), encoding="utf-8")
+    if export_format in ("jsonl", "both"):
+        jsonl_path = base.with_suffix(".jsonl")
+        jsonl_path.write_text(
+            "\n".join(json.dumps(payload, sort_keys=True, default=str) for payload in payloads)
+            + ("\n" if payloads else ""),
+            encoding="utf-8",
+        )
+
+    distilled_rows, summary = distill_trace_payloads(payloads)
+    distilled_path = export_dir / "mlflow-traces.distilled.jsonl"
+    distilled_payloads = [{"kind": "trace_bundle_summary", **summary}, *distilled_rows]
+    distilled_path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True, default=str) for row in distilled_payloads)
+        + ("\n" if distilled_payloads else ""),
+        encoding="utf-8",
+    )
+    return {
+        "json_path": str(json_path) if json_path else None,
+        "jsonl_path": str(jsonl_path) if jsonl_path else None,
+        "distilled_bundle_path": str(distilled_path),
+        "summary": summary,
+    }

--- a/src/frontend/src/features/workspace/screen/workspace-screen.tsx
+++ b/src/frontend/src/features/workspace/screen/workspace-screen.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useMutation } from "@tanstack/react-query";
+import { FileJson, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { useTelemetry } from "@/lib/telemetry/use-telemetry";
 import { useAppNavigate } from "@/hooks/use-app-navigate";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -16,6 +21,15 @@ import { getWorkspaceRuntimeGuard } from "@/features/workspace/runtime-guard";
 import { detectRepoContext } from "@/lib/utils/repo-context";
 import { detectContextPaths } from "@/lib/utils/source-context";
 import { isRlmCoreEnabled } from "@/lib/rlm-api";
+import { rlmApiClient } from "@/lib/rlm-api/client";
+
+type SessionTraceExportResponse = {
+  session_id: string;
+  trace_count: number;
+  distilled_bundle_path: string;
+  json_path: string;
+  jsonl_path: string;
+};
 import type { WsExecutionMode } from "@/lib/rlm-api/ws-types";
 import { requestSettingsDialogOpen } from "@/features/settings/settings-events";
 
@@ -74,9 +88,38 @@ export function WorkspaceScreen() {
     loadConversation,
   } = chatRuntime;
   const stopStreaming = useChatStore((state) => state.stopStreaming);
+  const sessionId = useChatStore((state) => state.sessionId);
   const [executionMode, setExecutionMode] = useState<WsExecutionMode>("auto");
   const runtimeMode = useChatStore((state) => state.runtimeMode);
   const setRuntimeMode = useChatStore((state) => state.setRuntimeMode);
+  const [headerActionsHost, setHeaderActionsHost] = useState<HTMLElement | null>(null);
+  const [traceExport, setTraceExport] = useState<SessionTraceExportResponse | null>(null);
+  const { mutate: exportTraceMutation, isPending: isExportingTraces } = useMutation({
+    mutationFn: (targetSessionId: string) =>
+      rlmApiClient.post<SessionTraceExportResponse>(
+        `/api/v1/sessions/${encodeURIComponent(targetSessionId)}/trace-export`,
+        { format: "both" },
+        undefined,
+        120_000,
+      ),
+    onSuccess: (result) => {
+      setTraceExport(result);
+      if (result.trace_count === 0) {
+        toast.warning("Trace export completed with no traces", {
+          description: "Run a chat turn first or verify the session is linked to MLflow traces.",
+        });
+        return;
+      }
+      toast.success("Trace export ready", {
+        description: result.distilled_bundle_path ?? result.jsonl_path ?? result.json_path,
+      });
+    },
+    onError: (error) => {
+      toast.error("Trace export failed", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    },
+  });
 
   const didInitRuntimeMode = useRef(false);
   useEffect(() => {
@@ -84,6 +127,15 @@ export function WorkspaceScreen() {
     didInitRuntimeMode.current = true;
     setRuntimeMode("daytona_pilot");
   }, [setRuntimeMode]);
+
+  useEffect(() => {
+    const updateHeaderActionsHost = () => {
+      setHeaderActionsHost(document.getElementById("workspace-header-actions"));
+    };
+
+    updateHeaderActionsHost();
+    window.requestAnimationFrame(updateHeaderActionsHost);
+  }, []);
 
   const handleOpenRuntimeSettings = useCallback(() => {
     const wasHandledByDialog = requestSettingsDialogOpen({
@@ -216,11 +268,56 @@ export function WorkspaceScreen() {
     hasMessages,
   });
 
+  const handleExportTraces = useCallback(() => {
+    const trimmedSessionId = (sessionId ?? "").trim();
+    if (!trimmedSessionId) {
+      toast.error("No active runtime session id is available.");
+      return;
+    }
+    exportTraceMutation(trimmedSessionId);
+  }, [exportTraceMutation, sessionId]);
+
+  const traceExportAction = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-8 gap-1.5 text-xs"
+      disabled={!sessionId || isExportingTraces}
+      onClick={handleExportTraces}
+      title="Export traces for GEPA"
+    >
+      {isExportingTraces ? (
+        <Loader2 className="animate-spin" data-icon="inline-start" />
+      ) : (
+        <FileJson data-icon="inline-start" />
+      )}
+      Export traces for GEPA
+    </Button>
+  );
+
   return (
     <div className="flex flex-col h-full w-full bg-background overflow-hidden">
+      {headerActionsHost ? createPortal(traceExportAction, headerActionsHost) : null}
       <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
         {/* Main chat column */}
         <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+          {traceExport ? (
+            <div className="px-4 pt-4 md:px-6">
+              <Alert className="mx-auto max-w-175">
+                <FileJson className="text-muted-foreground" />
+                <AlertTitle>Trace export ready for GEPA</AlertTitle>
+                <AlertDescription>
+                  <div className="space-y-1 text-xs">
+                    <div>Session: {traceExport.session_id}</div>
+                    <div>JSON: {traceExport.json_path ?? "-"}</div>
+                    <div>JSONL: {traceExport.jsonl_path ?? "-"}</div>
+                    <div>Distilled: {traceExport.distilled_bundle_path ?? "-"}</div>
+                  </div>
+                </AlertDescription>
+              </Alert>
+            </div>
+          ) : null}
           <div className="flex-1 min-h-0" data-slot="workspace-agent-chat">
             <WorkspaceMessageList
               messages={messages}

--- a/tests/unit/api/test_optimization_paths.py
+++ b/tests/unit/api/test_optimization_paths.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from fleet_rlm.api.routers.optimization._deps import OPTIMIZATION_DATA_ROOT
+from fleet_rlm.api.routers.optimization.orchestration import (
+    resolve_output_path,
+    resolve_trace_bundle_paths,
+)
+
+
+def test_resolve_trace_bundle_paths_accepts_relative_paths_under_root(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.api.routers.optimization.orchestration.OPTIMIZATION_DATA_ROOT",
+        tmp_path,
+    )
+    bundle_dir = tmp_path / "traces"
+    bundle_dir.mkdir()
+    bundle_file = bundle_dir / "session.jsonl"
+    bundle_file.write_text("{}\n", encoding="utf-8")
+
+    resolved = resolve_trace_bundle_paths(["traces/session.jsonl"])
+
+    assert resolved == [str(bundle_file.resolve())]
+
+
+def test_resolve_trace_bundle_paths_rejects_absolute_paths() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_trace_bundle_paths(["/etc/passwd"])
+
+    assert exc_info.value.status_code == 400
+    assert "Absolute paths" in str(exc_info.value.detail)
+
+
+def test_resolve_trace_bundle_paths_rejects_path_traversal(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.api.routers.optimization.orchestration.OPTIMIZATION_DATA_ROOT",
+        tmp_path / "artifacts",
+    )
+    (tmp_path / "artifacts").mkdir()
+    outside = tmp_path / "outside.env"
+    outside.write_text("SECRET=1\n", encoding="utf-8")
+
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_trace_bundle_paths(["../outside.env"])
+
+    assert exc_info.value.status_code == 400
+    assert "escapes" in str(exc_info.value.detail).lower()
+
+
+def test_resolve_trace_bundle_paths_rejects_empty_entries() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_trace_bundle_paths(["  "])
+
+    assert exc_info.value.status_code == 400
+
+
+def test_resolve_output_path_matches_trace_bundle_policy(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.api.routers.optimization.orchestration.OPTIMIZATION_DATA_ROOT",
+        tmp_path,
+    )
+    allowed = tmp_path / "datasets" / "train.jsonl"
+    allowed.parent.mkdir(parents=True)
+    allowed.write_text("[]\n", encoding="utf-8")
+
+    resolved = resolve_output_path("datasets/train.jsonl")
+
+    assert resolved == Path(allowed.resolve())
+    assert str(OPTIMIZATION_DATA_ROOT)  # import used for parity with production root constant

--- a/tests/unit/api/test_session_traces.py
+++ b/tests/unit/api/test_session_traces.py
@@ -6,9 +6,13 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 
 from fleet_rlm.api.runtime_services.session_service import SessionService
+from fleet_rlm.api.schemas.sessions import SessionTraceExportRequest
 from fleet_rlm.integrations.database.models_enums import ExternalTraceProvider
+from fleet_rlm.integrations.observability.mlflow_traces import _trace_session_id
+from fleet_rlm.integrations.persistence_protocol import UnsupportedLocalCapabilityError
 
 
 @pytest.mark.asyncio
@@ -43,3 +47,365 @@ async def test_get_session_traces_maps_repository_rows() -> None:
     assert response.items[0].trace_id == "tr-abc"
     assert response.items[0].client_request_id == "chat-123"
     assert response.items[0].metadata["fleet_rlm.routing_decision"] == "forced_rlm"
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_writes_artifacts(tmp_path, monkeypatch) -> None:
+    session_id = uuid.uuid4()
+    turn_id = uuid.uuid4()
+    trace_row = SimpleNamespace(
+        trace_id="tr-abc",
+        client_request_id="chat-123",
+        turn_id=turn_id,
+        provider=ExternalTraceProvider.MLFLOW,
+        experiment_id="1",
+        experiment_name="fleet-rlm",
+        observed_at=datetime.now(UTC),
+        metadata_json={"fleet_rlm.routing_decision": "forced_rlm"},
+    )
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=SimpleNamespace(id=session_id)),
+        list_external_traces_for_session=AsyncMock(return_value=([trace_row], 1)),
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    from fleet_rlm.integrations.observability import mlflow_traces
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(mlflow_traces, "resolve_trace", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        mlflow_traces,
+        "trace_to_full_payload",
+        lambda trace, **kwargs: {
+            "info": {"trace_id": "tr-abc", "client_request_id": "chat-123"},
+            "session_id": kwargs["session_id"],
+            "turn_id": kwargs["turn_id"],
+            "metadata": kwargs["external_trace_metadata"],
+            "spans": [],
+            "assessments": [],
+        },
+    )
+
+    response = await SessionService(persistence).export_session_traces(
+        persisted_identity=identity,
+        session_id=str(session_id),
+        body=SessionTraceExportRequest(format="both"),
+    )
+
+    assert response.trace_count == 1
+    assert response.skipped_trace_ids == []
+    assert response.json_path is not None
+    assert response.jsonl_path is not None
+    assert response.distilled_bundle_path is not None
+    assert response.summary["trace_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_reports_missing_trace(tmp_path, monkeypatch) -> None:
+    session_id = uuid.uuid4()
+    trace_row = SimpleNamespace(
+        trace_id="tr-missing",
+        client_request_id="chat-missing",
+        turn_id=None,
+        provider=ExternalTraceProvider.MLFLOW,
+        metadata_json={},
+    )
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=SimpleNamespace(id=session_id)),
+        list_external_traces_for_session=AsyncMock(return_value=([trace_row], 1)),
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    from fleet_rlm.integrations.observability import mlflow_traces
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(mlflow_traces, "resolve_trace", lambda **kwargs: None)
+
+    response = await SessionService(persistence).export_session_traces(
+        persisted_identity=identity,
+        session_id=str(session_id),
+        body=SessionTraceExportRequest(format="jsonl"),
+    )
+
+    assert response.trace_count == 0
+    assert response.json_path is None
+    assert response.jsonl_path is not None
+    assert response.skipped_trace_ids == ["tr-missing"]
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_falls_back_to_mlflow_session_lookup(tmp_path, monkeypatch) -> None:
+    session_id = uuid.UUID(int=42)
+    session = SimpleNamespace(
+        id=session_id,
+        title="frontend-session-1",
+        external_session_id="frontend-session-1",
+        workspace_id="local-workspace",
+        owner_user="local-user",
+    )
+
+    async def unsupported_external_traces(**kwargs):
+        _ = kwargs
+        raise UnsupportedLocalCapabilityError("list_external_traces_for_session")
+
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=session),
+        list_external_traces_for_session=unsupported_external_traces,
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    from fleet_rlm.integrations.observability import mlflow_traces
+
+    searched_session_ids: list[str] = []
+
+    def fake_search_traces_by_session_id(session_id: str, **_kwargs):
+        searched_session_ids.append(session_id)
+        if session_id == "default:anonymous:frontend-session-1":
+            return [SimpleNamespace()]
+        return []
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(mlflow_traces, "search_traces_by_session_id", fake_search_traces_by_session_id)
+    monkeypatch.setattr(
+        mlflow_traces,
+        "trace_to_full_payload",
+        lambda trace, **kwargs: {
+            "info": {"trace_id": "tr-local", "client_request_id": "chat-local"},
+            "session_id": kwargs["session_id"],
+            "turn_id": kwargs["turn_id"],
+            "metadata": kwargs["external_trace_metadata"],
+            "spans": [],
+            "assessments": [],
+        },
+    )
+
+    response = await SessionService(persistence).export_session_traces(
+        persisted_identity=identity,
+        session_id=str(session_id),
+        body=SessionTraceExportRequest(format="jsonl"),
+    )
+
+    assert response.trace_count == 1
+    assert response.skipped_trace_ids == []
+    assert searched_session_ids == ["default:anonymous:frontend-session-1"]
+    assert response.jsonl_path is not None
+    assert response.distilled_bundle_path is not None
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_supports_validated_mlflow_session_hint(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    durable_session_id = uuid.uuid4()
+    mlflow_session_id = "default:anonymous:frontend-session-1"
+    session = SimpleNamespace(
+        id=durable_session_id,
+        title="frontend-session-1",
+        metadata_json={"external_session_id": "frontend-session-1"},
+        workspace_id="local-workspace",
+        owner_user="local-user",
+    )
+
+    async def unsupported_external_traces(**kwargs):
+        _ = kwargs
+        raise UnsupportedLocalCapabilityError("list_external_traces_for_session")
+
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=session),
+        get_chat_session_by_external_id=AsyncMock(return_value=None),
+        list_external_traces_for_session=unsupported_external_traces,
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    from fleet_rlm.integrations.observability import mlflow_traces
+
+    searched_session_ids: list[str] = []
+
+    def fake_search_traces_by_session_id(session_id: str, **_kwargs):
+        searched_session_ids.append(session_id)
+        if session_id == mlflow_session_id:
+            return [SimpleNamespace()]
+        return []
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(mlflow_traces, "search_traces_by_session_id", fake_search_traces_by_session_id)
+    monkeypatch.setattr(
+        mlflow_traces,
+        "trace_to_full_payload",
+        lambda trace, **kwargs: {
+            "info": {"trace_id": "tr-direct", "client_request_id": "chat-direct"},
+            "session_id": kwargs["session_id"],
+            "turn_id": kwargs["turn_id"],
+            "metadata": kwargs["external_trace_metadata"],
+            "spans": [],
+            "assessments": [],
+        },
+    )
+
+    response = await SessionService(persistence).export_session_traces(
+        persisted_identity=identity,
+        session_id=str(durable_session_id),
+        body=SessionTraceExportRequest(format="both", mlflow_session_id=mlflow_session_id),
+    )
+
+    assert response.session_id == str(durable_session_id)
+    assert response.trace_count == 1
+    assert response.summary["trace_count"] == 1
+    assert searched_session_ids == [mlflow_session_id]
+    assert response.jsonl_path is not None
+    assert response.distilled_bundle_path is not None
+
+
+def test_trace_session_id_reads_modern_mlflow_session_metadata() -> None:
+    trace = SimpleNamespace(
+        to_dict=lambda: {
+            "info": {
+                "trace_metadata": {
+                    "mlflow.trace.session": "default:anonymous:frontend-session-1",
+                }
+            }
+        }
+    )
+
+    assert _trace_session_id(trace) == "default:anonymous:frontend-session-1"
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_rejects_unlinked_runtime_session() -> None:
+    runtime_session_id = str(uuid.uuid4())
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=None),
+        get_chat_session_by_external_id=AsyncMock(return_value=None),
+        list_external_traces_for_session=AsyncMock(
+            side_effect=AssertionError("external trace lookup should be skipped")
+        ),
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await SessionService(persistence).export_session_traces(
+            persisted_identity=identity,
+            session_id=runtime_session_id,
+            body=SessionTraceExportRequest(format="jsonl"),
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_rejects_spoofed_mlflow_session_hint(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    session_id = uuid.uuid4()
+    session = SimpleNamespace(
+        id=session_id,
+        title="owned-session",
+        metadata_json={"external_session_id": "owned-session"},
+        workspace_id="workspace-a",
+        owner_user="user-a",
+    )
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=session),
+        get_chat_session_by_external_id=AsyncMock(return_value=None),
+        list_external_traces_for_session=AsyncMock(return_value=([], 0)),
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await SessionService(persistence).export_session_traces(
+            persisted_identity=identity,
+            session_id=str(session_id),
+            body=SessionTraceExportRequest(
+                format="jsonl",
+                mlflow_session_id="default:anonymous:someone-elses-session",
+            ),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_resolves_external_session_id(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    runtime_session_id = str(uuid.uuid4())
+    durable_session_id = uuid.uuid4()
+    session = SimpleNamespace(
+        id=durable_session_id,
+        title="runtime chat",
+        metadata_json={"external_session_id": runtime_session_id},
+        workspace_id="workspace-a",
+        owner_user="user-a",
+    )
+    trace_row = SimpleNamespace(
+        trace_id="tr-ext",
+        client_request_id="chat-ext",
+        turn_id=None,
+        provider=ExternalTraceProvider.MLFLOW,
+        metadata_json={},
+    )
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=None),
+        get_chat_session_by_external_id=AsyncMock(return_value=session),
+        list_external_traces_for_session=AsyncMock(return_value=([trace_row], 1)),
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    from fleet_rlm.integrations.observability import mlflow_traces
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(mlflow_traces, "resolve_trace", lambda **kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        mlflow_traces,
+        "trace_to_full_payload",
+        lambda trace, **kwargs: {
+            "info": {"trace_id": "tr-ext", "client_request_id": "chat-ext"},
+            "session_id": kwargs["session_id"],
+            "turn_id": kwargs["turn_id"],
+            "metadata": kwargs["external_trace_metadata"],
+            "spans": [],
+            "assessments": [],
+        },
+    )
+
+    response = await SessionService(persistence).export_session_traces(
+        persisted_identity=identity,
+        session_id=runtime_session_id,
+        body=SessionTraceExportRequest(format="jsonl"),
+    )
+
+    assert response.trace_count == 1
+    persistence.get_chat_session_by_external_id.assert_awaited_once()

--- a/tests/unit/quality/test_trace_bundles.py
+++ b/tests/unit/quality/test_trace_bundles.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fleet_rlm.quality.trace_bundles import (
+    distill_trace_payloads,
+    write_session_trace_artifacts,
+)
+
+
+def test_distill_trace_payloads_clusters_failures() -> None:
+    rows, summary = distill_trace_payloads(
+        [
+            {
+                "info": {"trace_id": "tr-1", "client_request_id": "chat-1"},
+                "session_id": "session-1",
+                "spans": [{"span_type": "TOOL", "status": "error"}],
+                "assessments": [{"assessment_name": "response_is_correct"}],
+                "metadata": {"detail": "missing evidence and malformed json"},
+            }
+        ]
+    )
+
+    assert rows[0]["trace_id"] == "tr-1"
+    assert "missing_evidence" in rows[0]["failure_categories"]
+    assert "formatting_issues" in rows[0]["failure_categories"]
+    assert summary["trace_count"] == 1
+    assert summary["failure_clusters"]
+
+
+def test_write_session_trace_artifacts_writes_raw_and_distilled(tmp_path: Path) -> None:
+    artifacts = write_session_trace_artifacts(
+        session_id="session-1",
+        payloads=[{"info": {"trace_id": "tr-1"}, "spans": [], "assessments": []}],
+        export_format="both",
+        root=tmp_path,
+    )
+
+    assert Path(artifacts["json_path"] or "").exists()
+    assert Path(artifacts["jsonl_path"] or "").exists()
+    distilled_path = Path(artifacts["distilled_bundle_path"])
+    assert distilled_path.exists()
+    first_row = json.loads(distilled_path.read_text(encoding="utf-8").splitlines()[0])
+    assert first_row["kind"] == "trace_bundle_summary"


### PR DESCRIPTION
## Summary
- Sandbox `trace_bundle_paths` under `OPTIMIZATION_DATA_ROOT` via `resolve_trace_bundle_paths()`
- Harden session trace export: owned-session lookup, external id resolution, validated `mlflow_session_id` hint (403 on spoof)
- Extract `session_trace_export.py`; workspace warns when `trace_count === 0`

## Test plan
- [x] `pytest tests/unit/api/test_optimization_paths.py tests/unit/api/test_session_traces.py`
- [ ] Manual: chat turn → export traces → non-zero `trace_count`

**Merge gate:** Do not ship Optimization broadly until this PR lands.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session trace export with multiple format options (JSON, JSONL, or both) for analysis and debugging.
  * Enhanced session lookup and management with external ID support.
  * Improved GEPA optimization runtime orchestration and execution.

* **Improvements**
  * Enhanced scoring for LongCoT-based answers with structured payload detection.
  * Strengthened path validation and resolution for optimization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->