### PR TITLE
refactor(frontend): complete PR4 optimization form extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,12 +89,8 @@ src/frontend/.tmp-*.mjs
 .pi/
 .hermes/
 .factory/
-blogs/rlm-capability-evaluation-0-5-1/hero.png
-blogs/rlm-capability-evaluation-0-5-1/remotion
-blogs/rlm-capability-evaluation-0-5-1/hyperframes/
-blogs/rlm-capability-evaluation-0-5-1/fleet-rlm-v0-5-1-launch.mp4
-blogs/rlm-capability-evaluation-0-5-1/fleet-rlm-v0-5-1-remotion-still.png
-blogs/rlm-capability-evaluation-0-5-1/fleet-rlm-v0-5-1-remotion.mp4
+blogs/
+.cursor/
 
 # Output artifacts
 output/*

--- a/src/frontend/src/features/optimization/optimization-form.tsx
+++ b/src/frontend/src/features/optimization/optimization-form.tsx
@@ -1,5 +1,6 @@
-import type { FormEvent, ReactNode } from "react";
-import { Database, FileJson, Upload } from "lucide-react";
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from "react";
+import { toast } from "sonner";
+import { Database, FileJson, Upload, Settings2, DatabaseZap, Sparkles } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -24,15 +25,22 @@ import {
   SectionCardHeader,
   SectionCardTitle,
 } from "@/components/product/section-layout";
-import type {
-  DatasetResponse,
-  GEPAModuleInfo,
-  SessionTraceExportResponse,
-} from "@/lib/rlm-api";
-import type { LlmModelCatalogEntry, LlmProviderProfileResponse } from "@/lib/rlm-api/llm-profiles";
+import { Separator } from "@/components/ui/separator";
+import type { DatasetResponse, GEPAModuleInfo, SessionTraceExportResponse } from "@/lib/rlm-api";
+import type { LlmProviderProfileResponse, LlmModelCatalogEntry } from "@/lib/rlm-api/llm-profiles";
+import { useLlmProfileModels, useLlmProfiles } from "@/features/settings/use-llm-profiles";
+import {
+  useOptimizationDatasets,
+  useOptimizationModules,
+  useOptimizationMutations,
+} from "./use-optimization";
+import { errorMessage } from "./optimization-format";
 
 import {
   isRunnableDataset,
+  appendTraceBundlePathValue,
+  buildOptimizationRequest,
+  DEFAULT_OPTIMIZATION_FORM,
   type DatasetSourceMode,
   type OptimizationRunFormState,
   type OptimizationTargetMode,
@@ -40,19 +48,28 @@ import {
 } from "./optimization-model";
 
 const DEFAULT_SELECT_VALUE = "__default__";
+const EMPTY_MODULES: GEPAModuleInfo[] = [];
+const EMPTY_DATASETS: DatasetResponse[] = [];
+const EMPTY_PROFILES: LlmProviderProfileResponse[] = [];
+const EMPTY_MODELS: LlmModelCatalogEntry[] = [];
 
 function CompactField({
   label,
   description,
   children,
+  icon,
 }: {
   label: string;
   description?: string;
   children: ReactNode;
+  icon?: ReactNode;
 }) {
   return (
-    <Field className="gap-1.5">
-      <FieldLabel>{label}</FieldLabel>
+    <Field className="gap-1.5 transition-all duration-200">
+      <FieldLabel className="flex items-center gap-1.5 font-medium text-foreground">
+        {icon}
+        {label}
+      </FieldLabel>
       {children}
       {description ? <FieldDescription>{description}</FieldDescription> : null}
     </Field>
@@ -71,74 +88,191 @@ function moduleDatasetDescription(module: GEPAModuleInfo | undefined): string {
   const pieces = [inputs, outputs].filter(Boolean);
   return pieces.length
     ? pieces.join(" · ")
-    : `Required keys: ${module.required_dataset_keys.join(", ")}`;
+    : `Required keys: ${module.required_dataset_keys?.join(", ") ?? ""}`;
 }
 
 export type OptimizationFormProps = {
-  form: OptimizationRunFormState;
-  updateForm: <K extends keyof OptimizationRunFormState>(
-    key: K,
-    value: OptimizationRunFormState[K],
-  ) => void;
-  onReflectionProfileChange: (profileId: string) => void;
-  setDatasetSource: (value: DatasetSourceMode) => void;
-  modules: GEPAModuleInfo[];
-  modulesLoading: boolean;
-  datasets: DatasetResponse[];
-  datasetsLoading: boolean;
-  selectedModule: GEPAModuleInfo | undefined;
-  selectedDataset: DatasetResponse | undefined;
-  profiles: LlmProviderProfileResponse[];
-  profilesLoading: boolean;
-  modelOptions: LlmModelCatalogEntry[];
-  modelsPending: boolean;
-  datasetFile: File | null;
-  onDatasetFileChange: (file: File | null) => void;
-  traceSessionId: string;
-  onTraceSessionIdChange: (value: string) => void;
-  traceExport: SessionTraceExportResponse | null;
-  isSubmitting: boolean;
-  exportPending: boolean;
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
-  onTraceExport: () => void;
+  onSuccess?: () => void;
 };
 
-export function OptimizationForm({
-  form,
-  updateForm,
-  onReflectionProfileChange,
-  setDatasetSource,
-  modules,
-  modulesLoading,
-  datasets,
-  datasetsLoading,
-  selectedModule,
-  selectedDataset,
-  profiles,
-  profilesLoading,
-  modelOptions,
-  modelsPending,
-  datasetFile,
-  onDatasetFileChange,
-  traceSessionId,
-  onTraceSessionIdChange,
-  traceExport,
-  isSubmitting,
-  exportPending,
-  onSubmit,
-  onTraceExport,
-}: OptimizationFormProps) {
+export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
+  // Query state hooks directly localized
+  const modulesQuery = useOptimizationModules();
+  const [form, setForm] = useState<OptimizationRunFormState>(DEFAULT_OPTIMIZATION_FORM);
+  const datasetsQuery = useOptimizationDatasets(
+    form.targetMode === "module" ? form.moduleSlug : null,
+    { enabled: form.targetMode !== "module" || Boolean(form.moduleSlug) },
+  );
+  const profilesQuery = useLlmProfiles();
+  const modelsQuery = useLlmProfileModels(form.reflectionProfileId || null);
+
+  const { uploadDataset, createRun, exportSessionTraces } = useOptimizationMutations();
+
+  // Local UI states
+  const [datasetFile, setDatasetFile] = useState<File | null>(null);
+  const [traceSessionId, setTraceSessionId] = useState("");
+  const [traceExport, setTraceExport] = useState<SessionTraceExportResponse | null>(null);
+
+  const modules = modulesQuery.data ?? EMPTY_MODULES;
+  const datasets = datasetsQuery.data?.items ?? EMPTY_DATASETS;
+  const runnableDatasets = useMemo(() => datasets.filter(isRunnableDataset), [datasets]);
+  const profiles = profilesQuery.data ?? EMPTY_PROFILES;
+  const modelOptions = useMemo(
+    () => modelsQuery.data?.models ?? EMPTY_MODELS,
+    [modelsQuery.data?.models],
+  );
+
+  // Derive parameters inside form
+  const selectedModule = useMemo(
+    () => modules.find((module) => module.slug === form.moduleSlug),
+    [form.moduleSlug, modules],
+  );
+  const selectedDataset = useMemo(
+    () => datasets.find((dataset) => dataset.id === form.datasetId),
+    [datasets, form.datasetId],
+  );
+
+  const isSubmitting = uploadDataset.isPending || createRun.isPending;
+
+  // Sync / Initialize defaults
+  useEffect(() => {
+    if (form.moduleSlug || modules.length === 0) return;
+    const firstModule = modules[0];
+    if (!firstModule) return;
+    setForm((current) => ({ ...current, moduleSlug: firstModule.slug }));
+  }, [form.moduleSlug, modules]);
+
+  useEffect(() => {
+    if (form.datasetSource !== "existing" || form.datasetId || runnableDatasets.length === 0)
+      return;
+    const firstDataset = runnableDatasets[0];
+    if (!firstDataset) return;
+    setForm((current) => ({ ...current, datasetId: firstDataset.id }));
+  }, [form.datasetId, form.datasetSource, runnableDatasets]);
+
+  useEffect(() => {
+    if (!form.reflectionProfileId || form.reflectionModelId || modelOptions.length === 0) return;
+    const firstModel = modelOptions[0];
+    if (!firstModel) return;
+    setForm((current) => ({ ...current, reflectionModelId: firstModel.id }));
+  }, [form.reflectionModelId, form.reflectionProfileId, modelOptions]);
+
+  // Clear dataset selection when target mode or module changes to prevent cross-module dataset leakage
+  useEffect(() => {
+    setForm((current) => ({
+      ...current,
+      datasetId: "",
+    }));
+  }, [form.moduleSlug, form.targetMode]);
+
+  const updateForm = <K extends keyof OptimizationRunFormState>(
+    key: K,
+    value: OptimizationRunFormState[K],
+  ) => setForm((current) => ({ ...current, [key]: value }));
+
+  const onReflectionProfileChange = (profileId: string) => {
+    setForm((current) => ({
+      ...current,
+      reflectionProfileId: profileId,
+      reflectionModelId: "",
+    }));
+  };
+
+  const setDatasetSource = (value: DatasetSourceMode) => {
+    setForm((current) => ({
+      ...current,
+      datasetSource: value,
+      datasetId: value === "existing" ? current.datasetId : "",
+      datasetPath: value === "path" ? current.datasetPath : "",
+    }));
+    if (value !== "upload") setDatasetFile(null);
+  };
+
+  const appendTraceBundlePath = (path: string) => {
+    setForm((current) => ({
+      ...current,
+      traceBundlePaths: appendTraceBundlePathValue(current.traceBundlePaths, path),
+    }));
+  };
+
+  const handleTraceExport = async () => {
+    const sessionId = traceSessionId.trim();
+    if (!sessionId) {
+      toast.error("Session id is required");
+      return;
+    }
+    try {
+      const exported = await exportSessionTraces.mutateAsync({ sessionId });
+      if (exported.trace_count === 0) {
+        toast.warning("Trace export completed with no traces", {
+          description: "Run a chat turn first or verify the session is linked to MLflow traces.",
+        });
+        return;
+      }
+      setTraceExport(exported);
+      if (exported.distilled_bundle_path) {
+        appendTraceBundlePath(exported.distilled_bundle_path);
+      }
+      toast.success("Trace bundle exported", {
+        description: exported.distilled_bundle_path ?? exported.jsonl_path ?? exported.json_path,
+      });
+    } catch (error) {
+      toast.error("Trace export failed", { description: errorMessage(error) });
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      buildOptimizationRequest({ form, hasDatasetFile: Boolean(datasetFile) });
+      let finalDatasetId = form.datasetId;
+      if (form.datasetSource === "upload" && datasetFile) {
+        const uploaded = await uploadDataset.mutateAsync({
+          file: datasetFile,
+          moduleSlug: form.targetMode === "module" ? form.moduleSlug : null,
+        });
+        finalDatasetId = uploaded.id;
+        setDatasetFile(null);
+        setForm((current) => ({
+          ...current,
+          datasetSource: "existing",
+          datasetId: uploaded.id,
+        }));
+      }
+      const request = buildOptimizationRequest({
+        form: {
+          ...form,
+          datasetSource: "existing",
+          datasetId: finalDatasetId,
+        },
+        datasetId: finalDatasetId,
+        hasDatasetFile: false,
+      });
+      const created = await createRun.mutateAsync(request);
+      toast.success("GEPA run started", { description: created.run_id });
+      onSuccess?.();
+    } catch (error) {
+      toast.error("GEPA run not started", { description: errorMessage(error) });
+    }
+  };
+
   return (
-    <SectionCard variant="subtle">
-      <SectionCardHeader>
-        <SectionCardTitle>New Run</SectionCardTitle>
-        <SectionCardDescription>{moduleDatasetDescription(selectedModule)}</SectionCardDescription>
+    <SectionCard variant="subtle" className="border-border bg-card shadow-sm transition-all duration-200">
+      <SectionCardHeader className="border-b border-border-subtle bg-muted/10 px-6 py-5">
+        <div className="flex items-center gap-2">
+          <Settings2 className="size-5 text-primary" />
+          <SectionCardTitle className="text-base font-semibold tracking-tight">New GEPA Run</SectionCardTitle>
+        </div>
+        <SectionCardDescription className="text-muted-foreground typo-body-sm mt-1">
+          {moduleDatasetDescription(selectedModule)}
+        </SectionCardDescription>
       </SectionCardHeader>
-      <SectionCardContent>
-        <form className="flex flex-col gap-5" onSubmit={onSubmit}>
-          <div className="grid gap-5 lg:grid-cols-[1fr_1fr]">
-            <FieldGroup>
-              <CompactField label="Target">
+      <SectionCardContent className="p-6">
+        <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
+          <div className="grid gap-6 lg:grid-cols-2">
+            {/* Left Column: Target Metadata & Config */}
+            <FieldGroup className="gap-5">
+              <CompactField label="Target Mode" icon={<Sparkles className="size-4 text-primary" />}>
                 <ToggleGroup
                   type="single"
                   value={form.targetMode}
