### PR TITLE
fix(optimization): GEPA remediation hardening

### DIFF
--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "lastRunAtMs": 0,
+  "turnsSinceLastRun": 5,
+  "lastTranscriptMtimeMs": null,
+  "lastProcessedGenerationId": "f786fd85-9e0c-4c0c-90a3-4b0ec61611dc",
+  "trialStartedAtMs": null
+}

--- a/.cursor/hooks/state/continual-learning.json
+++ b/.cursor/hooks/state/continual-learning.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "lastRunAtMs": 0,
-  "turnsSinceLastRun": 5,
-  "lastTranscriptMtimeMs": null,
-  "lastProcessedGenerationId": "f786fd85-9e0c-4c0c-90a3-4b0ec61611dc",
-  "trialStartedAtMs": null
-}

--- a/src/fleet_rlm/api/routers/optimization/runs.py
+++ b/src/fleet_rlm/api/routers/optimization/runs.py
@@ -403,6 +403,12 @@ async def create_run_promotion_draft(
     )
     if row is None:
         raise HTTPException(status_code=404, detail=f"Optimization run {run_id} not found.")
+    status = row.status.value if hasattr(row.status, "value") else str(row.status)
+    if status != OptimizationRunStatus.COMPLETED.value:
+        raise HTTPException(
+            status_code=409,
+            detail="Promotion drafts are only available for completed optimization runs.",
+        )
     return create_or_load_promotion_draft(
         _db_run_to_response(row),
         tenant_id=str(persisted_identity.tenant_id),

--- a/src/fleet_rlm/api/runtime_services/session_trace_export.py
+++ b/src/fleet_rlm/api/runtime_services/session_trace_export.py
@@ -14,6 +14,8 @@ from fleet_rlm.integrations.persistence_protocol import UnsupportedLocalCapabili
 from ..schemas.sessions import SessionTraceExportRequest, SessionTraceExportResponse
 from .session_helpers import optional_string, parse_session_uuid, session_external_id
 
+MLFLOW_EXPORT_MAX_RESULTS = 500
+
 __all__ = [
     "export_owned_session_traces",
     "ordered_runtime_session_ids",
@@ -33,9 +35,9 @@ def runtime_session_id_candidates(
     if not external_id:
         return []
     candidates = [
-        f"default:anonymous:{external_id}",
         f"{getattr(session, 'workspace_id', '')}:{getattr(session, 'owner_user', '')}:{external_id}",
         f"{persisted_identity.workspace_id}:{persisted_identity.user_id}:{external_id}",
+        f"default:anonymous:{external_id}",
     ]
     seen: set[str] = set()
     ordered: list[str] = []
@@ -67,6 +69,64 @@ def ordered_runtime_session_ids(
             detail="mlflow_session_id is not authorized for this session.",
         )
     return [hint, *[candidate for candidate in candidates if candidate != hint]]
+
+
+def _trace_info_payload(trace: object) -> dict[str, Any]:
+    to_dict = getattr(trace, "to_dict", None)
+    if callable(to_dict):
+        try:
+            payload = to_dict()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            info = payload.get("info")
+            if isinstance(info, dict):
+                return info
+
+    info = getattr(trace, "info", None)
+    if isinstance(info, dict):
+        return dict(info)
+    if info is None:
+        return {}
+
+    result: dict[str, Any] = {
+        "trace_id": getattr(info, "trace_id", None),
+        "client_request_id": getattr(info, "client_request_id", None),
+    }
+    trace_metadata = getattr(info, "trace_metadata", None)
+    if isinstance(trace_metadata, dict):
+        result["trace_metadata"] = trace_metadata
+    return result
+
+
+def _trace_owned_by_session(
+    trace: Any,
+    *,
+    session: Any,
+    persisted_identity: IdentityUpsertResult,
+) -> bool:
+    """Return True when trace metadata matches the owned session identity."""
+    trace_metadata = _trace_info_payload(trace).get("trace_metadata")
+    if not isinstance(trace_metadata, dict) or not trace_metadata:
+        return True
+
+    trace_user = str(trace_metadata.get("mlflow.trace.user") or "").strip()
+    allowed_users = {
+        str(getattr(session, "owner_user", "") or "").strip(),
+        str(persisted_identity.user_id).strip(),
+    }
+    if trace_user and trace_user not in allowed_users:
+        return False
+
+    trace_workspace = str(trace_metadata.get("fleet_rlm.workspace_id") or "").strip()
+    allowed_workspaces = {
+        str(getattr(session, "workspace_id", "") or "").strip(),
+        str(persisted_identity.workspace_id).strip(),
+    }
+    if trace_workspace and trace_workspace not in allowed_workspaces:
+        return False
+
+    return True
 
 
 async def resolve_owned_chat_session(
@@ -190,10 +250,24 @@ async def export_owned_session_traces(
                 search_traces_by_session_id,
                 runtime_session_id,
                 allow_unfiltered_fallback=False,
+                max_results=MLFLOW_EXPORT_MAX_RESULTS,
             )
             if not direct_traces:
                 continue
             for trace in direct_traces:
+                if not _trace_owned_by_session(
+                    trace,
+                    session=session,
+                    persisted_identity=persisted_identity,
+                ):
+                    trace_info = _trace_info_payload(trace)
+                    skipped_trace_ids.append(
+                        str(trace_info.get("trace_id") or trace_info.get("client_request_id") or "unknown")
+                    )
+                    errors.append(
+                        f"{trace_info.get('trace_id') or 'unknown'}: trace metadata does not match session ownership"
+                    )
+                    continue
                 payloads.append(
                     trace_to_full_payload(
                         trace,
@@ -205,7 +279,8 @@ async def export_owned_session_traces(
                         },
                     )
                 )
-            break
+            if payloads:
+                break
 
     artifacts = await asyncio.to_thread(
         write_session_trace_artifacts,

--- a/tests/unit/api/test_optimization_run_details.py
+++ b/tests/unit/api/test_optimization_run_details.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
 import json
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
 
 from fleet_rlm.api.routers.optimization import run_details
+from fleet_rlm.api.routers.optimization import runs as runs_module
 from fleet_rlm.api.routers.optimization.run_details import (
     build_optimization_run_detail,
     create_or_load_promotion_draft,
 )
 from fleet_rlm.api.schemas.optimization import OptimizationRunResponse
+from fleet_rlm.integrations.database.models_enums import OptimizationRunStatus
 
 
 def _run(tmp_path: Path, *, manifest_path: Path | None, output_path: Path | None) -> OptimizationRunResponse:
@@ -189,6 +196,28 @@ def test_run_details_marks_trainset_fallback_as_not_promotion_ready(tmp_path: Pa
     assert detail.score_summary.validation_examples == 0
 
 
+def test_promotion_draft_paths_are_isolated_by_tenant(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(run_details, "OPTIMIZATION_DATA_ROOT", tmp_path)
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text("{}", encoding="utf-8")
+    run = _run(tmp_path, manifest_path=manifest_path, output_path=None)
+
+    draft_a = create_or_load_promotion_draft(
+        run,
+        tenant_id="tenant-a",
+        workspace_id="workspace-a",
+    )
+    draft_b = create_or_load_promotion_draft(
+        run,
+        tenant_id="tenant-b",
+        workspace_id="workspace-a",
+    )
+
+    assert draft_a.draft_path != draft_b.draft_path
+    assert "tenant-a" in draft_a.draft_path
+    assert "tenant-b" in draft_b.draft_path
+
+
 def test_promotion_draft_is_a_non_mutating_artifact(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(run_details, "OPTIMIZATION_DATA_ROOT", tmp_path)
     source_skill = tmp_path / "source" / "SKILL.md"
@@ -213,3 +242,36 @@ def test_promotion_draft_is_a_non_mutating_artifact(tmp_path: Path, monkeypatch)
     assert Path(draft.draft_path).is_file()
     assert loaded.draft_path == draft.draft_path
     assert source_skill.read_text(encoding="utf-8") == "original skill"
+
+
+@pytest.mark.asyncio
+async def test_create_run_promotion_draft_rejects_non_completed_run(monkeypatch) -> None:
+    run_uuid = uuid.uuid4()
+
+    async def fake_resolve_persisted_identity(**kwargs):
+        _ = kwargs
+        return SimpleNamespace(
+            tenant_id=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+        )
+
+    monkeypatch.setattr(runs_module, "_resolve_persisted_identity", fake_resolve_persisted_identity)
+    persistence = SimpleNamespace(
+        get_optimization_run=AsyncMock(
+            return_value=SimpleNamespace(
+                id=run_uuid,
+                status=OptimizationRunStatus.RUNNING,
+            )
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await runs_module.create_run_promotion_draft(
+            config_deps=SimpleNamespace(),
+            identity=SimpleNamespace(),
+            persistence=persistence,
+            run_id=str(run_uuid),
+        )
+
+    assert exc_info.value.status_code == 409

--- a/tests/unit/api/test_session_traces.py
+++ b/tests/unit/api/test_session_traces.py
@@ -170,9 +170,11 @@ async def test_export_session_traces_falls_back_to_mlflow_session_lookup(tmp_pat
 
     searched_session_ids: list[str] = []
 
+    workspace_scoped_session_id = "local-workspace:local-user:frontend-session-1"
+
     def fake_search_traces_by_session_id(session_id: str, **_kwargs):
         searched_session_ids.append(session_id)
-        if session_id == "default:anonymous:frontend-session-1":
+        if session_id == workspace_scoped_session_id:
             return [SimpleNamespace()]
         return []
 
@@ -199,9 +201,67 @@ async def test_export_session_traces_falls_back_to_mlflow_session_lookup(tmp_pat
 
     assert response.trace_count == 1
     assert response.skipped_trace_ids == []
-    assert searched_session_ids == ["default:anonymous:frontend-session-1"]
+    assert searched_session_ids == [workspace_scoped_session_id]
     assert response.jsonl_path is not None
     assert response.distilled_bundle_path is not None
+
+
+@pytest.mark.asyncio
+async def test_export_session_traces_skips_foreign_mlflow_fallback_traces(tmp_path, monkeypatch) -> None:
+    session_id = uuid.UUID(int=42)
+    session = SimpleNamespace(
+        id=session_id,
+        title="frontend-session-1",
+        external_session_id="frontend-session-1",
+        workspace_id="local-workspace",
+        owner_user="local-user",
+    )
+
+    async def unsupported_external_traces(**kwargs):
+        _ = kwargs
+        raise UnsupportedLocalCapabilityError("list_external_traces_for_session")
+
+    persistence = SimpleNamespace(
+        get_chat_session=AsyncMock(return_value=session),
+        list_external_traces_for_session=unsupported_external_traces,
+    )
+    identity = SimpleNamespace(
+        tenant_id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    from fleet_rlm.integrations.observability import mlflow_traces
+
+    foreign_trace = SimpleNamespace(
+        to_dict=lambda: {
+            "info": {
+                "trace_id": "tr-foreign",
+                "trace_metadata": {
+                    "mlflow.trace.user": "other-user",
+                    "fleet_rlm.workspace_id": "other-workspace",
+                },
+            }
+        }
+    )
+
+    def fake_search_traces_by_session_id(session_id: str, **_kwargs):
+        if session_id == "local-workspace:local-user:frontend-session-1":
+            return [foreign_trace]
+        return []
+
+    monkeypatch.setenv("FLEET_RLM_OPTIMIZATION_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(mlflow_traces, "search_traces_by_session_id", fake_search_traces_by_session_id)
+
+    response = await SessionService(persistence).export_session_traces(
+        persisted_identity=identity,
+        session_id=str(session_id),
+        body=SessionTraceExportRequest(format="jsonl"),
+    )
+
+    assert response.trace_count == 0
+    assert response.skipped_trace_ids == ["tr-foreign"]
+    assert any("ownership" in error for error in response.errors)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Post-merge hardening from thermo branch audit:

- Prefer workspace-scoped MLflow session IDs over `default:anonymous` on trace export fallback
- Cap MLflow fallback search at 500 traces per session-id attempt
- Skip MLflow fallback traces whose metadata does not match session ownership
- Return 409 when creating promotion drafts for non-completed optimization runs
- Add cross-tenant promotion draft isolation test

## Test plan

- [x] `pytest tests/unit/api/test_session_traces.py tests/unit/api/test_optimization_run_details.py`
- [ ] CI Quality + Unit + Frontend

Made with [Cursor](https://cursor.com)