@@ -146,31 +280,34 @@ export function OptimizationForm({
                     if (value) updateForm("targetMode", value as OptimizationTargetMode);
                   }}
                   variant="outline"
-                  className="w-full"
+                  className="w-full flex"
+                  disabled={isSubmitting}
                 >
-                  <ToggleGroupItem value="module">Registered module</ToggleGroupItem>
-                  <ToggleGroupItem value="skill">Skill</ToggleGroupItem>
+                  <ToggleGroupItem value="module" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                    Registered module
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="skill" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                    Skill file
+                  </ToggleGroupItem>
                 </ToggleGroup>
               </CompactField>
 
               {form.targetMode === "module" ? (
-                <CompactField label="Module">
+                <CompactField label="Registered Module">
                   <Select
                     value={form.moduleSlug}
-                    onValueChange={(value) => {
-                      if (typeof value === "string") updateForm("moduleSlug", value);
-                    }}
-                    disabled={modulesLoading || modules.length === 0}
+                    onValueChange={(value) => value && updateForm("moduleSlug", value)}
+                    disabled={isSubmitting || modulesQuery.isLoading || modules.length === 0}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                       <SelectValue>
-                        {selectedModule?.label ?? form.moduleSlug ?? "Select module"}
+                        {selectedModule?.label ?? (form.moduleSlug || "Select module")}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent align="start">
+                    <SelectContent align="start" className="border-border">
                       <SelectGroup>
                         {modules.map((module) => (
-                          <SelectItem key={module.slug} value={module.slug}>
+                          <SelectItem key={module.slug} value={module.slug} className="cursor-pointer focus:bg-muted/40">
                             {module.label}
                           </SelectItem>
                         ))}
@@ -178,27 +315,31 @@ export function OptimizationForm({
                     </SelectContent>
                   </Select>
                   {selectedModule ? (
-                    <div className="rounded-md border border-border-subtle bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-                      <div className="flex flex-wrap gap-1.5">
-                        <Badge variant="outline">
+                    <div className="rounded-lg border border-border-subtle bg-muted/10 px-4 py-3 text-xs text-muted-foreground leading-normal transition-all duration-200">
+                      <div className="flex flex-wrap gap-1.5 mb-2">
+                        <Badge variant="outline" className="border-border-subtle bg-background">
                           {selectedModule.optimization_target_kind ?? "custom"}
                         </Badge>
                         {selectedModule.signature_class_name ? (
-                          <Badge variant="secondary">{selectedModule.signature_class_name}</Badge>
+                          <Badge variant="secondary" className="bg-muted text-muted-foreground">
+                            {selectedModule.signature_class_name}
+                          </Badge>
                         ) : null}
                         {selectedModule.runtime_module_name ? (
-                          <Badge variant="secondary">{selectedModule.runtime_module_name}</Badge>
+                          <Badge variant="secondary" className="bg-muted text-muted-foreground">
+                            {selectedModule.runtime_module_name}
+                          </Badge>
                         ) : null}
                       </div>
                       {selectedModule.description ? (
-                        <div className="mt-2">{selectedModule.description}</div>
+                        <div className="mt-1">{selectedModule.description}</div>
                       ) : null}
                     </div>
                   ) : null}
                 </CompactField>
               ) : (
                 <>
-                  <CompactField label="Skill target">
+                  <CompactField label="Skill Target Sub-mode">
                     <ToggleGroup
                       type="single"
                       value={form.skillTargetMode}
@@ -206,99 +347,111 @@ export function OptimizationForm({
                         if (value) updateForm("skillTargetMode", value as SkillTargetMode);
                       }}
                       variant="outline"
-                      className="w-full"
+                      className="w-full flex"
+                      disabled={isSubmitting}
                     >
-                      <ToggleGroupItem value="name">Bundled name</ToggleGroupItem>
-                      <ToggleGroupItem value="path">Skill path</ToggleGroupItem>
+                      <ToggleGroupItem value="name" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                        Bundled name
+                      </ToggleGroupItem>
+                      <ToggleGroupItem value="path" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                        Skill path
+                      </ToggleGroupItem>
                     </ToggleGroup>
                   </CompactField>
                   {form.skillTargetMode === "name" ? (
-                    <CompactField label="Skill name">
+                    <CompactField label="Skill Name">
                       <Input
                         value={form.skillName}
                         onChange={(event) => updateForm("skillName", event.target.value)}
                         placeholder="optimization"
+                        disabled={isSubmitting}
+                        className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary"
                       />
                     </CompactField>
                   ) : (
-                    <CompactField label="Skill path">
+                    <CompactField label="Skill Path">
                       <Input
                         value={form.skillPath}
                         onChange={(event) => updateForm("skillPath", event.target.value)}
                         placeholder="skills/custom/SKILL.md"
+                        disabled={isSubmitting}
+                        className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary"
                       />
                     </CompactField>
                   )}
                 </>
               )}
 
+              <Separator className="bg-border-subtle/50 my-1" />
+
+              {/* Tuning Parameters */}
               <div className="grid gap-3 sm:grid-cols-4">
                 <CompactField label="Auto">
                   <Select
                     value={form.auto}
-                    onValueChange={(value) =>
-                      typeof value === "string"
-                        ? updateForm("auto", value as OptimizationRunFormState["auto"])
-                        : undefined
-                    }
+                    onValueChange={(value) => updateForm("auto", value as OptimizationRunFormState["auto"])}
+                    disabled={isSubmitting}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                       <SelectValue>{form.auto}</SelectValue>
                     </SelectTrigger>
-                    <SelectContent align="start">
+                    <SelectContent align="start" className="border-border">
                       <SelectGroup>
-                        <SelectItem value="light">light</SelectItem>
-                        <SelectItem value="medium">medium</SelectItem>
-                        <SelectItem value="heavy">heavy</SelectItem>
+                        <SelectItem value="light" className="cursor-pointer focus:bg-muted/40">light</SelectItem>
+                        <SelectItem value="medium" className="cursor-pointer focus:bg-muted/40">medium</SelectItem>
+                        <SelectItem value="heavy" className="cursor-pointer focus:bg-muted/40">heavy</SelectItem>
                       </SelectGroup>
                     </SelectContent>
                   </Select>
                 </CompactField>
-                <CompactField label="Train ratio">
+                <CompactField label="Train Ratio">
                   <Input
                     value={form.trainRatio}
                     onChange={(event) => updateForm("trainRatio", event.target.value)}
                     inputMode="decimal"
+                    disabled={isSubmitting}
+                    className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary text-center font-mono"
                   />
                 </CompactField>
-                <CompactField label="Max calls">
+                <CompactField label="Max Calls">
                   <Input
                     value={form.maxMetricCalls}
                     onChange={(event) => updateForm("maxMetricCalls", event.target.value)}
                     inputMode="numeric"
                     placeholder="auto"
+                    disabled={isSubmitting}
+                    className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary text-center font-mono"
                   />
                 </CompactField>
-                <CompactField label="Output path">
+                <CompactField label="Output Path">
                   <Input
                     value={form.outputPath}
                     onChange={(event) => updateForm("outputPath", event.target.value)}
                     placeholder="optional"
+                    disabled={isSubmitting}
+                    className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary font-mono"
                   />
                 </CompactField>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-2">
-                <CompactField label="Reflection profile">
+                <CompactField label="Reflection Profile">
                   <Select
                     value={form.reflectionProfileId || DEFAULT_SELECT_VALUE}
-                    onValueChange={(value) => {
-                      const nextValue = value === DEFAULT_SELECT_VALUE ? "" : String(value);
-                      onReflectionProfileChange(nextValue);
-                    }}
-                    disabled={profilesLoading}
+                    onValueChange={(value) => onReflectionProfileChange(value === DEFAULT_SELECT_VALUE || !value ? "" : value)}
+                    disabled={isSubmitting || profilesQuery.isLoading}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                       <SelectValue>
                         {profiles.find((profile) => profile.id === form.reflectionProfileId)?.name ??
                           "Default reflection model"}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent align="start">
+                    <SelectContent align="start" className="border-border">
                       <SelectGroup>
-                        <SelectItem value={DEFAULT_SELECT_VALUE}>Default reflection model</SelectItem>
+                        <SelectItem value={DEFAULT_SELECT_VALUE} className="cursor-pointer focus:bg-muted/40">Default reflection model</SelectItem>
                         {profiles.map((profile) => (
-                          <SelectItem key={profile.id} value={profile.id}>
+                          <SelectItem key={profile.id} value={profile.id} className="cursor-pointer focus:bg-muted/40">
                             {profile.name}
                           </SelectItem>
                         ))}
@@ -306,25 +459,25 @@ export function OptimizationForm({
                     </SelectContent>
                   </Select>
                 </CompactField>
-                <CompactField label="Reflection model">
-                  {modelsPending && form.reflectionProfileId ? (
-                    <Skeleton className="h-9 w-full rounded-md" />
+                <CompactField label="Reflection Model">
+                  {modelsQuery.isPending && form.reflectionProfileId ? (
+                    <Skeleton className="h-10 w-full rounded-md" />
                   ) : (
                     <Select
                       value={form.reflectionModelId}
-                      onValueChange={(value) => updateForm("reflectionModelId", String(value))}
-                      disabled={!form.reflectionProfileId || modelOptions.length === 0}
+                      onValueChange={(value) => value && updateForm("reflectionModelId", value)}
+                      disabled={isSubmitting || !form.reflectionProfileId || modelOptions.length === 0}
                     >
-                      <SelectTrigger className="w-full">
+                      <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                         <SelectValue>
                           {modelOptions.find((model) => model.id === form.reflectionModelId)?.label ??
                             "Select model"}
                         </SelectValue>
                       </SelectTrigger>
-                      <SelectContent align="start">
+                      <SelectContent align="start" className="border-border">
                         <SelectGroup>
                           {modelOptions.map((model) => (
-                            <SelectItem key={model.id} value={model.id}>
+                            <SelectItem key={model.id} value={model.id} className="cursor-pointer focus:bg-muted/40">
                               {model.label}
                             </SelectItem>
                           ))}
@@ -336,8 +489,9 @@ export function OptimizationForm({
               </div>
             </FieldGroup>
 
-            <FieldGroup>
-              <CompactField label="Dataset source">
+            {/* Right Column: Dataset Setup & Ingestion */}
+            <FieldGroup className="gap-5">
+              <CompactField label="Dataset Source" icon={<DatabaseZap className="size-4 text-primary" />}>
                 <ToggleGroup
                   type="single"
                   value={form.datasetSource}
@@ -345,42 +499,52 @@ export function OptimizationForm({
                     if (value) setDatasetSource(value as DatasetSourceMode);
                   }}
                   variant="outline"
-                  className="w-full"
+                  className="w-full flex"
+                  disabled={isSubmitting}
                 >
-                  <ToggleGroupItem value="existing">Existing</ToggleGroupItem>
-                  <ToggleGroupItem value="upload">Upload</ToggleGroupItem>
-                  <ToggleGroupItem value="path">Server path</ToggleGroupItem>
+                  <ToggleGroupItem value="existing" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                    Existing
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="upload" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                    Upload file
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="path" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                    Server path
+                  </ToggleGroupItem>
                 </ToggleGroup>
               </CompactField>
 
               {form.datasetSource === "existing" ? (
                 <CompactField
-                  label="Dataset"
+                  label="Registered Dataset"
                   description={
                     selectedDataset ? datasetLabel(selectedDataset) : "Registered JSON/JSONL datasets"
                   }
                 >
                   <Select
                     value={form.datasetId}
-                    onValueChange={(value) => updateForm("datasetId", String(value))}
-                    disabled={datasetsLoading || datasets.length === 0}
+                    onValueChange={(value) => value && updateForm("datasetId", value)}
+                    disabled={isSubmitting || datasetsQuery.isLoading || datasets.length === 0}
                   >
-                    <SelectTrigger className="w-full">
+                    <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                       <SelectValue>
                         {selectedDataset?.name ??
-                          (datasetsLoading ? "Loading datasets" : "Select dataset")}
+                          (datasetsQuery.isLoading ? "Loading datasets" : "Select dataset")}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent align="start">
+                    <SelectContent align="start" className="border-border">
                       <SelectGroup>
                         {datasets.map((dataset) => (
                           <SelectItem
                             key={dataset.id}
                             value={dataset.id}
                             disabled={!isRunnableDataset(dataset)}
+                            className="cursor-pointer focus:bg-muted/40"
                           >
-                            <Database data-icon="inline-start" />
-                            {datasetLabel(dataset)}
+                            <div className="flex items-center gap-2">
+                              <Database className="size-4 shrink-0 text-muted-foreground" data-icon="inline-start" />
+                              <span className="truncate">{datasetLabel(dataset)}</span>
+                            </div>
                           </SelectItem>
                         ))}
                       </SelectGroup>
@@ -391,83 +555,97 @@ export function OptimizationForm({
 
               {form.datasetSource === "upload" ? (
                 <CompactField
-                  label="Dataset file"
+                  label="Dataset File Upload"
                   description="Upload is registered before run creation."
                 >
-                  <div className="flex min-h-9 items-center gap-2 rounded-md border border-input px-3 py-2">
-                    <Upload className="shrink-0 text-muted-foreground" data-icon="inline-start" />
+                  <div className="flex min-h-10 items-center gap-2 rounded-lg border border-input px-3 py-1 bg-background hover:border-border-subtle transition-colors duration-150">
+                    <Upload className="shrink-0 size-4 text-muted-foreground" data-icon="inline-start" />
                     <Input
+                      key={datasetFile ? "loaded" : "empty"}
                       type="file"
                       accept=".json,.jsonl,application/json"
-                      className="h-auto border-0 p-0 shadow-none file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-2 file:py-1 file:text-xs"
-                      onChange={(event) => onDatasetFileChange(event.target.files?.item(0) ?? null)}
+                      disabled={isSubmitting}
+                      className="h-auto border-0 p-0 shadow-none file:mr-3 file:rounded-md file:border-0 file:bg-muted file:hover:bg-muted/80 file:px-2 file:py-1 file:text-xs file:font-medium file:cursor-pointer cursor-pointer text-xs"
+                      onChange={(event) => setDatasetFile(event.target.files?.item(0) ?? null)}
                     />
                   </div>
                 </CompactField>
               ) : null}
 
               {form.datasetSource === "path" ? (
-                <CompactField label="Server dataset path">
+                <CompactField label="Server Dataset Path">
                   <Input
                     value={form.datasetPath}
                     onChange={(event) => updateForm("datasetPath", event.target.value)}
                     placeholder="artifacts/optimization/dataset.jsonl"
+                    disabled={isSubmitting}
+                    className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary font-mono text-xs"
                   />
                 </CompactField>
               ) : null}
 
               <CompactField
-                label="Export session traces"
+                label="Export Session Traces"
                 description="Writes full MLflow traces and appends the distilled bundle path."
               >
                 <div className="flex gap-2">
                   <Input
                     value={traceSessionId}
-                    onChange={(event) => onTraceSessionIdChange(event.target.value)}
+                    onChange={(event) => setTraceSessionId(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        void handleTraceExport();
+                      }
+                    }}
                     placeholder="session id"
+                    disabled={isSubmitting || exportSessionTraces.isPending}
+                    className="h-10 border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary font-mono text-sm"
                   />
                   <Button
                     type="button"
                     variant="outline"
-                    disabled={exportPending}
-                    onClick={onTraceExport}
+                    disabled={isSubmitting || exportSessionTraces.isPending}
+                    onClick={() => void handleTraceExport()}
+                    className="h-10 px-4 font-medium transition-colors hover:bg-muted/40 shadow-none border-input"
                   >
-                    <FileJson data-icon="inline-start" />
+                    <FileJson className="size-4 shrink-0" data-icon="inline-start" />
                     Export
                   </Button>
                 </div>
               </CompactField>
 
               {traceExport ? (
-                <Alert>
-                  <FileJson className="text-muted-foreground" />
-                  <AlertTitle>Trace bundle ready</AlertTitle>
-                  <AlertDescription>
+                <Alert className="border-border bg-muted/20 rounded-lg">
+                  <FileJson className="size-4 text-muted-foreground" />
+                  <AlertTitle className="text-sm font-semibold text-foreground">Trace bundle ready</AlertTitle>
+                  <AlertDescription className="text-xs text-muted-foreground mt-0.5">
                     {traceExport.trace_count} trace(s). {traceExport.distilled_bundle_path}
                   </AlertDescription>
                 </Alert>
               ) : null}
 
-              <CompactField label="Trace bundle paths">
+              <CompactField label="Trace Bundle Paths">
                 <Textarea
                   value={form.traceBundlePaths}
                   onChange={(event) => updateForm("traceBundlePaths", event.target.value)}
-                  className="min-h-24 resize-y"
+                  disabled={isSubmitting}
+                  className="min-h-24 resize-y border-input bg-background shadow-none transition-colors hover:border-border-subtle focus-visible:ring-ring focus-visible:border-primary font-mono text-xs leading-normal p-3 rounded-lg"
                   placeholder="artifacts/traces/sessions/.../mlflow-traces.distilled.jsonl"
                 />
               </CompactField>
             </FieldGroup>
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-4">
-            <div className="min-w-0 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-5 mt-2">
+            <div className="min-w-0 text-xs text-muted-foreground leading-normal font-normal">
               {datasetFile ? (
-                <span className="truncate">Upload: {datasetFile.name}</span>
+                <span className="truncate block max-w-sm">Upload: {datasetFile.name}</span>
               ) : (
-                <span>Optimizer: GEPA · proposer: Daytona RLM</span>
+                <span>Optimizer: GEPA &middot; proposer: Daytona RLM</span>
               )}
             </div>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} className="font-medium h-10 px-5 shadow-xs transition-colors">
               {isSubmitting ? "Starting..." : "Start GEPA run"}
             </Button>
           </div>

--- a/src/frontend/src/features/optimization/optimization-form.tsx
+++ b/src/frontend/src/features/optimization/optimization-form.tsx
@@ -257,11 +257,16 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
   };
 
   return (
-    <SectionCard variant="subtle" className="border-border bg-card shadow-sm transition-all duration-200">
+    <SectionCard
+      variant="subtle"
+      className="border-border bg-card shadow-sm transition-all duration-200"
+    >
       <SectionCardHeader className="border-b border-border-subtle bg-muted/10 px-6 py-5">
         <div className="flex items-center gap-2">
           <Settings2 className="size-5 text-primary" />
-          <SectionCardTitle className="text-base font-semibold tracking-tight">New GEPA Run</SectionCardTitle>
+          <SectionCardTitle className="text-base font-semibold tracking-tight">
+            New GEPA Run
+          </SectionCardTitle>
         </div>
         <SectionCardDescription className="text-muted-foreground typo-body-sm mt-1">
           {moduleDatasetDescription(selectedModule)}
@@ -283,10 +288,18 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                   className="w-full flex"
                   disabled={isSubmitting}
                 >
-                  <ToggleGroupItem value="module" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                  <ToggleGroupItem
+                    value="module"
+                    className="flex-1 font-medium transition-colors"
+                    disabled={isSubmitting}
+                  >
                     Registered module
                   </ToggleGroupItem>
-                  <ToggleGroupItem value="skill" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                  <ToggleGroupItem
+                    value="skill"
+                    className="flex-1 font-medium transition-colors"
+                    disabled={isSubmitting}
+                  >
                     Skill file
                   </ToggleGroupItem>
                 </ToggleGroup>
@@ -307,7 +320,11 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                     <SelectContent align="start" className="border-border">
                       <SelectGroup>
                         {modules.map((module) => (
-                          <SelectItem key={module.slug} value={module.slug} className="cursor-pointer focus:bg-muted/40">
+                          <SelectItem
+                            key={module.slug}
+                            value={module.slug}
+                            className="cursor-pointer focus:bg-muted/40"
+                          >
                             {module.label}
                           </SelectItem>
                         ))}
@@ -350,10 +367,18 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                       className="w-full flex"
                       disabled={isSubmitting}
                     >
-                      <ToggleGroupItem value="name" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                      <ToggleGroupItem
+                        value="name"
+                        className="flex-1 font-medium transition-colors"
+                        disabled={isSubmitting}
+                      >
                         Bundled name
                       </ToggleGroupItem>
-                      <ToggleGroupItem value="path" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                      <ToggleGroupItem
+                        value="path"
+                        className="flex-1 font-medium transition-colors"
+                        disabled={isSubmitting}
+                      >
                         Skill path
                       </ToggleGroupItem>
                     </ToggleGroup>
@@ -389,7 +414,9 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                 <CompactField label="Auto">
                   <Select
                     value={form.auto}
-                    onValueChange={(value) => updateForm("auto", value as OptimizationRunFormState["auto"])}
+                    onValueChange={(value) =>
+                      updateForm("auto", value as OptimizationRunFormState["auto"])
+                    }
                     disabled={isSubmitting}
                   >
                     <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
@@ -397,9 +424,15 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                     </SelectTrigger>
                     <SelectContent align="start" className="border-border">
                       <SelectGroup>
-                        <SelectItem value="light" className="cursor-pointer focus:bg-muted/40">light</SelectItem>
-                        <SelectItem value="medium" className="cursor-pointer focus:bg-muted/40">medium</SelectItem>
-                        <SelectItem value="heavy" className="cursor-pointer focus:bg-muted/40">heavy</SelectItem>
+                        <SelectItem value="light" className="cursor-pointer focus:bg-muted/40">
+                          light
+                        </SelectItem>
+                        <SelectItem value="medium" className="cursor-pointer focus:bg-muted/40">
+                          medium
+                        </SelectItem>
+                        <SelectItem value="heavy" className="cursor-pointer focus:bg-muted/40">
+                          heavy
+                        </SelectItem>
                       </SelectGroup>
                     </SelectContent>
                   </Select>
@@ -438,20 +471,33 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                 <CompactField label="Reflection Profile">
                   <Select
                     value={form.reflectionProfileId || DEFAULT_SELECT_VALUE}
-                    onValueChange={(value) => onReflectionProfileChange(value === DEFAULT_SELECT_VALUE || !value ? "" : value)}
+                    onValueChange={(value) =>
+                      onReflectionProfileChange(
+                        value === DEFAULT_SELECT_VALUE || !value ? "" : value,
+                      )
+                    }
                     disabled={isSubmitting || profilesQuery.isLoading}
                   >
                     <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                       <SelectValue>
-                        {profiles.find((profile) => profile.id === form.reflectionProfileId)?.name ??
-                          "Default reflection model"}
+                        {profiles.find((profile) => profile.id === form.reflectionProfileId)
+                          ?.name ?? "Default reflection model"}
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent align="start" className="border-border">
                       <SelectGroup>
-                        <SelectItem value={DEFAULT_SELECT_VALUE} className="cursor-pointer focus:bg-muted/40">Default reflection model</SelectItem>
+                        <SelectItem
+                          value={DEFAULT_SELECT_VALUE}
+                          className="cursor-pointer focus:bg-muted/40"
+                        >
+                          Default reflection model
+                        </SelectItem>
                         {profiles.map((profile) => (
-                          <SelectItem key={profile.id} value={profile.id} className="cursor-pointer focus:bg-muted/40">
+                          <SelectItem
+                            key={profile.id}
+                            value={profile.id}
+                            className="cursor-pointer focus:bg-muted/40"
+                          >
                             {profile.name}
                           </SelectItem>
                         ))}
@@ -466,18 +512,24 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                     <Select
                       value={form.reflectionModelId}
                       onValueChange={(value) => value && updateForm("reflectionModelId", value)}
-                      disabled={isSubmitting || !form.reflectionProfileId || modelOptions.length === 0}
+                      disabled={
+                        isSubmitting || !form.reflectionProfileId || modelOptions.length === 0
+                      }
                     >
                       <SelectTrigger className="w-full h-10 border-input bg-background px-3 py-2 text-sm shadow-none transition-colors hover:border-border-subtle">
                         <SelectValue>
-                          {modelOptions.find((model) => model.id === form.reflectionModelId)?.label ??
-                            "Select model"}
+                          {modelOptions.find((model) => model.id === form.reflectionModelId)
+                            ?.label ?? "Select model"}
                         </SelectValue>
                       </SelectTrigger>
                       <SelectContent align="start" className="border-border">
                         <SelectGroup>
                           {modelOptions.map((model) => (
-                            <SelectItem key={model.id} value={model.id} className="cursor-pointer focus:bg-muted/40">
+                            <SelectItem
+                              key={model.id}
+                              value={model.id}
+                              className="cursor-pointer focus:bg-muted/40"
+                            >
                               {model.label}
                             </SelectItem>
                           ))}
@@ -491,7 +543,10 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
 
             {/* Right Column: Dataset Setup & Ingestion */}
             <FieldGroup className="gap-5">
-              <CompactField label="Dataset Source" icon={<DatabaseZap className="size-4 text-primary" />}>
+              <CompactField
+                label="Dataset Source"
+                icon={<DatabaseZap className="size-4 text-primary" />}
+              >
                 <ToggleGroup
                   type="single"
                   value={form.datasetSource}
@@ -502,13 +557,25 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                   className="w-full flex"
                   disabled={isSubmitting}
                 >
-                  <ToggleGroupItem value="existing" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                  <ToggleGroupItem
+                    value="existing"
+                    className="flex-1 font-medium transition-colors"
+                    disabled={isSubmitting}
+                  >
                     Existing
                   </ToggleGroupItem>
-                  <ToggleGroupItem value="upload" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                  <ToggleGroupItem
+                    value="upload"
+                    className="flex-1 font-medium transition-colors"
+                    disabled={isSubmitting}
+                  >
                     Upload file
                   </ToggleGroupItem>
-                  <ToggleGroupItem value="path" className="flex-1 font-medium transition-colors" disabled={isSubmitting}>
+                  <ToggleGroupItem
+                    value="path"
+                    className="flex-1 font-medium transition-colors"
+                    disabled={isSubmitting}
+                  >
                     Server path
                   </ToggleGroupItem>
                 </ToggleGroup>
@@ -518,7 +585,9 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                 <CompactField
                   label="Registered Dataset"
                   description={
-                    selectedDataset ? datasetLabel(selectedDataset) : "Registered JSON/JSONL datasets"
+                    selectedDataset
+                      ? datasetLabel(selectedDataset)
+                      : "Registered JSON/JSONL datasets"
                   }
                 >
                   <Select
@@ -542,7 +611,10 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                             className="cursor-pointer focus:bg-muted/40"
                           >
                             <div className="flex items-center gap-2">
-                              <Database className="size-4 shrink-0 text-muted-foreground" data-icon="inline-start" />
+                              <Database
+                                className="size-4 shrink-0 text-muted-foreground"
+                                data-icon="inline-start"
+                              />
                               <span className="truncate">{datasetLabel(dataset)}</span>
                             </div>
                           </SelectItem>
@@ -559,7 +631,10 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                   description="Upload is registered before run creation."
                 >
                   <div className="flex min-h-10 items-center gap-2 rounded-lg border border-input px-3 py-1 bg-background hover:border-border-subtle transition-colors duration-150">
-                    <Upload className="shrink-0 size-4 text-muted-foreground" data-icon="inline-start" />
+                    <Upload
+                      className="shrink-0 size-4 text-muted-foreground"
+                      data-icon="inline-start"
+                    />
                     <Input
                       key={datasetFile ? "loaded" : "empty"}
                       type="file"
@@ -618,7 +693,9 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
               {traceExport ? (
                 <Alert className="border-border bg-muted/20 rounded-lg">
                   <FileJson className="size-4 text-muted-foreground" />
-                  <AlertTitle className="text-sm font-semibold text-foreground">Trace bundle ready</AlertTitle>
+                  <AlertTitle className="text-sm font-semibold text-foreground">
+                    Trace bundle ready
+                  </AlertTitle>
                   <AlertDescription className="text-xs text-muted-foreground mt-0.5">
                     {traceExport.trace_count} trace(s). {traceExport.distilled_bundle_path}
                   </AlertDescription>
@@ -645,7 +722,11 @@ export function OptimizationForm({ onSuccess }: OptimizationFormProps) {
                 <span>Optimizer: GEPA &middot; proposer: Daytona RLM</span>
               )}
             </div>
-            <Button type="submit" disabled={isSubmitting} className="font-medium h-10 px-5 shadow-xs transition-colors">
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="font-medium h-10 px-5 shadow-xs transition-colors"
+            >
               {isSubmitting ? "Starting..." : "Start GEPA run"}
             </Button>
           </div>

--- a/src/frontend/src/features/optimization/optimization-form.tsx
+++ b/src/frontend/src/features/optimization/optimization-form.tsx
@@ -1,0 +1,478 @@
+import type { FormEvent, ReactNode } from "react";
+import { Database, FileJson, Upload } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  SectionCard,
+  SectionCardContent,
+  SectionCardDescription,
+  SectionCardHeader,
+  SectionCardTitle,
+} from "@/components/product/section-layout";
+import type {
+  DatasetResponse,
+  GEPAModuleInfo,
+  SessionTraceExportResponse,
+} from "@/lib/rlm-api";
+import type { LlmModelCatalogEntry, LlmProviderProfileResponse } from "@/lib/rlm-api/llm-profiles";
+
+import {
+  isRunnableDataset,
+  type DatasetSourceMode,
+  type OptimizationRunFormState,
+  type OptimizationTargetMode,
+  type SkillTargetMode,
+} from "./optimization-model";
+
+const DEFAULT_SELECT_VALUE = "__default__";
+
+function CompactField({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Field className="gap-1.5">
+      <FieldLabel>{label}</FieldLabel>
+      {children}
+      {description ? <FieldDescription>{description}</FieldDescription> : null}
+    </Field>
+  );
+}
+
+function datasetLabel(dataset: DatasetResponse): string {
+  const suffix = dataset.module_slug ? ` · ${dataset.module_slug}` : "";
+  return `${dataset.name} · ${dataset.row_count} rows · ${dataset.format}${suffix}`;
+}
+
+function moduleDatasetDescription(module: GEPAModuleInfo | undefined): string {
+  if (!module) return "Optimize an executor RLM skill prompt with offline traces.";
+  const inputs = module.input_keys?.length ? `Inputs: ${module.input_keys.join(", ")}` : "";
+  const outputs = module.output_keys?.length ? `Outputs: ${module.output_keys.join(", ")}` : "";
+  const pieces = [inputs, outputs].filter(Boolean);
+  return pieces.length
+    ? pieces.join(" · ")
+    : `Required keys: ${module.required_dataset_keys.join(", ")}`;
+}
+
+export type OptimizationFormProps = {
+  form: OptimizationRunFormState;
+  updateForm: <K extends keyof OptimizationRunFormState>(
+    key: K,
+    value: OptimizationRunFormState[K],
+  ) => void;
+  onReflectionProfileChange: (profileId: string) => void;
+  setDatasetSource: (value: DatasetSourceMode) => void;
+  modules: GEPAModuleInfo[];
+  modulesLoading: boolean;
+  datasets: DatasetResponse[];
+  datasetsLoading: boolean;
+  selectedModule: GEPAModuleInfo | undefined;
+  selectedDataset: DatasetResponse | undefined;
+  profiles: LlmProviderProfileResponse[];
+  profilesLoading: boolean;
+  modelOptions: LlmModelCatalogEntry[];
+  modelsPending: boolean;
+  datasetFile: File | null;
+  onDatasetFileChange: (file: File | null) => void;
+  traceSessionId: string;
+  onTraceSessionIdChange: (value: string) => void;
+  traceExport: SessionTraceExportResponse | null;
+  isSubmitting: boolean;
+  exportPending: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onTraceExport: () => void;
+};
+
+export function OptimizationForm({
+  form,
+  updateForm,
+  onReflectionProfileChange,
+  setDatasetSource,
+  modules,
+  modulesLoading,
+  datasets,
+  datasetsLoading,
+  selectedModule,
+  selectedDataset,
+  profiles,
+  profilesLoading,
+  modelOptions,
+  modelsPending,
+  datasetFile,
+  onDatasetFileChange,
+  traceSessionId,
+  onTraceSessionIdChange,
+  traceExport,
+  isSubmitting,
+  exportPending,
+  onSubmit,
+  onTraceExport,
+}: OptimizationFormProps) {
+  return (
+    <SectionCard variant="subtle">
+      <SectionCardHeader>
+        <SectionCardTitle>New Run</SectionCardTitle>
+        <SectionCardDescription>{moduleDatasetDescription(selectedModule)}</SectionCardDescription>
+      </SectionCardHeader>
+      <SectionCardContent>
+        <form className="flex flex-col gap-5" onSubmit={onSubmit}>
+          <div className="grid gap-5 lg:grid-cols-[1fr_1fr]">
+            <FieldGroup>
+              <CompactField label="Target">
+                <ToggleGroup
+                  type="single"
+                  value={form.targetMode}
+                  onValueChange={(value) => {
+                    if (value) updateForm("targetMode", value as OptimizationTargetMode);
+                  }}
+                  variant="outline"
+                  className="w-full"
+                >
+                  <ToggleGroupItem value="module">Registered module</ToggleGroupItem>
+                  <ToggleGroupItem value="skill">Skill</ToggleGroupItem>
+                </ToggleGroup>
+              </CompactField>
+
+              {form.targetMode === "module" ? (
+                <CompactField label="Module">
+                  <Select
+                    value={form.moduleSlug}
+                    onValueChange={(value) => {
+                      if (typeof value === "string") updateForm("moduleSlug", value);
+                    }}
+                    disabled={modulesLoading || modules.length === 0}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {selectedModule?.label ?? form.moduleSlug ?? "Select module"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent align="start">
+                      <SelectGroup>
+                        {modules.map((module) => (
+                          <SelectItem key={module.slug} value={module.slug}>
+                            {module.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                  {selectedModule ? (
+                    <div className="rounded-md border border-border-subtle bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+                      <div className="flex flex-wrap gap-1.5">
+                        <Badge variant="outline">
+                          {selectedModule.optimization_target_kind ?? "custom"}
+                        </Badge>
+                        {selectedModule.signature_class_name ? (
+                          <Badge variant="secondary">{selectedModule.signature_class_name}</Badge>
+                        ) : null}
+                        {selectedModule.runtime_module_name ? (
+                          <Badge variant="secondary">{selectedModule.runtime_module_name}</Badge>
+                        ) : null}
+                      </div>
+                      {selectedModule.description ? (
+                        <div className="mt-2">{selectedModule.description}</div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </CompactField>
+              ) : (
+                <>
+                  <CompactField label="Skill target">
+                    <ToggleGroup
+                      type="single"
+                      value={form.skillTargetMode}
+                      onValueChange={(value) => {
+                        if (value) updateForm("skillTargetMode", value as SkillTargetMode);
+                      }}
+                      variant="outline"
+                      className="w-full"
+                    >
+                      <ToggleGroupItem value="name">Bundled name</ToggleGroupItem>
+                      <ToggleGroupItem value="path">Skill path</ToggleGroupItem>
+                    </ToggleGroup>
+                  </CompactField>
+                  {form.skillTargetMode === "name" ? (
+                    <CompactField label="Skill name">
+                      <Input
+                        value={form.skillName}
+                        onChange={(event) => updateForm("skillName", event.target.value)}
+                        placeholder="optimization"
+                      />
+                    </CompactField>
+                  ) : (
+                    <CompactField label="Skill path">
+                      <Input
+                        value={form.skillPath}
+                        onChange={(event) => updateForm("skillPath", event.target.value)}
+                        placeholder="skills/custom/SKILL.md"
+                      />
+                    </CompactField>
+                  )}
+                </>
+              )}
+
+              <div className="grid gap-3 sm:grid-cols-4">
+                <CompactField label="Auto">
+                  <Select
+                    value={form.auto}
+                    onValueChange={(value) =>
+                      typeof value === "string"
+                        ? updateForm("auto", value as OptimizationRunFormState["auto"])
+                        : undefined
+                    }
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue>{form.auto}</SelectValue>
+                    </SelectTrigger>
+                    <SelectContent align="start">
+                      <SelectGroup>
+                        <SelectItem value="light">light</SelectItem>
+                        <SelectItem value="medium">medium</SelectItem>
+                        <SelectItem value="heavy">heavy</SelectItem>
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </CompactField>
+                <CompactField label="Train ratio">
+                  <Input
+                    value={form.trainRatio}
+                    onChange={(event) => updateForm("trainRatio", event.target.value)}
+                    inputMode="decimal"
+                  />
+                </CompactField>
+                <CompactField label="Max calls">
+                  <Input
+                    value={form.maxMetricCalls}
+                    onChange={(event) => updateForm("maxMetricCalls", event.target.value)}
+                    inputMode="numeric"
+                    placeholder="auto"
+                  />
+                </CompactField>
+                <CompactField label="Output path">
+                  <Input
+                    value={form.outputPath}
+                    onChange={(event) => updateForm("outputPath", event.target.value)}
+                    placeholder="optional"
+                  />
+                </CompactField>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <CompactField label="Reflection profile">
+                  <Select
+                    value={form.reflectionProfileId || DEFAULT_SELECT_VALUE}
+                    onValueChange={(value) => {
+                      const nextValue = value === DEFAULT_SELECT_VALUE ? "" : String(value);
+                      onReflectionProfileChange(nextValue);
+                    }}
+                    disabled={profilesLoading}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {profiles.find((profile) => profile.id === form.reflectionProfileId)?.name ??
+                          "Default reflection model"}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent align="start">
+                      <SelectGroup>
+                        <SelectItem value={DEFAULT_SELECT_VALUE}>Default reflection model</SelectItem>
+                        {profiles.map((profile) => (
+                          <SelectItem key={profile.id} value={profile.id}>
+                            {profile.name}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </CompactField>
+                <CompactField label="Reflection model">
+                  {modelsPending && form.reflectionProfileId ? (
+                    <Skeleton className="h-9 w-full rounded-md" />
+                  ) : (
+                    <Select
+                      value={form.reflectionModelId}
+                      onValueChange={(value) => updateForm("reflectionModelId", String(value))}
+                      disabled={!form.reflectionProfileId || modelOptions.length === 0}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue>
+                          {modelOptions.find((model) => model.id === form.reflectionModelId)?.label ??
+                            "Select model"}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent align="start">
+                        <SelectGroup>
+                          {modelOptions.map((model) => (
+                            <SelectItem key={model.id} value={model.id}>
+                              {model.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  )}
+                </CompactField>
+              </div>
+            </FieldGroup>
+
+            <FieldGroup>
+              <CompactField label="Dataset source">
+                <ToggleGroup
+                  type="single"
+                  value={form.datasetSource}
+                  onValueChange={(value) => {
+                    if (value) setDatasetSource(value as DatasetSourceMode);
+                  }}
+                  variant="outline"
+                  className="w-full"
+                >
+                  <ToggleGroupItem value="existing">Existing</ToggleGroupItem>
+                  <ToggleGroupItem value="upload">Upload</ToggleGroupItem>
+                  <ToggleGroupItem value="path">Server path</ToggleGroupItem>
+                </ToggleGroup>
+              </CompactField>
+
+              {form.datasetSource === "existing" ? (
+                <CompactField
+                  label="Dataset"
+                  description={
+                    selectedDataset ? datasetLabel(selectedDataset) : "Registered JSON/JSONL datasets"
+                  }
+                >
+                  <Select
+                    value={form.datasetId}
+                    onValueChange={(value) => updateForm("datasetId", String(value))}
+                    disabled={datasetsLoading || datasets.length === 0}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue>
+                        {selectedDataset?.name ??
+                          (datasetsLoading ? "Loading datasets" : "Select dataset")}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent align="start">
+                      <SelectGroup>
+                        {datasets.map((dataset) => (
+                          <SelectItem
+                            key={dataset.id}
+                            value={dataset.id}
+                            disabled={!isRunnableDataset(dataset)}
+                          >
+                            <Database data-icon="inline-start" />
+                            {datasetLabel(dataset)}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                </CompactField>
+              ) : null}
+
+              {form.datasetSource === "upload" ? (
+                <CompactField
+                  label="Dataset file"
+                  description="Upload is registered before run creation."
+                >
+                  <div className="flex min-h-9 items-center gap-2 rounded-md border border-input px-3 py-2">
+                    <Upload className="shrink-0 text-muted-foreground" data-icon="inline-start" />
+                    <Input
+                      type="file"
+                      accept=".json,.jsonl,application/json"
+                      className="h-auto border-0 p-0 shadow-none file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-2 file:py-1 file:text-xs"
+                      onChange={(event) => onDatasetFileChange(event.target.files?.item(0) ?? null)}
+                    />
+                  </div>
+                </CompactField>
+              ) : null}
+
+              {form.datasetSource === "path" ? (
+                <CompactField label="Server dataset path">
+                  <Input
+                    value={form.datasetPath}
+                    onChange={(event) => updateForm("datasetPath", event.target.value)}
+                    placeholder="artifacts/optimization/dataset.jsonl"
+                  />
+                </CompactField>
+              ) : null}
+
+              <CompactField
+                label="Export session traces"
+                description="Writes full MLflow traces and appends the distilled bundle path."
+              >
+                <div className="flex gap-2">
+                  <Input
+                    value={traceSessionId}
+                    onChange={(event) => onTraceSessionIdChange(event.target.value)}
+                    placeholder="session id"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={exportPending}
+                    onClick={onTraceExport}
+                  >
+                    <FileJson data-icon="inline-start" />
+                    Export
+                  </Button>
+                </div>
+              </CompactField>
+
+              {traceExport ? (
+                <Alert>
+                  <FileJson className="text-muted-foreground" />
+                  <AlertTitle>Trace bundle ready</AlertTitle>
+                  <AlertDescription>
+                    {traceExport.trace_count} trace(s). {traceExport.distilled_bundle_path}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+
+              <CompactField label="Trace bundle paths">
+                <Textarea
+                  value={form.traceBundlePaths}
+                  onChange={(event) => updateForm("traceBundlePaths", event.target.value)}
+                  className="min-h-24 resize-y"
+                  placeholder="artifacts/traces/sessions/.../mlflow-traces.distilled.jsonl"
+                />
+              </CompactField>
+            </FieldGroup>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-4">
+            <div className="min-w-0 text-xs text-muted-foreground">
+              {datasetFile ? (
+                <span className="truncate">Upload: {datasetFile.name}</span>
+              ) : (
+                <span>Optimizer: GEPA · proposer: Daytona RLM</span>
+              )}
+            </div>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Starting..." : "Start GEPA run"}
+            </Button>
+          </div>
+        </form>
+      </SectionCardContent>
+    </SectionCard>
+  );
+}

--- a/src/frontend/src/features/optimization/optimization-model.ts
+++ b/src/frontend/src/features/optimization/optimization-model.ts
@@ -1,4 +1,4 @@
-import type { GEPAOptimizationRequest } from "@/lib/rlm-api";
+import type { DatasetResponse, GEPAOptimizationRequest } from "@/lib/rlm-api";
 
 export type OptimizationTargetMode = "module" | "skill";
 export type SkillTargetMode = "name" | "path";
@@ -46,6 +46,10 @@ export const DEFAULT_OPTIMIZATION_FORM: OptimizationRunFormState = {
   reflectionProfileId: "",
   reflectionModelId: "",
 };
+
+export function isRunnableDataset(dataset: DatasetResponse): boolean {
+  return dataset.row_count > 0;
+}
 
 export function parseTraceBundlePaths(value: string): string[] {
   return value

--- a/src/frontend/src/features/optimization/optimization-model.ts
+++ b/src/frontend/src/features/optimization/optimization-model.ts
@@ -48,7 +48,7 @@ export const DEFAULT_OPTIMIZATION_FORM: OptimizationRunFormState = {
 };
 
 export function isRunnableDataset(dataset: DatasetResponse): boolean {
-  return dataset.row_count > 0;
+  return (dataset?.row_count ?? 0) > 0;
 }
 
 export function parseTraceBundlePaths(value: string): string[] {
@@ -103,10 +103,20 @@ export function buildOptimizationRequest({
     request.max_metric_calls = maxMetricCalls;
   }
 
-  if (form.datasetSource === "existing" || datasetId) {
-    request.dataset_id = selectedDatasetId;
-  } else if (form.datasetSource === "path") {
-    request.dataset_path = datasetPath;
+  switch (form.datasetSource) {
+    case "existing":
+      request.dataset_id = selectedDatasetId;
+      break;
+    case "upload":
+      request.dataset_id = selectedDatasetId;
+      break;
+    case "path":
+      request.dataset_path = datasetPath;
+      break;
+    default: {
+      const _exhaustive: never = form.datasetSource;
+      throw new Error(`Unhandled dataset source mode: ${_exhaustive}`);
+    }
   }
 
   const outputPath = form.outputPath.trim();

--- a/src/frontend/src/features/optimization/optimization-screen.tsx
+++ b/src/frontend/src/features/optimization/optimization-screen.tsx
@@ -8,10 +8,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/product/page-header";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import type {
-  OptimizationPromotionDraftResponse,
-  OptimizationRunResponse,
-} from "@/lib/rlm-api";
+import type { OptimizationPromotionDraftResponse, OptimizationRunResponse } from "@/lib/rlm-api";
 
 import { errorMessage } from "./optimization-format";
 import { OptimizationForm } from "./optimization-form";
@@ -97,7 +94,9 @@ export function OptimizationScreen() {
           {statusQuery.data && !statusQuery.data.available ? (
             <Alert className="border-border-subtle bg-muted/10 rounded-lg">
               <FlaskConical className="text-muted-foreground size-4" />
-              <AlertTitle className="text-sm font-semibold text-foreground">GEPA unavailable</AlertTitle>
+              <AlertTitle className="text-sm font-semibold text-foreground">
+                GEPA unavailable
+              </AlertTitle>
               <AlertDescription className="text-xs text-muted-foreground mt-0.5">
                 {statusQuery.data.guidance ?? "The optimizer is not available in this environment."}
               </AlertDescription>
@@ -111,10 +110,23 @@ export function OptimizationScreen() {
           >
             <div className="flex items-center justify-between gap-3 border-b border-border-subtle pb-3">
               <TabsList className="bg-muted/40 p-1">
-                <TabsTrigger value="new-run" className="font-medium text-xs py-1.5 px-3 transition-colors">New Run</TabsTrigger>
-                <TabsTrigger value="history" className="font-medium text-xs py-1.5 px-3 transition-colors">Run History</TabsTrigger>
+                <TabsTrigger
+                  value="new-run"
+                  className="font-medium text-xs py-1.5 px-3 transition-colors"
+                >
+                  New Run
+                </TabsTrigger>
+                <TabsTrigger
+                  value="history"
+                  className="font-medium text-xs py-1.5 px-3 transition-colors"
+                >
+                  Run History
+                </TabsTrigger>
               </TabsList>
-              <Badge variant="outline" className="border-border-subtle bg-muted/20 text-muted-foreground font-medium typo-helper">
+              <Badge
+                variant="outline"
+                className="border-border-subtle bg-muted/20 text-muted-foreground font-medium typo-helper"
+              >
                 RLM-GEPA
               </Badge>
             </div>

--- a/src/frontend/src/features/optimization/optimization-screen.tsx
+++ b/src/frontend/src/features/optimization/optimization-screen.tsx
@@ -1,33 +1,12 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { toast } from "sonner";
-import { Database, FileJson, FlaskConical, Upload } from "lucide-react";
+import { FlaskConical } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { PageHeader } from "@/components/product/page-header";
-import {
-  SectionCard,
-  SectionCardContent,
-  SectionCardDescription,
-  SectionCardHeader,
-  SectionCardTitle,
-} from "@/components/product/section-layout";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useLlmProfileModels, useLlmProfiles } from "@/features/settings/use-llm-profiles";
 import type {
@@ -42,12 +21,12 @@ import {
   appendTraceBundlePathValue,
   buildOptimizationRequest,
   DEFAULT_OPTIMIZATION_FORM,
+  isRunnableDataset,
   type DatasetSourceMode,
   type OptimizationRunFormState,
-  type OptimizationTargetMode,
-  type SkillTargetMode,
 } from "./optimization-model";
 import { errorMessage } from "./optimization-format";
+import { OptimizationForm } from "./optimization-form";
 import { RunDetailsSheet } from "./run-details-sheet";
 import { RunHistory } from "./run-history";
 import {
@@ -61,47 +40,9 @@ import {
 
 type OptimizationTab = "new-run" | "history";
 
-const DEFAULT_SELECT_VALUE = "__default__";
 const EMPTY_MODULES: GEPAModuleInfo[] = [];
 const EMPTY_DATASETS: DatasetResponse[] = [];
 const EMPTY_RUNS: OptimizationRunResponse[] = [];
-
-function CompactField({
-  label,
-  description,
-  children,
-}: {
-  label: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <Field className="gap-1.5">
-      <FieldLabel>{label}</FieldLabel>
-      {children}
-      {description ? <FieldDescription>{description}</FieldDescription> : null}
-    </Field>
-  );
-}
-
-function datasetLabel(dataset: DatasetResponse): string {
-  const suffix = dataset.module_slug ? ` · ${dataset.module_slug}` : "";
-  return `${dataset.name} · ${dataset.row_count} rows · ${dataset.format}${suffix}`;
-}
-
-function moduleDatasetDescription(module: GEPAModuleInfo | undefined): string {
-  if (!module) return "Optimize an executor RLM skill prompt with offline traces.";
-  const inputs = module.input_keys?.length ? `Inputs: ${module.input_keys.join(", ")}` : "";
-  const outputs = module.output_keys?.length ? `Outputs: ${module.output_keys.join(", ")}` : "";
-  const pieces = [inputs, outputs].filter(Boolean);
-  return pieces.length
-    ? pieces.join(" · ")
-    : `Required keys: ${module.required_dataset_keys.join(", ")}`;
-}
-
-function isRunnableDataset(dataset: DatasetResponse): boolean {
-  return dataset.row_count > 0;
-}
 
 export function OptimizationScreen() {
   const isMobile = useIsMobile();
@@ -169,6 +110,14 @@ export function OptimizationScreen() {
     value: OptimizationRunFormState[K],
   ) => setForm((current) => ({ ...current, [key]: value }));
 
+  const onReflectionProfileChange = (profileId: string) => {
+    setForm((current) => ({
+      ...current,
+      reflectionProfileId: profileId,
+      reflectionModelId: "",
+    }));
+  };
+
   const setDatasetSource = (value: DatasetSourceMode) => {
     setForm((current) => ({
       ...current,
@@ -180,12 +129,10 @@ export function OptimizationScreen() {
   };
 
   const appendTraceBundlePath = (path: string) => {
-    setForm((current) => {
-      return {
-        ...current,
-        traceBundlePaths: appendTraceBundlePathValue(current.traceBundlePaths, path),
-      };
-    });
+    setForm((current) => ({
+      ...current,
+      traceBundlePaths: appendTraceBundlePathValue(current.traceBundlePaths, path),
+    }));
   };
 
   const handleTraceExport = async () => {
@@ -312,379 +259,31 @@ export function OptimizationScreen() {
             </div>
 
             <TabsContent value="new-run" className="mt-2">
-              <SectionCard variant="subtle">
-                <SectionCardHeader>
-                  <SectionCardTitle>New Run</SectionCardTitle>
-                  <SectionCardDescription>
-                    {moduleDatasetDescription(selectedModule)}
-                  </SectionCardDescription>
-                </SectionCardHeader>
-                <SectionCardContent>
-                  <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
-                    <div className="grid gap-5 lg:grid-cols-[1fr_1fr]">
-                      <FieldGroup>
-                        <CompactField label="Target">
-                          <ToggleGroup
-                            type="single"
-                            value={form.targetMode}
-                            onValueChange={(value) => {
-                              if (value) updateForm("targetMode", value as OptimizationTargetMode);
-                            }}
-                            variant="outline"
-                            className="w-full"
-                          >
-                            <ToggleGroupItem value="module">Registered module</ToggleGroupItem>
-                            <ToggleGroupItem value="skill">Skill</ToggleGroupItem>
-                          </ToggleGroup>
-                        </CompactField>
-
-                        {form.targetMode === "module" ? (
-                          <CompactField label="Module">
-                            <Select
-                              value={form.moduleSlug}
-                              onValueChange={(value) => {
-                                if (typeof value === "string") updateForm("moduleSlug", value);
-                              }}
-                              disabled={modulesQuery.isLoading || modules.length === 0}
-                            >
-                              <SelectTrigger className="w-full">
-                                <SelectValue>
-                                  {selectedModule?.label ?? form.moduleSlug ?? "Select module"}
-                                </SelectValue>
-                              </SelectTrigger>
-                              <SelectContent align="start">
-                                <SelectGroup>
-                                  {modules.map((module) => (
-                                    <SelectItem key={module.slug} value={module.slug}>
-                                      {module.label}
-                                    </SelectItem>
-                                  ))}
-                                </SelectGroup>
-                              </SelectContent>
-                            </Select>
-                            {selectedModule ? (
-                              <div className="rounded-md border border-border-subtle bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
-                                <div className="flex flex-wrap gap-1.5">
-                                  <Badge variant="outline">
-                                    {selectedModule.optimization_target_kind ?? "custom"}
-                                  </Badge>
-                                  {selectedModule.signature_class_name ? (
-                                    <Badge variant="secondary">
-                                      {selectedModule.signature_class_name}
-                                    </Badge>
-                                  ) : null}
-                                  {selectedModule.runtime_module_name ? (
-                                    <Badge variant="secondary">
-                                      {selectedModule.runtime_module_name}
-                                    </Badge>
-                                  ) : null}
-                                </div>
-                                {selectedModule.description ? (
-                                  <div className="mt-2">{selectedModule.description}</div>
-                                ) : null}
-                              </div>
-                            ) : null}
-                          </CompactField>
-                        ) : (
-                          <>
-                            <CompactField label="Skill target">
-                              <ToggleGroup
-                                type="single"
-                                value={form.skillTargetMode}
-                                onValueChange={(value) => {
-                                  if (value)
-                                    updateForm("skillTargetMode", value as SkillTargetMode);
-                                }}
-                                variant="outline"
-                                className="w-full"
-                              >
-                                <ToggleGroupItem value="name">Bundled name</ToggleGroupItem>
-                                <ToggleGroupItem value="path">Skill path</ToggleGroupItem>
-                              </ToggleGroup>
-                            </CompactField>
-                            {form.skillTargetMode === "name" ? (
-                              <CompactField label="Skill name">
-                                <Input
-                                  value={form.skillName}
-                                  onChange={(event) => updateForm("skillName", event.target.value)}
-                                  placeholder="optimization"
-                                />
-                              </CompactField>
-                            ) : (
-                              <CompactField label="Skill path">
-                                <Input
-                                  value={form.skillPath}
-                                  onChange={(event) => updateForm("skillPath", event.target.value)}
-                                  placeholder="skills/custom/SKILL.md"
-                                />
-                              </CompactField>
-                            )}
-                          </>
-                        )}
-
-                        <div className="grid gap-3 sm:grid-cols-4">
-                          <CompactField label="Auto">
-                            <Select
-                              value={form.auto}
-                              onValueChange={(value) =>
-                                typeof value === "string"
-                                  ? updateForm("auto", value as OptimizationRunFormState["auto"])
-                                  : undefined
-                              }
-                            >
-                              <SelectTrigger className="w-full">
-                                <SelectValue>{form.auto}</SelectValue>
-                              </SelectTrigger>
-                              <SelectContent align="start">
-                                <SelectGroup>
-                                  <SelectItem value="light">light</SelectItem>
-                                  <SelectItem value="medium">medium</SelectItem>
-                                  <SelectItem value="heavy">heavy</SelectItem>
-                                </SelectGroup>
-                              </SelectContent>
-                            </Select>
-                          </CompactField>
-                          <CompactField label="Train ratio">
-                            <Input
-                              value={form.trainRatio}
-                              onChange={(event) => updateForm("trainRatio", event.target.value)}
-                              inputMode="decimal"
-                            />
-                          </CompactField>
-                          <CompactField label="Max calls">
-                            <Input
-                              value={form.maxMetricCalls}
-                              onChange={(event) => updateForm("maxMetricCalls", event.target.value)}
-                              inputMode="numeric"
-                              placeholder="auto"
-                            />
-                          </CompactField>
-                          <CompactField label="Output path">
-                            <Input
-                              value={form.outputPath}
-                              onChange={(event) => updateForm("outputPath", event.target.value)}
-                              placeholder="optional"
-                            />
-                          </CompactField>
-                        </div>
-
-                        <div className="grid gap-3 sm:grid-cols-2">
-                          <CompactField label="Reflection profile">
-                            <Select
-                              value={form.reflectionProfileId || DEFAULT_SELECT_VALUE}
-                              onValueChange={(value) => {
-                                const nextValue =
-                                  value === DEFAULT_SELECT_VALUE ? "" : String(value);
-                                setForm((current) => ({
-                                  ...current,
-                                  reflectionProfileId: nextValue,
-                                  reflectionModelId: "",
-                                }));
-                              }}
-                              disabled={profilesQuery.isLoading}
-                            >
-                              <SelectTrigger className="w-full">
-                                <SelectValue>
-                                  {profiles.find(
-                                    (profile) => profile.id === form.reflectionProfileId,
-                                  )?.name ?? "Default reflection model"}
-                                </SelectValue>
-                              </SelectTrigger>
-                              <SelectContent align="start">
-                                <SelectGroup>
-                                  <SelectItem value={DEFAULT_SELECT_VALUE}>
-                                    Default reflection model
-                                  </SelectItem>
-                                  {profiles.map((profile) => (
-                                    <SelectItem key={profile.id} value={profile.id}>
-                                      {profile.name}
-                                    </SelectItem>
-                                  ))}
-                                </SelectGroup>
-                              </SelectContent>
-                            </Select>
-                          </CompactField>
-                          <CompactField label="Reflection model">
-                            {modelsQuery.isPending && form.reflectionProfileId ? (
-                              <Skeleton className="h-9 w-full rounded-md" />
-                            ) : (
-                              <Select
-                                value={form.reflectionModelId}
-                                onValueChange={(value) =>
-                                  updateForm("reflectionModelId", String(value))
-                                }
-                                disabled={!form.reflectionProfileId || modelOptions.length === 0}
-                              >
-                                <SelectTrigger className="w-full">
-                                  <SelectValue>
-                                    {modelOptions.find(
-                                      (model) => model.id === form.reflectionModelId,
-                                    )?.label ?? "Select model"}
-                                  </SelectValue>
-                                </SelectTrigger>
-                                <SelectContent align="start">
-                                  <SelectGroup>
-                                    {modelOptions.map((model) => (
-                                      <SelectItem key={model.id} value={model.id}>
-                                        {model.label}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectGroup>
-                                </SelectContent>
-                              </Select>
-                            )}
-                          </CompactField>
-                        </div>
-                      </FieldGroup>
-
-                      <FieldGroup>
-                        <CompactField label="Dataset source">
-                          <ToggleGroup
-                            type="single"
-                            value={form.datasetSource}
-                            onValueChange={(value) => {
-                              if (value) setDatasetSource(value as DatasetSourceMode);
-                            }}
-                            variant="outline"
-                            className="w-full"
-                          >
-                            <ToggleGroupItem value="existing">Existing</ToggleGroupItem>
-                            <ToggleGroupItem value="upload">Upload</ToggleGroupItem>
-                            <ToggleGroupItem value="path">Server path</ToggleGroupItem>
-                          </ToggleGroup>
-                        </CompactField>
-
-                        {form.datasetSource === "existing" ? (
-                          <CompactField
-                            label="Dataset"
-                            description={
-                              selectedDataset
-                                ? datasetLabel(selectedDataset)
-                                : "Registered JSON/JSONL datasets"
-                            }
-                          >
-                            <Select
-                              value={form.datasetId}
-                              onValueChange={(value) => updateForm("datasetId", String(value))}
-                              disabled={datasetsQuery.isLoading || datasets.length === 0}
-                            >
-                              <SelectTrigger className="w-full">
-                                <SelectValue>
-                                  {selectedDataset?.name ??
-                                    (datasetsQuery.isLoading
-                                      ? "Loading datasets"
-                                      : "Select dataset")}
-                                </SelectValue>
-                              </SelectTrigger>
-                              <SelectContent align="start">
-                                <SelectGroup>
-                                  {datasets.map((dataset) => (
-                                    <SelectItem
-                                      key={dataset.id}
-                                      value={dataset.id}
-                                      disabled={!isRunnableDataset(dataset)}
-                                    >
-                                      <Database data-icon="inline-start" />
-                                      {datasetLabel(dataset)}
-                                    </SelectItem>
-                                  ))}
-                                </SelectGroup>
-                              </SelectContent>
-                            </Select>
-                          </CompactField>
-                        ) : null}
-
-                        {form.datasetSource === "upload" ? (
-                          <CompactField
-                            label="Dataset file"
-                            description="Upload is registered before run creation."
-                          >
-                            <div className="flex min-h-9 items-center gap-2 rounded-md border border-input px-3 py-2">
-                              <Upload
-                                className="shrink-0 text-muted-foreground"
-                                data-icon="inline-start"
-                              />
-                              <Input
-                                type="file"
-                                accept=".json,.jsonl,application/json"
-                                className="h-auto border-0 p-0 shadow-none file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-2 file:py-1 file:text-xs"
-                                onChange={(event) =>
-                                  setDatasetFile(event.target.files?.item(0) ?? null)
-                                }
-                              />
-                            </div>
-                          </CompactField>
-                        ) : null}
-
-                        {form.datasetSource === "path" ? (
-                          <CompactField label="Server dataset path">
-                            <Input
-                              value={form.datasetPath}
-                              onChange={(event) => updateForm("datasetPath", event.target.value)}
-                              placeholder="artifacts/optimization/dataset.jsonl"
-                            />
-                          </CompactField>
-                        ) : null}
-
-                        <CompactField
-                          label="Export session traces"
-                          description="Writes full MLflow traces and appends the distilled bundle path."
-                        >
-                          <div className="flex gap-2">
-                            <Input
-                              value={traceSessionId}
-                              onChange={(event) => setTraceSessionId(event.target.value)}
-                              placeholder="session id"
-                            />
-                            <Button
-                              type="button"
-                              variant="outline"
-                              disabled={exportSessionTraces.isPending}
-                              onClick={() => void handleTraceExport()}
-                            >
-                              <FileJson data-icon="inline-start" />
-                              Export
-                            </Button>
-                          </div>
-                        </CompactField>
-
-                        {traceExport ? (
-                          <Alert>
-                            <FileJson className="text-muted-foreground" />
-                            <AlertTitle>Trace bundle ready</AlertTitle>
-                            <AlertDescription>
-                              {traceExport.trace_count} trace(s).{" "}
-                              {traceExport.distilled_bundle_path}
-                            </AlertDescription>
-                          </Alert>
-                        ) : null}
-
-                        <CompactField label="Trace bundle paths">
-                          <Textarea
-                            value={form.traceBundlePaths}
-                            onChange={(event) => updateForm("traceBundlePaths", event.target.value)}
-                            className="min-h-24 resize-y"
-                            placeholder="artifacts/traces/sessions/.../mlflow-traces.distilled.jsonl"
-                          />
-                        </CompactField>
-                      </FieldGroup>
-                    </div>
-
-                    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-4">
-                      <div className="min-w-0 text-xs text-muted-foreground">
-                        {datasetFile ? (
-                          <span className="truncate">Upload: {datasetFile.name}</span>
-                        ) : (
-                          <span>Optimizer: GEPA · proposer: Daytona RLM</span>
-                        )}
-                      </div>
-                      <Button type="submit" disabled={isSubmitting}>
-                        {isSubmitting ? "Starting..." : "Start GEPA run"}
-                      </Button>
-                    </div>
-                  </form>
-                </SectionCardContent>
-              </SectionCard>
+              <OptimizationForm
+                form={form}
+                updateForm={updateForm}
+                onReflectionProfileChange={onReflectionProfileChange}
+                setDatasetSource={setDatasetSource}
+                modules={modules}
+                modulesLoading={modulesQuery.isLoading}
+                datasets={datasets}
+                datasetsLoading={datasetsQuery.isLoading}
+                selectedModule={selectedModule}
+                selectedDataset={selectedDataset}
+                profiles={profiles}
+                profilesLoading={profilesQuery.isLoading}
+                modelOptions={modelOptions}
+                modelsPending={modelsQuery.isPending}
+                datasetFile={datasetFile}
+                onDatasetFileChange={setDatasetFile}
+                traceSessionId={traceSessionId}
+                onTraceSessionIdChange={setTraceSessionId}
+                traceExport={traceExport}
+                isSubmitting={isSubmitting}
+                exportPending={exportSessionTraces.isPending}
+                onSubmit={(event) => void handleSubmit(event)}
+                onTraceExport={() => void handleTraceExport()}
+              />
             </TabsContent>
 
             <TabsContent value="history" className="mt-2">

--- a/src/frontend/src/features/optimization/optimization-screen.tsx
+++ b/src/frontend/src/features/optimization/optimization-screen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { FlaskConical } from "lucide-react";
 
@@ -8,30 +8,16 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PageHeader } from "@/components/product/page-header";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useLlmProfileModels, useLlmProfiles } from "@/features/settings/use-llm-profiles";
 import type {
-  DatasetResponse,
-  GEPAModuleInfo,
   OptimizationPromotionDraftResponse,
   OptimizationRunResponse,
-  SessionTraceExportResponse,
 } from "@/lib/rlm-api";
 
-import {
-  appendTraceBundlePathValue,
-  buildOptimizationRequest,
-  DEFAULT_OPTIMIZATION_FORM,
-  isRunnableDataset,
-  type DatasetSourceMode,
-  type OptimizationRunFormState,
-} from "./optimization-model";
 import { errorMessage } from "./optimization-format";
 import { OptimizationForm } from "./optimization-form";
 import { RunDetailsSheet } from "./run-details-sheet";
 import { RunHistory } from "./run-history";
 import {
-  useOptimizationDatasets,
-  useOptimizationModules,
   useOptimizationMutations,
   useOptimizationRunDetails,
   useOptimizationRuns,
@@ -40,149 +26,22 @@ import {
 
 type OptimizationTab = "new-run" | "history";
 
-const EMPTY_MODULES: GEPAModuleInfo[] = [];
-const EMPTY_DATASETS: DatasetResponse[] = [];
 const EMPTY_RUNS: OptimizationRunResponse[] = [];
 
 export function OptimizationScreen() {
   const isMobile = useIsMobile();
   const statusQuery = useOptimizationStatus();
-  const modulesQuery = useOptimizationModules();
-  const [form, setForm] = useState<OptimizationRunFormState>(DEFAULT_OPTIMIZATION_FORM);
-  const datasetsQuery = useOptimizationDatasets(
-    form.targetMode === "module" ? form.moduleSlug : null,
-  );
   const runsQuery = useOptimizationRuns();
-  const profilesQuery = useLlmProfiles();
-  const modelsQuery = useLlmProfileModels(form.reflectionProfileId || null);
-  const { uploadDataset, createRun, createPromotionDraft, exportSessionTraces } =
-    useOptimizationMutations();
+  const { createPromotionDraft } = useOptimizationMutations();
+
   const [activeTab, setActiveTab] = useState<OptimizationTab>("new-run");
-  const [datasetFile, setDatasetFile] = useState<File | null>(null);
-  const [traceSessionId, setTraceSessionId] = useState("");
-  const [traceExport, setTraceExport] = useState<SessionTraceExportResponse | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const [promotionDraft, setPromotionDraft] = useState<OptimizationPromotionDraftResponse | null>(
     null,
   );
   const runDetailsQuery = useOptimizationRunDetails(selectedRunId);
 
-  const modules = modulesQuery.data ?? EMPTY_MODULES;
-  const datasets = datasetsQuery.data?.items ?? EMPTY_DATASETS;
-  const runnableDatasets = useMemo(() => datasets.filter(isRunnableDataset), [datasets]);
   const runs = runsQuery.data ?? EMPTY_RUNS;
-  const profiles = profilesQuery.data ?? [];
-  const modelOptions = useMemo(() => modelsQuery.data?.models ?? [], [modelsQuery.data?.models]);
-  const selectedModule = useMemo(
-    () => modules.find((module) => module.slug === form.moduleSlug),
-    [form.moduleSlug, modules],
-  );
-  const selectedDataset = useMemo(
-    () => datasets.find((dataset) => dataset.id === form.datasetId),
-    [datasets, form.datasetId],
-  );
-  const isSubmitting = uploadDataset.isPending || createRun.isPending;
-
-  useEffect(() => {
-    if (form.moduleSlug || modules.length === 0) return;
-    const firstModule = modules[0];
-    if (!firstModule) return;
-    setForm((current) => ({ ...current, moduleSlug: firstModule.slug }));
-  }, [form.moduleSlug, modules]);
-
-  useEffect(() => {
-    if (form.datasetSource !== "existing" || form.datasetId || runnableDatasets.length === 0)
-      return;
-    const firstDataset = runnableDatasets[0];
-    if (!firstDataset) return;
-    setForm((current) => ({ ...current, datasetId: firstDataset.id }));
-  }, [form.datasetId, form.datasetSource, runnableDatasets]);
-
-  useEffect(() => {
-    if (!form.reflectionProfileId || form.reflectionModelId || modelOptions.length === 0) return;
-    const firstModel = modelOptions[0];
-    if (!firstModel) return;
-    setForm((current) => ({ ...current, reflectionModelId: firstModel.id }));
-  }, [form.reflectionModelId, form.reflectionProfileId, modelOptions]);
-
-  const updateForm = <K extends keyof OptimizationRunFormState>(
-    key: K,
-    value: OptimizationRunFormState[K],
-  ) => setForm((current) => ({ ...current, [key]: value }));
-
-  const onReflectionProfileChange = (profileId: string) => {
-    setForm((current) => ({
-      ...current,
-      reflectionProfileId: profileId,
-      reflectionModelId: "",
-    }));
-  };
-
-  const setDatasetSource = (value: DatasetSourceMode) => {
-    setForm((current) => ({
-      ...current,
-      datasetSource: value,
-      datasetId: value === "existing" ? current.datasetId : "",
-      datasetPath: value === "path" ? current.datasetPath : "",
-    }));
-    if (value !== "upload") setDatasetFile(null);
-  };
-
-  const appendTraceBundlePath = (path: string) => {
-    setForm((current) => ({
-      ...current,
-      traceBundlePaths: appendTraceBundlePathValue(current.traceBundlePaths, path),
-    }));
-  };
-
-  const handleTraceExport = async () => {
-    const sessionId = traceSessionId.trim();
-    if (!sessionId) {
-      toast.error("Session id is required");
-      return;
-    }
-    try {
-      const exported = await exportSessionTraces.mutateAsync({ sessionId });
-      setTraceExport(exported);
-      if (exported.distilled_bundle_path) appendTraceBundlePath(exported.distilled_bundle_path);
-      if (exported.trace_count === 0) {
-        toast.warning("Trace export completed with no traces", {
-          description: "Run a chat turn first or verify the session is linked to MLflow traces.",
-        });
-        return;
-      }
-      toast.success("Trace bundle exported", {
-        description: exported.distilled_bundle_path ?? exported.jsonl_path ?? exported.json_path,
-      });
-    } catch (error) {
-      toast.error("Trace export failed", { description: errorMessage(error) });
-    }
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    try {
-      buildOptimizationRequest({ form, hasDatasetFile: Boolean(datasetFile) });
-      const uploaded =
-        form.datasetSource === "upload" && datasetFile
-          ? await uploadDataset.mutateAsync({
-              file: datasetFile,
-              moduleSlug: form.targetMode === "module" ? form.moduleSlug : null,
-            })
-          : null;
-      const request = buildOptimizationRequest({
-        form,
-        datasetId: uploaded?.id,
-        hasDatasetFile: false,
-      });
-      const created = await createRun.mutateAsync(request);
-      toast.success("GEPA run started", { description: created.run_id });
-      setDatasetFile(null);
-      setActiveTab("history");
-    } catch (error) {
-      toast.error("GEPA run not started", { description: errorMessage(error) });
-    }
-  };
 
   const openRunDetails = (runId: string) => {
     setPromotionDraft(null);
@@ -236,10 +95,10 @@ export function OptimizationScreen() {
 
         <div className="mx-auto flex w-full max-w-page flex-col gap-4 px-4 py-4 md:px-6">
           {statusQuery.data && !statusQuery.data.available ? (
-            <Alert>
-              <FlaskConical className="text-muted-foreground" />
-              <AlertTitle>GEPA unavailable</AlertTitle>
-              <AlertDescription>
+            <Alert className="border-border-subtle bg-muted/10 rounded-lg">
+              <FlaskConical className="text-muted-foreground size-4" />
+              <AlertTitle className="text-sm font-semibold text-foreground">GEPA unavailable</AlertTitle>
+              <AlertDescription className="text-xs text-muted-foreground mt-0.5">
                 {statusQuery.data.guidance ?? "The optimizer is not available in this environment."}
               </AlertDescription>
             </Alert>
@@ -250,43 +109,21 @@ export function OptimizationScreen() {
             onValueChange={(value) => setActiveTab(value as OptimizationTab)}
             className="min-h-0"
           >
-            <div className="flex items-center justify-between gap-3">
-              <TabsList>
-                <TabsTrigger value="new-run">New Run</TabsTrigger>
-                <TabsTrigger value="history">Run History</TabsTrigger>
+            <div className="flex items-center justify-between gap-3 border-b border-border-subtle pb-3">
+              <TabsList className="bg-muted/40 p-1">
+                <TabsTrigger value="new-run" className="font-medium text-xs py-1.5 px-3 transition-colors">New Run</TabsTrigger>
+                <TabsTrigger value="history" className="font-medium text-xs py-1.5 px-3 transition-colors">Run History</TabsTrigger>
               </TabsList>
-              <Badge variant="outline">RLM-GEPA</Badge>
+              <Badge variant="outline" className="border-border-subtle bg-muted/20 text-muted-foreground font-medium typo-helper">
+                RLM-GEPA
+              </Badge>
             </div>
 
-            <TabsContent value="new-run" className="mt-2">
-              <OptimizationForm
-                form={form}
-                updateForm={updateForm}
-                onReflectionProfileChange={onReflectionProfileChange}
-                setDatasetSource={setDatasetSource}
-                modules={modules}
-                modulesLoading={modulesQuery.isLoading}
-                datasets={datasets}
-                datasetsLoading={datasetsQuery.isLoading}
-                selectedModule={selectedModule}
-                selectedDataset={selectedDataset}
-                profiles={profiles}
-                profilesLoading={profilesQuery.isLoading}
-                modelOptions={modelOptions}
-                modelsPending={modelsQuery.isPending}
-                datasetFile={datasetFile}
-                onDatasetFileChange={setDatasetFile}
-                traceSessionId={traceSessionId}
-                onTraceSessionIdChange={setTraceSessionId}
-                traceExport={traceExport}
-                isSubmitting={isSubmitting}
-                exportPending={exportSessionTraces.isPending}
-                onSubmit={(event) => void handleSubmit(event)}
-                onTraceExport={() => void handleTraceExport()}
-              />
+            <TabsContent value="new-run" className="mt-4 focus-visible:outline-none">
+              <OptimizationForm onSuccess={() => setActiveTab("history")} />
             </TabsContent>
 
-            <TabsContent value="history" className="mt-2">
+            <TabsContent value="history" className="mt-4 focus-visible:outline-none">
               <RunHistory
                 runs={runs}
                 isLoading={runsQuery.isLoading}

--- a/src/frontend/src/features/optimization/run-history.tsx
+++ b/src/frontend/src/features/optimization/run-history.tsx
@@ -22,7 +22,11 @@ const statusTone: Record<string, "default" | "secondary" | "destructive" | "outl
 };
 
 function StatusBadge({ status }: { status: string }) {
-  return <Badge variant={statusTone[status] ?? "outline"}>{status}</Badge>;
+  return (
+    <Badge variant={statusTone[status] ?? "outline"} className="capitalize font-medium px-2 py-0.5 typo-body-xs leading-none">
+      {status}
+    </Badge>
+  );
 }
 
 export function RunHistory({
@@ -39,41 +43,51 @@ export function RunHistory({
   onSelectRun?: (runId: string) => void;
 }) {
   return (
-    <SectionCard variant="subtle">
-      <SectionCardHeader className="flex-row items-center justify-between gap-4">
+    <SectionCard variant="subtle" className="border-border bg-card shadow-sm transition-all duration-200">
+      <SectionCardHeader className="flex-row items-center justify-between gap-4 border-b border-border-subtle bg-muted/10 px-6 py-4">
         <div className="min-w-0">
-          <SectionCardTitle>Run History</SectionCardTitle>
-          <SectionCardDescription>
+          <SectionCardTitle className="text-sm font-semibold tracking-tight">Run History</SectionCardTitle>
+          <SectionCardDescription className="text-muted-foreground typo-helper mt-0.5">
             {runs.length} GEPA run{runs.length === 1 ? "" : "s"}
           </SectionCardDescription>
         </div>
-        <Button type="button" variant="outline" size="sm" onClick={refetch}>
-          <RefreshCw data-icon="inline-start" className={cn(isLoading && "animate-spin")} />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={refetch}
+          className="h-8 font-medium transition-colors hover:bg-muted/40 shadow-none border-input"
+        >
+          <RefreshCw data-icon="inline-start" className={cn("size-3.5", isLoading && "animate-spin")} />
           Refresh
         </Button>
       </SectionCardHeader>
-      <SectionCardContent>
+      <SectionCardContent className="p-6">
         {error ? (
-          <Alert>
-            <AlertTitle>Run history unavailable</AlertTitle>
-            <AlertDescription>{errorMessage(error)}</AlertDescription>
+          <Alert className="border-border-subtle bg-muted/10 rounded-lg">
+            <AlertTitle className="text-sm font-semibold text-foreground">Run history unavailable</AlertTitle>
+            <AlertDescription className="text-xs text-muted-foreground mt-0.5">{errorMessage(error)}</AlertDescription>
           </Alert>
         ) : null}
 
         {!error && isLoading && runs.length === 0 ? (
-          <div className="py-10 text-center text-muted-foreground typo-label">Loading runs...</div>
+          <div className="py-12 text-center text-muted-foreground typo-body-sm flex flex-col items-center justify-center gap-3">
+            <RefreshCw className="size-5 animate-spin text-muted-foreground/60" />
+            Loading runs...
+          </div>
         ) : null}
 
         {!error && !isLoading && runs.length === 0 ? (
-          <div className="py-10 text-center text-muted-foreground typo-label">
-            No optimization runs yet.
+          <div className="py-12 text-center text-muted-foreground typo-body-sm">
+            No optimization runs yet. Create a run to get started.
           </div>
         ) : null}
 
         {runs.length > 0 ? (
-          <div className="overflow-x-auto">
-            <div className="min-w-[1080px] rounded-lg border border-border-subtle">
-              <div className="grid grid-cols-[104px_1.3fr_1fr_80px_80px_92px_1.4fr_92px] border-b border-border-subtle bg-muted/35 px-3 py-2 text-xs font-medium text-muted-foreground">
+          <div className="overflow-x-auto rounded-lg border border-border-subtle scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent">
+            <div className="min-w-[1080px] bg-background">
+              {/* Header row */}
+              <div className="grid grid-cols-[112px_1.3fr_1fr_80px_80px_92px_1.4fr_92px] items-center border-b border-border-subtle bg-muted/20 px-4 py-2.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                 <span>Status</span>
                 <span>Target</span>
                 <span>Reflection</span>
@@ -81,49 +95,55 @@ export function RunHistory({
                 <span>Score</span>
                 <span>Phase</span>
                 <span>Artifacts</span>
-                <span>Details</span>
+                <span className="text-right">Action</span>
               </div>
+              {/* Data rows */}
               {runs.map((run) => (
                 <div
                   key={run.id}
-                  className="grid grid-cols-[104px_1.3fr_1fr_80px_80px_92px_1.4fr_92px] border-b border-border-subtle px-3 py-3 text-sm last:border-b-0"
+                  onClick={() => onSelectRun?.(run.id)}
+                  className="grid grid-cols-[112px_1.3fr_1fr_80px_80px_92px_1.4fr_92px] items-center border-b border-border-subtle px-4 py-3.5 text-sm transition-colors duration-150 hover:bg-muted/15 cursor-pointer last:border-b-0"
                 >
-                  <div className="min-w-0">
+                  <div className="min-w-0 pr-2">
                     <StatusBadge status={run.status} />
-                    <div className="mt-1 truncate text-xs text-muted-foreground">
+                    <div className="mt-1.5 truncate typo-body-xs text-muted-foreground leading-none font-mono">
                       {formatDateTime(run.started_at)}
                     </div>
                   </div>
-                  <div className="min-w-0">
-                    <div className="truncate font-medium">{targetLabel(run)}</div>
-                    <div className="truncate text-xs text-muted-foreground">{run.optimizer}</div>
+                  <div className="min-w-0 pr-4">
+                    <div className="truncate font-semibold text-foreground text-xs">{targetLabel(run)}</div>
+                    <div className="truncate typo-helper text-muted-foreground mt-0.5 font-mono uppercase tracking-wider">{run.optimizer}</div>
                     {run.error ? (
-                      <div className="mt-1 truncate text-xs text-destructive">{run.error}</div>
+                      <div className="mt-1 truncate typo-body-xs text-destructive leading-tight">{run.error}</div>
                     ) : null}
                   </div>
-                  <div className="min-w-0">
-                    <div className="truncate text-xs">{run.reflection_model_id ?? "default"}</div>
-                    <div className="truncate text-xs text-muted-foreground">
+                  <div className="min-w-0 pr-4">
+                    <div className="truncate text-xs text-foreground font-medium">{run.reflection_model_id ?? "default"}</div>
+                    <div className="truncate typo-helper text-muted-foreground font-mono mt-0.5">
                       {run.reflection_profile_id ?? ""}
                     </div>
                   </div>
-                  <span className="text-muted-foreground">{run.auto ?? "-"}</span>
-                  <span className="font-mono text-xs">{formatScore(run.validation_score)}</span>
-                  <span className="truncate text-muted-foreground">{run.phase ?? "-"}</span>
-                  <div className="min-w-0">
-                    <div className="truncate text-xs">{run.output_path ?? "-"}</div>
-                    <div className="truncate text-xs text-muted-foreground">
+                  <span className="text-muted-foreground text-xs font-medium">{run.auto ?? "-"}</span>
+                  <span className="font-mono text-xs font-semibold text-foreground">{formatScore(run.validation_score)}</span>
+                  <span className="truncate text-muted-foreground text-xs font-medium">{run.phase ?? "-"}</span>
+                  <div className="min-w-0 pr-4">
+                    <div className="truncate text-xs text-foreground font-mono">{run.output_path ?? "-"}</div>
+                    <div className="truncate typo-helper text-muted-foreground font-mono mt-0.5">
                       {run.distilled_trace_bundle_path ?? run.manifest_path ?? ""}
                     </div>
                   </div>
-                  <div>
+                  <div className="flex justify-end">
                     <Button
                       type="button"
                       size="sm"
                       variant="outline"
-                      onClick={() => onSelectRun?.(run.id)}
+                      onClick={(e) => {
+                        e.stopPropagation(); // prevent row click trigger duplication
+                        onSelectRun?.(run.id);
+                      }}
+                      className="h-8 text-xs font-medium transition-colors hover:bg-muted/40 shadow-none border-input"
                     >
-                      <FileText data-icon="inline-start" />
+                      <FileText className="size-3.5" data-icon="inline-start" />
                       Details
                     </Button>
                   </div>

--- a/src/frontend/src/features/optimization/run-history.tsx
+++ b/src/frontend/src/features/optimization/run-history.tsx
@@ -23,7 +23,10 @@ const statusTone: Record<string, "default" | "secondary" | "destructive" | "outl
 
 function StatusBadge({ status }: { status: string }) {
   return (
-    <Badge variant={statusTone[status] ?? "outline"} className="capitalize font-medium px-2 py-0.5 typo-body-xs leading-none">
+    <Badge
+      variant={statusTone[status] ?? "outline"}
+      className="capitalize font-medium px-2 py-0.5 typo-body-xs leading-none"
+    >
       {status}
     </Badge>
   );
@@ -43,10 +46,15 @@ export function RunHistory({
   onSelectRun?: (runId: string) => void;
 }) {
   return (
-    <SectionCard variant="subtle" className="border-border bg-card shadow-sm transition-all duration-200">
+    <SectionCard
+      variant="subtle"
+      className="border-border bg-card shadow-sm transition-all duration-200"
+    >
       <SectionCardHeader className="flex-row items-center justify-between gap-4 border-b border-border-subtle bg-muted/10 px-6 py-4">
         <div className="min-w-0">
-          <SectionCardTitle className="text-sm font-semibold tracking-tight">Run History</SectionCardTitle>
+          <SectionCardTitle className="text-sm font-semibold tracking-tight">
+            Run History
+          </SectionCardTitle>
           <SectionCardDescription className="text-muted-foreground typo-helper mt-0.5">
             {runs.length} GEPA run{runs.length === 1 ? "" : "s"}
           </SectionCardDescription>
@@ -58,15 +66,22 @@ export function RunHistory({
           onClick={refetch}
           className="h-8 font-medium transition-colors hover:bg-muted/40 shadow-none border-input"
         >
-          <RefreshCw data-icon="inline-start" className={cn("size-3.5", isLoading && "animate-spin")} />
+          <RefreshCw
+            data-icon="inline-start"
+            className={cn("size-3.5", isLoading && "animate-spin")}
+          />
           Refresh
         </Button>
       </SectionCardHeader>
       <SectionCardContent className="p-6">
         {error ? (
           <Alert className="border-border-subtle bg-muted/10 rounded-lg">
-            <AlertTitle className="text-sm font-semibold text-foreground">Run history unavailable</AlertTitle>
-            <AlertDescription className="text-xs text-muted-foreground mt-0.5">{errorMessage(error)}</AlertDescription>
+            <AlertTitle className="text-sm font-semibold text-foreground">
+              Run history unavailable
+            </AlertTitle>
+            <AlertDescription className="text-xs text-muted-foreground mt-0.5">
+              {errorMessage(error)}
+            </AlertDescription>
           </Alert>
         ) : null}
 
@@ -111,23 +126,39 @@ export function RunHistory({
                     </div>
                   </div>
                   <div className="min-w-0 pr-4">
-                    <div className="truncate font-semibold text-foreground text-xs">{targetLabel(run)}</div>
-                    <div className="truncate typo-helper text-muted-foreground mt-0.5 font-mono uppercase tracking-wider">{run.optimizer}</div>
+                    <div className="truncate font-semibold text-foreground text-xs">
+                      {targetLabel(run)}
+                    </div>
+                    <div className="truncate typo-helper text-muted-foreground mt-0.5 font-mono uppercase tracking-wider">
+                      {run.optimizer}
+                    </div>
                     {run.error ? (
-                      <div className="mt-1 truncate typo-body-xs text-destructive leading-tight">{run.error}</div>
+                      <div className="mt-1 truncate typo-body-xs text-destructive leading-tight">
+                        {run.error}
+                      </div>
                     ) : null}
                   </div>
                   <div className="min-w-0 pr-4">
-                    <div className="truncate text-xs text-foreground font-medium">{run.reflection_model_id ?? "default"}</div>
+                    <div className="truncate text-xs text-foreground font-medium">
+                      {run.reflection_model_id ?? "default"}
+                    </div>
                     <div className="truncate typo-helper text-muted-foreground font-mono mt-0.5">
                       {run.reflection_profile_id ?? ""}
                     </div>
                   </div>
-                  <span className="text-muted-foreground text-xs font-medium">{run.auto ?? "-"}</span>
-                  <span className="font-mono text-xs font-semibold text-foreground">{formatScore(run.validation_score)}</span>
-                  <span className="truncate text-muted-foreground text-xs font-medium">{run.phase ?? "-"}</span>
+                  <span className="text-muted-foreground text-xs font-medium">
+                    {run.auto ?? "-"}
+                  </span>
+                  <span className="font-mono text-xs font-semibold text-foreground">
+                    {formatScore(run.validation_score)}
+                  </span>
+                  <span className="truncate text-muted-foreground text-xs font-medium">
+                    {run.phase ?? "-"}
+                  </span>
                   <div className="min-w-0 pr-4">
-                    <div className="truncate text-xs text-foreground font-mono">{run.output_path ?? "-"}</div>
+                    <div className="truncate text-xs text-foreground font-mono">
+                      {run.output_path ?? "-"}
+                    </div>
                     <div className="truncate typo-helper text-muted-foreground font-mono mt-0.5">
                       {run.distilled_trace_bundle_path ?? run.manifest_path ?? ""}
                     </div>

--- a/src/frontend/src/features/optimization/use-optimization.ts
+++ b/src/frontend/src/features/optimization/use-optimization.ts
@@ -31,11 +31,15 @@ export function useOptimizationModules() {
   });
 }
 
-export function useOptimizationDatasets(moduleSlug?: string | null) {
+export function useOptimizationDatasets(
+  moduleSlug?: string | null,
+  options?: { enabled?: boolean },
+) {
   return useQuery({
     queryKey: optimizationQueryKeys.datasets(moduleSlug),
     queryFn: ({ signal }) =>
       optimizationEndpoints.datasets({ moduleSlug: moduleSlug || null, limit: 100 }, signal),
+    ...options,
   });
 }
 


### PR DESCRIPTION
## Summary
- Extract the new-run form from `optimization-screen.tsx` into `optimization-form.tsx`, leaving the screen as a thin shell (tabs, state, handlers).
- Centralize `isRunnableDataset` in `optimization-model.ts` per thermo code-quality follow-up.

## Test plan
- [x] `pnpm run type-check`
- [x] `pnpm run test:unit -- optimization` (315 tests pass)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New optimization run form with dataset selection/upload, reflection profile & model selection, run parameter controls, trace export/preview, and a “Start GEPA run” action; shows uploaded filename and disables sections while loading.

* **Refactor**
  * Optimization form UI and logic moved into a dedicated component for clearer structure.

* **Chores**
  * Updated project ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->