### PR TITLE
docs: align agent harness maps with current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,15 @@ where the durable rules live and which commands prove a change.
 - `src/fleet_rlm/AGENTS.md` - backend, runtime, API, persistence, Daytona, and package rules.
 - `src/frontend/AGENTS.md` - React, TanStack Router, Vite+, styling, and frontend checks.
 
+## Durable Detail Locations
+
+- Auth, database, websocket, runtime, and deployment details live in `src/fleet_rlm/AGENTS.md`
+  and the matching `docs/reference/*` or `docs/how-to-guides/*` page.
+- Frontend routing, Agent Elements, styling, session restore, and package rules live in
+  `src/frontend/AGENTS.md`.
+- Local Codex actions, ports, browser smoke expectations, and tool preferences live in
+  `docs/agent-harness/feedback-loop.md` and `docs/how-to-guides/codex-environment.md`.
+
 ## Setup
 
 ```bash
@@ -117,25 +126,3 @@ When changing workflow, contracts, or architecture, update the durable docs befo
 - `docs/README.md`, `docs/index.md`, and `docs/SUMMARY.md`.
 - `scripts/README.md`, `Makefile`, `pyproject.toml`, and `src/frontend/package.json` when commands move.
 - `openapi.yaml` and frontend API artifacts when backend request or response shapes move.
-
-## Learned User Preferences
-
-- Always use the `zsh` terminal profile for CLI commands. Adjust column width via `--an-max-width` in `agent-ui.css` instead of Tailwind, and use `pnpm run check` in `src/frontend` to verify format, types, linter, and unit tests.
-- Always include direct absolute markdown links to `.canvas.tsx` files when creating or mentioning an IDE Canvas, e.g. using the format: `[Descriptive Label]` immediately followed by `(/absolute/path/to/canvas.canvas.tsx)`.
-- For landing page suggestions in `workspace-message-list.tsx`, use the canonical `/agent-elements` `Suggestion` chip component with uncolored icon fills and a larger "Qredence Fleet" title, avoiding card-like empty states or colored icon accents.
-- Prefer the built-in Cursor Browser (`cursor-ide-browser` MCP server) over Playwright tools when requested to perform browser automation.
-
-## Learned Workspace Facts
-
-- **Local Ports & Runtime Services**: Local development runs on ports `:8000` (FastAPI), `:5173` (Vite dev), and `:5001` (MLflow on Python 3.13+); chat runtime runs in Daytona via `dspy.RLM` with multi-provider dropdown selection. The offline dev workspace has no external internet access (blocked at the DNS level), though `user-Neon` MCP operates fine.
-- **Database Architecture & Multi-Tenant Isolation**: Multi-tenant database isolation relies on Postgres Row-Level Security (RLS) policies (setting transaction local context variables `app.tenant_id`, `app.user_id`, `app.workspace_id` via `set_config` and `set_local`). Alembic schema drift checking requires importing all active SQLModel models inside `migrations/env.py`, while local fallback uses SQLModel/SQLite. Neon Postgres database security hardening requires securing pg_catalog and system functions (like `app.uuid_v7`, `app.set_updated_at`, `public.show_db_tree`) by setting an explicit, safe `search_path` (e.g., `SET search_path = app, pg_temp`) and relocating extensions (`pgcrypto`, `uuid-ossp`) to the secure `app` schema.
-- **Neon Auth, Token Decoding & Form Styling**: Neon Auth is integrated under `auth_mode="neon"`, using `@neondatabase/auth-ui` on the frontend (catch-alls `/auth/$pathname` and `/account/$pathname`). Its EdDSA-signed tokens require explicitly passing `algorithms=["EdDSA"]` in Python's `joserfc` JWT decoder (RFC 9864) to prevent signature rejection; browser WebSockets must use `POST /api/v1/auth/ws-ticket` and never raw Neon JWT query parameters. Custom layouts are best achieved by rendering granular forms (`SignInForm`, `SignUpForm`) directly rather than `AuthView`, stripping default borders/shadows using `classNames={{ base: "border-0 bg-transparent p-0 shadow-none w-full !max-w-none" }}` to integrate seamlessly.
-- **Session Lifetime & WebSocket Sync**: Chat sessions auto-create/save on first message, sorted descending (`createdAt`), guarded by `lastSavedStateRef` in `workspace-screen.tsx` to prevent redundant saves. WebSocket execution emits `"db_session_id"` inside the `"execution_started"` event `summary` payload, which `use-workspace-runtime.ts` captures dynamically to bind local and remote session state.
-- **Background Syncing & Restore**: On user authentication (`isAuthenticated`), `app-sidebar.tsx` triggers a background synchronizer that fetches and merges remote Neon database sessions (`sessionsEndpoints.list`) into the TanStack store to seamlessly restore conversation history. Keep FastAPI and `FleetRepository` responsible for runtime authorization rather than bypassing via Neon Data API.
-- **UI Styling, Cards, Tabs & Inputs**: Global `globals.css` overrides target sidebar subtrees to completely suppress focus outlines, rings, and borders, and implement hover-reveal transitions (`opacity 150ms`) for session list scrollbars using `.scroll-area-hover-reveal`. Tool names align horizontally via `ToolRowBase`. Standalone analytical outputs use IDE Canvases with categories (`gray`, `purple`, `green`, `yellow`, `pink`, `blue`, and `orange`). Align complex dashboards (like Optimization page) with `@basecn` / `@coss/ui` specifications: use standard `text-sm` navigation tabs without inline padding/background overrides, standard `variant="elevated"` cards to wrap major containers, and standard height `h-9` inputs/textareas/select triggers without redundant hover/focus colors or height overrides to preserve dark mode and layout consistency. Always target specific classes (e.g., `.visual-json-tree`) instead of generic selectors (like global `[role="tree"]` which breaks unrelated components such as filesystem trees) for CSS text-wrapping overrides, use standard Tailwind spacing scales (`w-44`/`max-w-44` instead of invalid/non-existent `w-45`/`max-w-45`), and preserve focus ring indicators on core input forms (like `input-bar.tsx`).
-- **Build & Package Pipeline**: Frontend uses `pnpm` exclusively (see `CLAUDE.md` dev commands). Under `uv build`, packaging delegates to `src/fleet_rlm/ui/build.py` which runs `scripts/ensure_frontend_entrypoint.py` to reconstruct `index.html` and copy assets to `src/fleet_rlm/ui/dist` for serving on port `:8000`.
-- **PNPM v11 Workspace Configuration & Security**: Starting in version 11, `pnpm` deprecates reading configurations from the `pnpm` field inside `package.json`. All settings must reside in `pnpm-workspace.yaml`. Crucially, legacy properties `onlyBuiltDependencies` and `trustedDependencies` have been completely removed and consolidated under the single `allowBuilds` key-value map in `pnpm-workspace.yaml` (e.g., `allowBuilds: ["esbuild", "core-js", "@tailwindcss/oxide"]`) to allow secure native compilation.
-- **TanStack Start Hydration**: Under TanStack Start, client entry `client.tsx` falls back to `createRoot` for static non-SSR serving while using `hydrateRoot` in SSR mode to avoid blank screens, sets `(window as any).__hydrated = true` for E2E tests, renders `PostHogProvider` unconditionally, and guards SSR manifest mutations via `WeakSet`.
-- **TanStack Routing & State Preservation**: Under TanStack Router/Start, route loaders must strictly await blocking data prefetching (e.g., `await Promise.allSettled([queryClient.ensureQueryData(...)])`) instead of using unawaited prefetch calls. Instant page transitions with empty caches trigger layout shifts, hydration flickers, and E2E/hydration mismatch errors. Ensure user actions like file staging (e.g., selecting custom local datasets) render immediate persistent layout-aligned feedback of the selection status (such as displaying `datasetFile.name` in the form's submission footer).
-- **Streaming & Terminal TUI**: Streaming responses in the runtime are standardized on `RuntimeEvent` (`runtime/events.py`) and projected using `project_chat`, while legacy `StreamEvent` DTOs are cleaned up and unused. The interactive terminal TUI in `chat.py` implements a Claude Code-inspired layout using `prompt_toolkit` with a boxed input prompt sticking to the bottom, active thinking/connection states, and a scrollable transcript.
-- **FastAPI Cloud Deployment**: On FastAPI Cloud, delete locked env vars first via `uv run fastapi cloud env delete <VAR> -y` and deploy with `--no-wait`; production and staging environments enforce `AUTH_REQUIRED=true` at startup.

--- a/docs/agent-harness/architecture-invariants.md
+++ b/docs/agent-harness/architecture-invariants.md
@@ -59,7 +59,7 @@ plus the current MCP attachment when servers are reattached.
 
 Keep shared UI primitives reusable:
 
-- `src/frontend/src/components/ui/*`, `components/ai-elements/*`, and `components/product/*` must
+- `src/frontend/src/components/ui/*`, `components/agent-elements/*`, and `components/product/*` must
   not import from route files or feature implementation modules.
 - `src/frontend/src/lib/workspace/*` must stay UI-independent.
 - `src/frontend/src/features/layout/*` should import product surfaces through feature contracts

--- a/docs/agent-harness/architecture-invariants.md
+++ b/docs/agent-harness/architecture-invariants.md
@@ -59,7 +59,7 @@ plus the current MCP attachment when servers are reattached.
 
 Keep shared UI primitives reusable:
 
-- `src/frontend/src/components/ui/*`, `components/agent-elements/*`, and `components/product/*` must
+- `src/frontend/src/components/{ui,agent-elements,product}/*` must
   not import from route files or feature implementation modules.
 - `src/frontend/src/lib/workspace/*` must stay UI-independent.
 - `src/frontend/src/features/layout/*` should import product surfaces through feature contracts

--- a/docs/agent-harness/feedback-loop.md
+++ b/docs/agent-harness/feedback-loop.md
@@ -34,6 +34,8 @@ Start the local app in a separate terminal:
 uv run fleet web
 ```
 
+The integrated FastAPI app serves on `:8000` by default.
+
 Or run the API directly:
 
 ```bash
@@ -48,6 +50,9 @@ For frontend-only iteration:
 pnpm run dev
 ```
 
+The frontend dev server uses Vite on `:5173` and proxies `/api/v1`, `/health`, and `/ready` to
+`localhost:8000`. MLflow uses `:5001` when started through `make mlflow`.
+
 ## Browser Smoke
 
 With the app running, smoke-test:
@@ -60,8 +65,9 @@ With the app running, smoke-test:
 5. `GET /api/v1/runtime/status` returns structured runtime status, even when live Daytona or LLM
    credentials are not configured.
 
-Use the Codex browser, Playwright, or the local browser tool already available in the session. Do
-not invent a second UI test framework for this smoke path.
+Use the local browser tool already available in the session. Prefer the built-in Cursor Browser
+(`cursor-ide-browser`) when it is available or explicitly requested; otherwise use the Codex browser
+or Playwright. Do not invent a second UI test framework for this smoke path.
 
 ## Runtime And MLflow Evidence
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ Three choices drive the shape of this codebase. They are intentional, not accide
 
 3. **Two agent layers, both `dspy.*`, both real.**
    - **Chat surface:** `dspy.ReAct` at `src/fleet_rlm/runtime/agent/agent.py` handles turn-taking, tool dispatch, and the user-visible conversation loop.
-   - **Recursive engine:** `dspy.RLM` at `src/fleet_rlm/runtime/models/builders.py` (with delegation at `src/fleet_rlm/runtime/tools/rlm_delegate.py`) implements Algorithm 1 from [arXiv 2512.24601v2](https://arxiv.org/abs/2512.24601). Inputs are stored as REPL variables inside a child Daytona sandbox; sub-queries are dispatched recursively, bounded by `max_iterations` and `max_llm_calls`; sandboxes are isolated per delegation.
+   - **Recursive engine:** `dspy.RLM` is assembled through `src/fleet_rlm/runtime/modules/factory.py` and the module registry in `src/fleet_rlm/runtime/modules/registry.py` (with delegation at `src/fleet_rlm/runtime/tools/rlm_delegate.py`). Inputs cross into Daytona as sandbox-serializable payloads; sub-queries are dispatched recursively, bounded by `max_iterations` and `max_llm_calls`; sandboxes are isolated per delegation.
 
    The chat agent is the entry point; the recursive engine runs when a task exceeds what a single ReAct context can handle. Both use DSPy's module abstractions and share a single LLM-call budget across a recursive tree (see the `Recursive RLM isolation` section below).
 
@@ -20,16 +20,16 @@ Three choices drive the shape of this codebase. They are intentional, not accide
 
 1. **Thin FastAPI/WebSocket transport** in `src/fleet_rlm/api/`
 2. **Runtime core** in `src/fleet_rlm/runtime/` and `src/fleet_rlm/integrations/daytona/`
-3. **Offline evaluation and optimization** in `src/fleet_rlm/runtime/quality/`
+3. **Offline evaluation and optimization** in `src/fleet_rlm/quality/`
 
 ```mermaid
 graph TB
     CLIENTS["CLI / Web UI"] --> API["FastAPI transport\napi/main.py\napi/routers/*\napi/runtime_services/*"]
-    API --> RUNTIME["runtime/\nchat agent + execution helpers + models"]
+    API --> RUNTIME["runtime/\nchat agent + execution helpers + modules"]
     RUNTIME --> DAYTONA["integrations/daytona/\ninterpreter + runtime + filesystem"]
     API --> EVENTS["api/events/\nexecution event shaping"]
     API --> PERSISTENCE["integrations/local_store.py\nintegrations/database/"]
-    RUNTIME --> QUALITY["runtime/quality/\noffline GEPA + DSPy optimization"]
+    RUNTIME --> QUALITY["quality/\noffline GEPA + DSPy optimization"]
 ```
 
 ## What Each Layer Owns
@@ -58,19 +58,21 @@ Responsibilities:
 
 Primary files:
 
-- `src/fleet_rlm/api/routers/ws/stream.py`
+- `src/fleet_rlm/api/routers/ws/connection_loop.py`
+- `src/fleet_rlm/api/routers/ws/turn_runner.py`
+- `src/fleet_rlm/api/routers/ws/stream_loop.py`
 - `src/fleet_rlm/runtime/factory.py`
 - `src/fleet_rlm/runtime/agent/agent.py`
 - `src/fleet_rlm/runtime/agent/runtime.py`
 - `src/fleet_rlm/runtime/execution/*`
-- `src/fleet_rlm/runtime/models/*`
+- `src/fleet_rlm/runtime/modules/*`
 
 Responsibilities:
 
 - Shared chat/runtime execution
 - Recursive delegation and tool execution
 - Execution-event assembly and workbench hydration inputs
-- Runtime model assembly and registry management
+- Runtime module assembly, registry management, escalation, and RLM routing
 
 ### 3. Daytona substrate
 
@@ -128,7 +130,7 @@ Importing a session replaces session-local memory and document state instead of 
 
 Primary files:
 
-- `src/fleet_rlm/runtime/quality/*`
+- `src/fleet_rlm/quality/*`
 
 Responsibilities:
 
@@ -141,32 +143,35 @@ Responsibilities:
 - `/health`
 - `/ready`
 - `GET /api/v1/auth/me`
-- `GET /api/v1/sessions/state`
-- `GET /api/v1/sessions`
-- `GET /api/v1/sessions/{id}`
-- `GET /api/v1/sessions/{id}/turns`
-- `DELETE /api/v1/sessions/{id}`
-- `POST /api/v1/sessions/{id}/export`
-- `GET /api/v1/runtime/settings`
-- `PATCH /api/v1/runtime/settings`
+- `POST /api/v1/auth/ws-ticket`
+- `GET /api/v1/info`
+- `GET/PATCH /api/v1/runtime/settings`
 - `POST /api/v1/runtime/tests/daytona`
 - `POST /api/v1/runtime/tests/lm`
 - `GET /api/v1/runtime/status`
-- `GET /api/v1/runtime/volume/tree`
-- `GET /api/v1/runtime/volume/file`
+- `GET /api/v1/runtime/volume/*`
+- `GET/POST/PATCH/DELETE /api/v1/runtime/llm-profiles*`
+- `GET/PATCH /api/v1/runtime/llm-roles`
+- `GET/PATCH/DELETE /api/v1/sessions/{id}`
+- `GET /api/v1/sessions`, `/state`, `/{id}/turns`, `/{id}/stats`, `/{id}/traces`, and `/{id}/trace-debug`
+- `POST /api/v1/sessions/{id}/restore`, `/export`, and `/trace-export`
+- `GET /api/v1/sandboxes`
+- `GET/DELETE /api/v1/sandboxes/{id}`
+- `POST /api/v1/sandboxes/{id}/archive`
+- `GET /api/v1/runs/{run_id}/steps`
 - `GET /api/v1/optimization/status`
-- `POST /api/v1/optimization/run`
 - `GET /api/v1/optimization/modules`
-- `POST /api/v1/optimization/runs`
-- `GET /api/v1/optimization/runs`
-- `GET /api/v1/optimization/runs/{run_id}`
-- `GET /api/v1/optimization/runs/{run_id}/results`
+- `POST /api/v1/optimization/run`
+- `GET/POST /api/v1/optimization/runs`
 - `GET /api/v1/optimization/runs/compare`
-- `POST /api/v1/optimization/datasets`
-- `GET /api/v1/optimization/datasets`
+- `GET /api/v1/optimization/runs/{run_id}`, `/details`, and `/results`
+- `POST /api/v1/optimization/runs/{run_id}/promotion-drafts`
+- `GET/POST /api/v1/optimization/datasets`
 - `GET /api/v1/optimization/datasets/{dataset_id}`
-- `/api/v1/ws/execution`
-- `/api/v1/ws/execution/events`
+- `POST /api/v1/optimization/transcript-datasets`
+- `POST /api/v1/traces/feedback`
+- `WS /api/v1/ws/execution`
+- `WS /api/v1/ws/execution/events`
 
 ## Reading Order
 
@@ -174,7 +179,7 @@ When you need the current backend story, start here:
 
 1. `src/fleet_rlm/api/main.py`
 2. `src/fleet_rlm/api/routers/ws/endpoint.py`
-3. `src/fleet_rlm/api/routers/ws/stream.py`
+3. `src/fleet_rlm/api/routers/ws/connection_loop.py`
 4. `src/fleet_rlm/runtime/factory.py`
 5. `src/fleet_rlm/runtime/agent/agent.py`
 6. `src/fleet_rlm/integrations/daytona/interpreter.py`

--- a/docs/explanation/frontend-product-surface.md
+++ b/docs/explanation/frontend-product-surface.md
@@ -15,13 +15,15 @@ The supported product flow is a chat-first execution workbench:
 5. The workspace sidepanel hydrates trajectories, graph, and volume state from
    execution summary, final artifacts, live transcript data, and Daytona volume
    APIs.
-6. The user can also open full-page volumes or settings from the same shell.
+6. The user can also open optimization, full-page volumes, or settings from the
+   same shell.
 
 ## Surface Map
 
 | Surface | Route | Owns | Notes |
 | --- | --- | --- | --- |
 | Workbench | `/app/workspace` | `features/workspace/*` | Primary chat execution surface with workspace-local sidepanel |
+| Optimization | `/app/optimization` | `features/optimization/*` | GEPA optimization setup, run history, and run inspection |
 | Volumes | `/app/volumes` | `features/volumes/*` | Full-page mounted Daytona volume browser |
 | Settings | `/app/settings` | `features/settings/*` | Dialog-first settings surface |
 
@@ -33,6 +35,7 @@ src/frontend/src/
 ├── features/
 │   ├── layout/            # Shell chrome, route sync, dialogs, sidebar, header
 │   ├── workspace/         # Workbench chat, sidepanel, transcript, session controls
+│   ├── optimization/      # GEPA optimization form, run history, and details
 │   ├── volumes/           # Full-page volume browser and file preview
 │   └── settings/          # Settings dialog and runtime forms
 ├── lib/
@@ -40,7 +43,7 @@ src/frontend/src/
 │   └── rlm-api/           # REST and websocket clients
 ├── stores/                # Shell/navigation state
 ├── components/ui/         # Shared UI primitives
-├── components/ai-elements/ # AI Elements rendering primitives
+├── components/agent-elements/ # Agent Elements rendering primitives
 └── components/product/    # Reusable product composition
 ```
 
@@ -89,6 +92,5 @@ The current frontend does not treat these as product surfaces:
 - `memory`
 - `analytics`
 - `history`
-- `optimization`
 
 New work should target `features/*`, `lib/*`, and the thin route wrappers.

--- a/docs/explanation/wiring-analysis.md
+++ b/docs/explanation/wiring-analysis.md
@@ -43,12 +43,16 @@ routes (`/health`, `/api/v1/*`) take precedence over the SPA catch-all.
 app
 ├── health.router          →  /health, /ready
 └── APIRouter(prefix="/api/v1")
-    ├── auth.router        →  /api/v1/auth/me          (GET)
-    ├── ws.router          →  /api/v1/ws/execution          (WebSocket)
-    │                         /api/v1/ws/execution      (WebSocket)
-    ├── sessions.router    →  /api/v1/sessions/state    (GET)
-    ├── runtime.router     →  /api/v1/runtime/*         (GET/POST)
-    └── traces.router      →  /api/v1/traces/feedback   (POST)
+    ├── auth.router         →  /api/v1/auth/me, /api/v1/auth/ws-ticket
+    ├── info.router         →  /api/v1/info
+    ├── ws.router           →  /api/v1/ws/execution, /api/v1/ws/execution/events
+    ├── sessions.router     →  /api/v1/sessions/*
+    ├── runtime.router      →  /api/v1/runtime/*
+    ├── llm_profiles.router →  /api/v1/runtime/llm-profiles, /api/v1/runtime/llm-roles
+    ├── sandboxes.router    →  /api/v1/sandboxes/*
+    ├── runs.router         →  /api/v1/runs/{run_id}/steps
+    ├── optimization.router →  /api/v1/optimization/*
+    └── traces.router       →  /api/v1/traces/feedback
 ```
 
 ### Frontend OpenAPI client
@@ -62,7 +66,11 @@ canonical `openapi.yaml` (see §6). The hand-written adapter layer lives in
 |-----------------|---------------------|
 | `auth.ts` | `GET /api/v1/auth/me` |
 | `runtime.ts` | `GET/POST /api/v1/runtime/*` |
-| `wsClient.ts` | `WS /api/v1/ws/execution`, `WS /api/v1/ws/execution` |
+| `llm-profiles.ts` | `GET/POST/PATCH/DELETE /api/v1/runtime/llm-profiles`, `GET/PATCH /api/v1/runtime/llm-roles` |
+| `optimization.ts` | `GET/POST /api/v1/optimization/*` |
+| `sessions.ts` | `GET/PATCH/POST/DELETE /api/v1/sessions/*` |
+| `volumes.ts` | `GET /api/v1/runtime/volume/*` |
+| `ws-client.ts` | `WS /api/v1/ws/execution`, `WS /api/v1/ws/execution/events` |
 | `config.ts` | URL derivation for all of the above |
 
 REST calls use the standard `fetch` API with the base URL from
@@ -77,7 +85,7 @@ REST calls use the standard `fetch` API with the base URL from
 | Path | Backend handler | Purpose |
 |------|-----------------|---------|
 | `/api/v1/ws/execution` | `chat_streaming()` in `routers/ws/endpoint.py` | Bidirectional chat streaming |
-| `/api/v1/ws/execution` | `execution_stream()` in `routers/ws/endpoint.py` | Read-only artifact/execution event stream |
+| `/api/v1/ws/execution/events` | `execution_stream()` in `routers/ws/endpoint.py` | Read-only execution-event subscription stream |
 
 ### Backend flow (`/ws/execution`, chat mode)
 
@@ -88,7 +96,7 @@ REST calls use the standard `fetch` API with the base URL from
 4. Build the canonical Daytona-backed agent context
    (`runtime_services/chat_runtime.py`).
 
-### Backend flow (`/ws/execution`)
+### Backend flow (`/ws/execution/events`)
 
 1. Authenticate, accept, and subscribe to the `ExecutionEventEmitter`.
 2. Hold the socket open; the emitter pushes artifact frames as they arrive
@@ -96,15 +104,15 @@ REST calls use the standard `fetch` API with the base URL from
 
 ### Frontend consumers
 
-- **`stores/chatStore.ts`** — Zustand store that owns `streamMessage()`. It
-  calls `streamChatOverWs()` from `wsClient.ts`, which opens a reconnecting
+- **`lib/workspace/stores/chat-store.ts`** — Zustand store that owns
+  `streamMessage()`. It calls `streamChatOverWs()` from `ws-client.ts`, which opens a reconnecting
   WebSocket to `rlmApiConfig.wsUrl` (`/api/v1/ws/execution`).
-- **`features/rlm-workspace/useBackendChatRuntime.ts`** — React hook that
+- **`features/workspace/use-workspace-runtime.ts`** — React hook that
   orchestrates submit → `streamMessage` → frame callbacks → UI state
   transitions (phase, typing indicator, artifact steps).
-- **`wsClient.ts: subscribeToExecutionStream()`** — opens a separate
+- **`ws-client.ts: subscribeToExecutionStream()`** — opens a separate
   reconnecting WebSocket to `rlmApiConfig.wsExecutionUrl`
-  (`/api/v1/ws/execution`) with the `session_id` as a query parameter.
+  (`/api/v1/ws/execution/events`) with the `session_id` as a query parameter.
 
 ### Message protocol
 
@@ -158,37 +166,33 @@ provider via `build_auth_provider()` in `api/auth/factory.py`:
 |------|----------|-----------|
 | `dev` | `DevAuthProvider` | Debug headers (`X-Fleet-User`, etc.) or HS256 JWT bearer tokens |
 | `entra` | `EntraAuthProvider` | Microsoft Entra ID (Azure AD) RS256 JWT validation via JWKS |
+| `neon` | `NeonAuthProvider` | Neon Auth EdDSA JWT validation and repository-backed tenant admission |
 
-Both providers implement `AuthProvider` and are used for HTTP requests
-(via `HTTPIdentityDep`) and WebSocket upgrades (via
-`_authenticate_websocket`).
+All providers implement `AuthProvider` and are used for HTTP requests (via
+`HTTPIdentityDep`) and WebSocket upgrades (via `_authenticate_websocket`).
 
 ### Frontend auth flow
 
-1. **Entra configuration** — `src/frontend/src/lib/auth/entra.ts` reads:
-   - `VITE_ENTRA_CLIENT_ID` — SPA client registration in Entra.
-   - `VITE_ENTRA_AUTHORITY` — defaults to
-     `https://login.microsoftonline.com/organizations`.
-   - `VITE_ENTRA_SCOPES` — e.g. `api://backend-client-id/access_as_user`.
-   - `VITE_ENTRA_REDIRECT_PATH` — defaults to `/login`.
-2. **MSAL bootstrap** — `getMsalClient()` lazily creates a
-   `PublicClientApplication` (from `@azure/msal-browser`), calls
-   `initialize()` and `handleRedirectPromise()`.
-3. **Token acquisition** — `initializeEntraSession()` attempts silent token
-   acquisition for the active account. `loginWithEntra()` triggers a popup
-   flow.
-4. **Token storage** — Acquired access tokens are stored via
-   `setAccessToken()` (in `lib/auth/tokenStore`).
-5. **API calls** — The stored token is attached as a `Bearer` header on
-   `GET /api/v1/auth/me`, which the backend validates through
-   `EntraAuthProvider` and returns `AuthMeResponse` with tenant/user claims.
+1. **Neon Auth UI routes** — `src/frontend/src/routes/login.tsx` and
+   `signup.tsx` render `SignInForm` and `SignUpForm` from
+   `@neondatabase/auth-ui`; `auth.$pathname.tsx` and
+   `account.$pathname.tsx` handle Neon-managed auth/account paths.
+2. **Session bootstrap** — `src/frontend/src/lib/auth/neon.ts` reads
+   `VITE_NEON_AUTH_URL`, refreshes the Neon session, and writes the current
+   bearer token through `lib/auth/token-store.ts`.
+3. **Provider state** — `lib/auth/auth-provider.tsx` calls
+   `GET /api/v1/auth/me`, exposes the normalized `AuthState`, and clears the
+   TanStack Query cache on logout or token expiration to avoid cross-tenant
+   state reuse.
+4. **API calls** — `lib/rlm-api/typed-client.ts` and the websocket clients
+   read `getAccessToken()` and attach the bearer token to HTTP requests or
+   exchange it for websocket tickets when required.
 
 ### Dev mode
 
-When Entra env vars are absent (`isEntraAuthConfigured()` returns `false`),
-the frontend skips MSAL entirely. The backend's `DevAuthProvider` accepts
-debug headers or a simple HS256 token, enabling local development without
-Azure infrastructure.
+When Neon Auth is not configured locally, the frontend can still run against
+the backend's `DevAuthProvider`, which accepts debug headers or a simple HS256
+token for development without external identity infrastructure.
 
 ---
 
@@ -262,23 +266,21 @@ priority:
 This produces two resolved URLs exported as `rlmApiConfig.wsUrl` and
 `rlmApiConfig.wsExecutionUrl`.
 
-### Entra auth variables
+### Neon auth variables
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `VITE_ENTRA_CLIENT_ID` | *(none)* | Entra SPA app registration client ID |
-| `VITE_ENTRA_AUTHORITY` | `https://login.microsoftonline.com/organizations` | Entra authority URL |
-| `VITE_ENTRA_SCOPES` | *(none)* | Comma-separated OAuth scopes |
-| `VITE_ENTRA_REDIRECT_PATH` | `/login` | Post-auth redirect path |
+| `VITE_NEON_AUTH_URL` | *(none)* | Neon Auth project URL used by the frontend auth UI |
+| `VITE_NEON_AUTH_SOCIAL_PROVIDERS` | `google` | Comma-separated social providers passed to Neon Auth UI |
 
-When `VITE_ENTRA_CLIENT_ID` and `VITE_ENTRA_SCOPES` are both set,
-`isEntraAuthConfigured()` returns `true` and the MSAL flow activates.
+When `VITE_NEON_AUTH_URL` is set, the frontend Neon Auth helpers can refresh
+browser sessions and provide access tokens for the API client.
 
 ### Backend-side counterparts
 
-The backend reads its own env vars (`AUTH_MODE`, `ENTRA_JWKS_URL`,
-`ENTRA_ISSUER_TEMPLATE`, `ENTRA_AUDIENCE`, etc.) via `ServerRuntimeConfig`.
-The frontend `VITE_ENTRA_*` vars configure the SPA-side MSAL client, while
-the backend `ENTRA_*` vars configure server-side JWT validation. Both sides
-must reference the same Entra app registration for tokens to validate
-correctly.
+The backend reads its own env vars (`AUTH_MODE`, `NEON_AUTH_URL`,
+`NEON_TENANT_CLAIM`, `ENTRA_JWKS_URL`, `ENTRA_ISSUER_TEMPLATE`,
+`ENTRA_AUDIENCE`, etc.) via `ServerRuntimeConfig`. Use `AUTH_MODE=neon` for
+the current Neon Auth product path. Use `AUTH_MODE=entra` only when an
+external client supplies Entra access tokens that match the backend
+`ENTRA_*` validation settings.

--- a/docs/how-to-guides/codex-environment.md
+++ b/docs/how-to-guides/codex-environment.md
@@ -94,3 +94,9 @@ codex features list | grep -E '^(hooks|multi_agent)[[:space:]]'
 ```
 
 Run `zsh .codex/workspace-bootstrap.zsh` when dependency refresh is acceptable.
+
+## Shell and Browser Tooling
+
+Use `zsh` for repo shell examples and project-local scripts. When browser automation is needed,
+prefer the built-in Cursor Browser (`cursor-ide-browser`) if it is available or explicitly
+requested; otherwise use the Codex browser or Playwright lane named by the task.

--- a/docs/how-to-guides/deploying-server.md
+++ b/docs/how-to-guides/deploying-server.md
@@ -41,7 +41,7 @@ This starts both the API server and serves frontend static assets.
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `APP_ENV` | Runtime environment (`local`, `staging`, `production`) | `production` |
-| `AUTH_MODE` | Authentication mode (`dev` or `entra`) | `entra` |
+| `AUTH_MODE` | Authentication mode (`neon`, `entra`, or `dev`) | `neon` |
 | `AUTH_REQUIRED` | Enforce authentication on protected routes | `true` |
 | `DATABASE_URL` | Neon PostgreSQL connection string | `postgresql://...` |
 | `DSPY_LM_MODEL` | LLM model identifier for the planner | `openai/gpt-4o` |
@@ -72,14 +72,13 @@ DSPY_LLM_API_KEY=sk-your-api-key
 DATABASE_URL=postgresql://user:password@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
 DATABASE_REQUIRED=true
 
-# Authentication (Entra ID)
-AUTH_MODE=entra
+# Authentication (Neon Auth)
+AUTH_MODE=neon
 AUTH_REQUIRED=true
 
-# Entra Configuration
-ENTRA_JWKS_URL=https://login.microsoftonline.com/common/discovery/v2.0/keys
-ENTRA_AUDIENCE=api://your-api-app-client-id
-ENTRA_ISSUER_TEMPLATE=https://login.microsoftonline.com/{tenantid}/v2.0
+# Neon Auth Configuration
+NEON_AUTH_URL=https://<your-neon-auth-project>.neon.tech
+NEON_TENANT_CLAIM=tenant_id
 
 # CORS (explicit origins only)
 CORS_ALLOWED_ORIGINS=https://app.yourdomain.com,https://admin.yourdomain.com
@@ -90,7 +89,10 @@ DSPY_DELEGATE_LM_MODEL=openai/gpt-4o-mini
 
 ## AUTH_MODE=entra Configuration
 
-Microsoft Entra ID (formerly Azure AD) provides production-grade multitenant authentication.
+Microsoft Entra ID (formerly Azure AD) remains a supported backend auth mode
+for deployments that already issue Entra access tokens. The current frontend
+product path uses Neon Auth UI; do not assume a handwritten Entra SPA
+implementation is present in `src/frontend`.
 
 ### Prerequisites
 
@@ -99,7 +101,7 @@ Microsoft Entra ID (formerly Azure AD) provides production-grade multitenant aut
    - Note the Application (client) ID for `ENTRA_AUDIENCE`
    - Expose an API scope (e.g., `api://<client-id>/access_as_user`)
 
-2. **Frontend App Registration** (SPA):
+2. **Client App Registration**:
    - Create a separate app registration for the frontend
    - Add the API scope as a delegated permission
    - Configure redirect URIs
@@ -122,7 +124,7 @@ ENTRA_ISSUER_TEMPLATE=https://login.microsoftonline.com/{tenantid}/v2.0
 
 ### Token Validation Flow
 
-1. Client obtains token from Entra (via frontend MSAL)
+1. Client obtains a valid Entra access token from the configured identity client
 2. Token includes `tid` (tenant ID) and `oid` (user object ID)
 3. Server validates:
    - Signature against JWKS
@@ -243,7 +245,7 @@ Response:
 ```json
 {
   "ok": true,
-  "version": "0.5.40"
+  "version": "0.6.0"
 }
 ```
 
@@ -351,6 +353,14 @@ If `AUTH_MODE=entra`, also set:
 - `ENTRA_AUDIENCE`
 - `ENTRA_ISSUER_TEMPLATE` (must contain `{tenantid}`)
 
+When changing a locked FastAPI Cloud environment variable from the CLI, delete the old value before
+setting the replacement:
+
+```bash
+# from repo root
+uv run fastapi cloud env delete <VAR> -y
+```
+
 ### 4. Pre-flight locally
 
 Run the included preflight target to catch problems before the cloud build:
@@ -368,12 +378,13 @@ fastapi deploy
 ```
 
 FastAPI Cloud reads `[tool.fastapi].entrypoint`, installs from `pyproject.toml` + `uv.lock`, and serves the app at a generated URL.
+Use `--no-wait` for operational deploys where a separate watcher will follow status.
 
 ### 6. Verify the deployment
 
 ```bash
 curl https://<assigned-host>/health
-# => {"ok": true, "version": "0.5.40"}
+# => {"ok": true, "version": "0.6.0"}
 
 curl https://<assigned-host>/ready
 # => {"ready": true, "planner": "ready", "database": "ready", ...}
@@ -388,7 +399,7 @@ Scaling note: FastAPI Cloud scales to zero. The first request after idling will 
 
 Because `FLEET_RLM_SERVE_UI=false`, the cloud box serves JSON at `/` and does not ship the React SPA. Deploy the frontend separately (Vercel / Netlify / Cloudflare Pages) and:
 
-1. Set `VITE_API_BASE_URL=https://<assigned-host>` in the frontend's build environment.
+1. Set `VITE_FLEET_API_URL=https://<assigned-host>` in the frontend's build environment.
 2. Add the frontend's public origin(s) to `CORS_ALLOWED_ORIGINS` on the API (this triggers a redeploy).
 
 ### Troubleshooting
@@ -436,13 +447,13 @@ services:
       - "8000:8000"
     environment:
       - APP_ENV=production
-      - AUTH_MODE=entra
+      - AUTH_MODE=neon
       - AUTH_REQUIRED=true
       - DATABASE_URL=${DATABASE_URL}
+      - NEON_AUTH_URL=${NEON_AUTH_URL}
+      - NEON_TENANT_CLAIM=${NEON_TENANT_CLAIM}
       - DSPY_LM_MODEL=${DSPY_LM_MODEL}
       - DSPY_LLM_API_KEY=${DSPY_LLM_API_KEY}
-      - ENTRA_JWKS_URL=${ENTRA_JWKS_URL}
-      - ENTRA_AUDIENCE=${ENTRA_AUDIENCE}
     env_file:
       - .env
     healthcheck:
@@ -465,14 +476,14 @@ az containerapp create \
   --ingress external \
   --env-vars \
     APP_ENV=production \
-    AUTH_MODE=entra \
+    AUTH_MODE=neon \
     AUTH_REQUIRED=true \
     DATABASE_URL=secretref:database-url \
     DATABASE_ADMIN_URL=secretref:database-admin-url \
+    NEON_AUTH_URL=secretref:neon-auth-url \
+    NEON_TENANT_CLAIM=tenant_id \
     DSPY_LM_MODEL=secretref:dspy-model \
-    DSPY_LLM_API_KEY=secretref:dspy-api-key \
-    ENTRA_JWKS_URL=secretref:entra-jwks \
-    ENTRA_AUDIENCE=secretref:entra-audience
+    DSPY_LLM_API_KEY=secretref:dspy-api-key
 ```
 
 ### Kubernetes Deployment
@@ -501,7 +512,7 @@ spec:
             - name: APP_ENV
               value: "production"
             - name: AUTH_MODE
-              value: "entra"
+              value: "neon"
             - name: AUTH_REQUIRED
               value: "true"
             - name: DATABASE_URL
@@ -509,6 +520,13 @@ spec:
                 secretKeyRef:
                   name: fleet-secrets
                   key: database-url
+            - name: NEON_AUTH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: fleet-secrets
+                  key: neon-auth-url
+            - name: NEON_TENANT_CLAIM
+              value: "tenant_id"
             - name: DSPY_LM_MODEL
               valueFrom:
                 secretKeyRef:
@@ -519,16 +537,6 @@ spec:
                 secretKeyRef:
                   name: fleet-secrets
                   key: dspy-api-key
-            - name: ENTRA_JWKS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: fleet-secrets
-                  key: entra-jwks
-            - name: ENTRA_AUDIENCE
-              valueFrom:
-                secretKeyRef:
-                  name: fleet-secrets
-                  key: entra-audience
           livenessProbe:
             httpGet:
               path: /health
@@ -595,15 +603,15 @@ The server will **fail to start** if:
 3. `CORS_ALLOWED_ORIGINS` contains `*` in staging/production
 4. `DEV_JWT_SECRET=change-me` with `AUTH_MODE=dev` in staging/production
 
-### Entra Mode Validation
+### Auth Mode Validation
 
 The server will **fail to start** if:
 
-1. `AUTH_REQUIRED=false` with `AUTH_MODE=entra`
-2. `DATABASE_REQUIRED=false` with `AUTH_MODE=entra`
-3. `ENTRA_JWKS_URL` not configured
-4. `ENTRA_AUDIENCE` not configured
-5. `ENTRA_ISSUER_TEMPLATE` missing `{tenantid}` placeholder
+1. `AUTH_REQUIRED=false` with `AUTH_MODE=neon` or `AUTH_MODE=entra`
+2. `DATABASE_REQUIRED=false` with `AUTH_MODE=neon` or `AUTH_MODE=entra`
+3. `NEON_AUTH_URL` not configured with `AUTH_MODE=neon`
+4. `ENTRA_JWKS_URL` or `ENTRA_AUDIENCE` not configured with `AUTH_MODE=entra`
+5. `ENTRA_ISSUER_TEMPLATE` missing `{tenantid}` placeholder with `AUTH_MODE=entra`
 
 ### Debug Mode
 
@@ -624,7 +632,8 @@ CORS_ALLOWED_ORIGINS=*
 ValueError: AUTH_REQUIRED must be true when APP_ENV is staging/production
 ```
 
-Set `AUTH_REQUIRED=true` or verify `AUTH_MODE=entra` (auto-enables auth).
+Set `AUTH_REQUIRED=true` or verify `AUTH_MODE=neon`/`AUTH_MODE=entra`
+(production auth modes auto-enable auth).
 
 ### Server Won't Start: Database Configuration
 

--- a/docs/how-to-guides/frontend-development.md
+++ b/docs/how-to-guides/frontend-development.md
@@ -31,15 +31,16 @@ Frontend source lives under `src/frontend/src/`.
 | `lib/rlm-api/` | REST and websocket clients plus generated API types |
 | `stores/` | Shell/navigation state |
 | `components/ui/` | Shared shadcn/Base UI primitives |
-| `components/ai-elements/` | AI Elements rendering primitives |
+| `components/agent-elements/` | Agent Elements rendering primitives |
 | `components/product/` | Reusable product composition built from the shared layers |
 | `app/` | App bootstrap and providers |
 
 ## Product Surface Rules
 
-- Supported surfaces are `/app/workspace`, `/app/volumes`, and `/app/settings`.
+- Supported surfaces are `/app/workspace`, `/app/optimization`,
+  `/app/volumes`, and `/app/settings`.
 - Retired `taxonomy`, `skills`, `memory`, `analytics`, `history`, and
-  `optimization` paths should fall through to `/404`.
+  other non-routed product paths should fall through to `/404`.
 - Route wrappers must stay thin and should not own page logic.
 - New work should target `features/*`, `lib/*`, or `components/product/*`, not
   a resurrected screen layer.

--- a/docs/how-to-guides/releasing.md
+++ b/docs/how-to-guides/releasing.md
@@ -11,7 +11,7 @@ Use the GitHub Actions workflow for a fully automated release:
 1. Go to **Actions** → **Release to PyPI** in the GitHub repository
 2. Click **Run workflow**
 3. Finalize the `CHANGELOG.md` section for the version you are shipping
-4. Enter the version number (for this release, `0.5.40` or `v0.5.40`)
+4. Enter the version number (for example, `<version>` or `v<version>`)
 5. Approve the TestPyPI environment deployment
 6. Once smoke tests pass, approve the PyPI environment deployment
 
@@ -115,8 +115,8 @@ make release-artifacts
 
 Expected outputs:
 
-- `dist/fleet_rlm-0.5.40.tar.gz`
-- `dist/fleet_rlm-0.5.40-py3-none-any.whl`
+- `dist/fleet_rlm-<version>.tar.gz`
+- `dist/fleet_rlm-<version>-py3-none-any.whl`
 
 ## 3) Upload to TestPyPI
 
@@ -143,7 +143,7 @@ uv venv .venv-release-smoke
 uv pip install --python .venv-release-smoke/bin/python \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple \
-  fleet-rlm==0.5.40
+  fleet-rlm==<version>
 source .venv-release-smoke/bin/activate
 python -m uvicorn fleet_rlm.api.main:app --host 127.0.0.1 --port 8765 >/tmp/fleet-release-smoke.log 2>&1 &
 SERVER_PID=$!
@@ -187,8 +187,8 @@ Finalize `CHANGELOG.md` and any docs release-notes page before tagging or runnin
 
 ```bash
 # from repo root
-git tag v0.5.40
-git push origin v0.5.40
+git tag v<version>
+git push origin v<version>
 ```
 
 ## Important rules

--- a/docs/reference/adr/001-rlm-runtime-architecture.md
+++ b/docs/reference/adr/001-rlm-runtime-architecture.md
@@ -57,7 +57,8 @@ class RLMReActChatSignature(dspy.Signature):
 
 ### 3. Streaming Context
 
-Real-time response streaming via `api/routers/ws/stream.py` and
+Real-time response streaming via `api/routers/ws/connection_loop.py`,
+`api/routers/ws/turn_runner.py`, `api/routers/ws/stream_loop.py`, and
 `runtime/execution/streaming_events.py` provides:
 
 - WebSocket-compatible event emission
@@ -103,6 +104,8 @@ The parent shares bounded runtime metadata and LLM budgets with children through
 - `src/fleet_rlm/runtime/agent/signatures.py` — DSPy signature definitions
 - `src/fleet_rlm/runtime/tools/rlm_delegate.py` — Recursive delegation tools
 - `src/fleet_rlm/integrations/daytona/isolation.py` — Child sandbox policy and isolation
-- `src/fleet_rlm/api/routers/ws/stream.py` — WebSocket streaming loop
+- `src/fleet_rlm/api/routers/ws/connection_loop.py` — WebSocket connection loop
+- `src/fleet_rlm/api/routers/ws/turn_runner.py` — Per-turn execution and terminal event handling
+- `src/fleet_rlm/api/routers/ws/stream_loop.py` — Runtime event iteration and websocket delivery
 - `src/fleet_rlm/runtime/execution/streaming_events.py` — Event construction and streaming helpers
 - DSPy documentation: https://dspy.ai/

--- a/docs/reference/adr/003-neon-postgres-rls-persistence.md
+++ b/docs/reference/adr/003-neon-postgres-rls-persistence.md
@@ -177,13 +177,14 @@ class DatabaseManager:
 
 - `DATABASE_URL` must use `postgresql+asyncpg://` scheme for async
 - `DATABASE_URL` is the pooled runtime connection; `DATABASE_ADMIN_URL` should use the direct non-pooler endpoint for Alembic and admin/debug tasks
-- `DATABASE_REQUIRED=true` enforced when `AUTH_MODE=entra`
+- `DATABASE_REQUIRED=true` enforced when `AUTH_MODE=entra` or `AUTH_MODE=neon`
 - Migrations managed via Alembic in `migrations/`
 
 ## References
 
-- `src/fleet_rlm/integrations/database/models.py` — SQLAlchemy model definitions
-- `src/fleet_rlm/integrations/database/repository.py` — Data access repository
+- `src/fleet_rlm/integrations/database/models_*.py` — SQLModel/SQLAlchemy model definitions
+- `src/fleet_rlm/integrations/database/fleet_repository.py` — Data access repository boundary
+- `src/fleet_rlm/integrations/database/repository_*.py` — Domain-specific repository helpers
 - `src/fleet_rlm/integrations/database/engine.py` — Connection management
 - `src/fleet_rlm/api/auth/admission.py` — Tenant admission flow
 - `migrations/` — Alembic migration scripts

--- a/docs/reference/auth.md
+++ b/docs/reference/auth.md
@@ -241,7 +241,8 @@ JWTs to Fleet HTTP routes with `Authorization: Bearer ...`.
 
 1. Extract bearer token from the HTTP `Authorization` header.
 2. Fetch public keys from `<NEON_AUTH_URL>/.well-known/jwks.json`.
-3. Verify EdDSA signature and standard claims:
+3. Verify EdDSA signature and standard claims. Python decoding must explicitly allow
+   `algorithms=["EdDSA"]` so Neon Auth tokens are not rejected before claim validation:
    - `iss` equals the origin of `NEON_AUTH_URL`
    - `aud` equals the origin of `NEON_AUTH_URL`
    - `exp` and `iat` are present and valid
@@ -294,6 +295,10 @@ wss://your-api.com/api/v1/ws/execution?ticket=<opaque-one-time-ticket>
 
 Raw Neon JWTs are rejected in WebSocket query parameters so they are not exposed
 through browser URLs, proxies, or access logs.
+
+Browser clients must also clear TanStack Query/session caches on logout or token expiration before
+showing unauthenticated or next-user state. Cached session lists are tenant-scoped product data, not
+anonymous browser state.
 
 ### Neon Data API Boundary
 

--- a/docs/reference/codebase-map.md
+++ b/docs/reference/codebase-map.md
@@ -92,7 +92,8 @@ Key files:
 - `cli/main.py` is the lightweight `fleet` launcher
 - `cli/fleet_cli.py` defines the `fleet-rlm` surface
 - `cli/runners.py` assembles shared runtime helpers
-- `cli/runtime_factory.py` remains a compatibility re-export only
+- Runtime construction is shared through `cli/runners.py` and `runtime/factory.py`; there is no
+  separate CLI runtime-factory module in the current tree
 
 ## Read First by Task
 
@@ -109,6 +110,6 @@ Key files:
 
 ## Historical Note
 
-Older docs may still refer to `api/routers/ws/stream.py` or `runtime/quality/` as ownership paths. The websocket loop is split across `connection_loop.py`, `turn_setup.py`, `turn_runner.py`, and `stream_loop.py`; offline optimization lives under top-level `quality/`.
+Older transition notes may still refer to retired websocket or runtime-quality ownership paths. The websocket loop is split across `connection_loop.py`, `turn_setup.py`, `turn_runner.py`, and `stream_loop.py`; offline optimization lives under top-level `quality/`.
 
 Older docs may still refer to bridge packages that are no longer present in the tree. Treat those references as historical context only; do not use them as current ownership labels.

--- a/docs/reference/database.md
+++ b/docs/reference/database.md
@@ -12,7 +12,7 @@ tenant + workspace scoped, and all new primary keys are generated with `app.uuid
 | Repository boundary | `src/fleet_rlm/integrations/database/fleet_repository.py` |
 | Shared repository context helpers | `src/fleet_rlm/integrations/database/repository_shared.py` |
 | SQLAlchemy models | `src/fleet_rlm/integrations/database/models_*.py` |
-| Typed request DTOs | `src/fleet_rlm/integrations/database/types.py` |
+| Typed request DTOs | Domain-specific dataclasses in `repository_*.py` modules |
 | Alembic migrations | `migrations/versions/` |
 
 ## Schema Baseline
@@ -92,6 +92,21 @@ Repository operations set transaction-local request context before tenant/worksp
 RLS policies are enabled and forced on tenant/workspace scoped tables and evaluate
 the context above. `app.workspace_id` is optional at query time; repository helpers
 auto-resolve a default workspace when callers provide only `tenant_id`.
+
+`FleetRepository` and shared repository helpers own this context setup through
+`set_config(...)`. Do not bypass that boundary from routers, runtime services, or browser-facing
+code when reading or writing tenant/workspace-scoped product data.
+
+## Neon Security Hardening
+
+The Neon hardening migration moves extension ownership and function lookup out of unsafe defaults:
+
+- `pgcrypto` and `uuid-ossp` are relocated to the `app` schema when needed.
+- `app.uuid_v7()` and `app.set_updated_at()` get explicit `search_path` settings.
+- Managed Neon helper `public.show_db_tree()` is hardened when present.
+
+Keep future database functions schema-qualified or explicitly pinned to a safe `search_path`; do
+not rely on role-mutable lookup paths for security-sensitive helpers.
 
 ## Environment
 

--- a/docs/reference/frontend-architecture.md
+++ b/docs/reference/frontend-architecture.md
@@ -29,7 +29,7 @@ flowchart TB
 
 ```text
 src/frontend/src/
-├── routes/              # TanStack Router file tree and not-found/login/logout/signup routes
+├── routes/              # TanStack Router file tree, auth pages, and not-found routes
 ├── features/
 │   ├── layout/          # Shell chrome, route sync, sidebar, header, dialogs
 │   ├── workspace/       # Chat-first workbench plus workspace-local sidepanel
@@ -42,7 +42,6 @@ src/frontend/src/
 ├── stores/              # Shell/navigation state shared across the app
 ├── components/ui/       # shadcn/Base UI primitives and thin local extensions
 ├── components/agent-elements/ # Canonical chat and tool transcript UI
-├── components/ai-elements/  # Legacy composer-only helpers
 ├── components/product/  # App-owned reusable composition built from registry layers
 └── app/                 # App bootstrap/providers
 ```
@@ -56,9 +55,10 @@ The live route tree is intentionally small and explicit:
 - `/` redirects to `/app/workspace`
 - `/app` mounts the shell layout
 - `/app/workspace` is the main workbench
+- `/app/optimization` is the GEPA prompt optimization surface
 - `/app/volumes` is the mounted storage browser
 - `/app/settings` is the settings dialog/page fallback
-- `/login`, `/logout`, `/signup`, and `/404` remain standalone routes
+- `/login`, `/signup`, `/auth/$pathname`, `/account/$pathname`, and `/404` remain standalone routes
 - `src/routes/$.tsx` is the catchall for unsupported paths
 
 The shell route files are thin wrappers only:

--- a/docs/reference/frontend-backend-integration.md
+++ b/docs/reference/frontend-backend-integration.md
@@ -13,10 +13,11 @@ contract.
 The live shell supports:
 
 - `/app/workspace`
+- `/app/optimization`
 - `/app/volumes`
 - `/app/settings`
 
-Legacy `taxonomy`, `skills`, `memory`, `analytics`, `history`, and `optimization` routes are not supported
+Legacy `taxonomy`, `skills`, `memory`, `analytics`, and `history` routes are not supported
 entrypoints.
 
 ## REST Surfaces Used By The Frontend
@@ -33,6 +34,11 @@ The frontend consumes the following backend surfaces:
 - `GET /api/v1/runtime/status`
 - `GET /api/v1/runtime/volume/tree`
 - `GET /api/v1/runtime/volume/file`
+- `GET /api/v1/optimization/status`
+- `GET /api/v1/optimization/modules`
+- `GET /api/v1/optimization/runs`
+- `GET /api/v1/optimization/runs/{run_id}`
+- `POST /api/v1/optimization/run`
 - `GET /api/v1/sessions/state`
 - `GET /api/v1/sessions`
 - `GET /api/v1/sessions/{id}`
@@ -44,7 +50,8 @@ The history surface uses the sessions endpoints. The settings surface uses the
 runtime settings and runtime status endpoints. The workspace surface uses
 `/api/v1/auth/me` and runtime status to gate the composer and warnings. The
 workspace sidepanel `Volume` tab and the `/app/volumes` route both use the
-Daytona-backed runtime volume APIs.
+Daytona-backed runtime volume APIs. The optimization surface uses the
+GEPA-backed optimization endpoints for status, modules, datasets, runs, and run details.
 
 ## Websocket Split
 

--- a/docs/reference/frontend-feature-spec.md
+++ b/docs/reference/frontend-feature-spec.md
@@ -24,6 +24,7 @@ retired screen shell.
 | Route | Surface | Owning feature module | Purpose |
 | --- | --- | --- | --- |
 | `/app/workspace` | Workbench | `features/workspace/screen/*` | Primary chat execution surface with workspace-local sidepanel |
+| `/app/optimization` | Optimization | `features/optimization/*` | GEPA optimization form, run history, and run inspection |
 | `/app/volumes` | Volumes | `features/volumes/*` | Full-page mounted Daytona volume browser |
 | `/app/settings` | Settings | `features/settings/settings-screen.tsx` | Runtime and app settings |
 
@@ -50,7 +51,7 @@ a chat box.
 | --- | --- | --- |
 | Header | Page identity, sidebar toggle, workspace sidepanel toggle | `features/layout/header.tsx` |
 | Transcript | Live user/assistant/trace rendering | `features/workspace/conversation/*` |
-| Composer | Submit, stop, execution mode, attachments | `features/workspace/composer/*` |
+| Composer | Submit, stop, execution mode, attachments | `features/workspace/conversation/*`, `components/agent-elements/input-bar.tsx` |
 | Sidepanel | Trajectories, graph, and inline volume browsing | `features/workspace/screen/*`, `features/workspace/workbench/*`, `lib/workspace/*` |
 | HITL | Human review / approval | `features/workspace/conversation/*` and `features/workspace/inspection/*` |
 | Session sidebar | Local conversation history and session actions | `features/workspace/session/*` |
@@ -105,6 +106,21 @@ they fall back to live transcript rows and artifact summary data.
 
 `Volume` uses Daytona volume APIs, includes inline preview, and supports a
 resizable tree/preview split.
+
+## Optimization Spec
+
+The Optimization surface configures GEPA optimization runs and inspects their
+results. It is a routed product surface, not a settings-only form.
+
+Rules:
+
+- `features/optimization/screen/optimization-screen.tsx` owns the page shell.
+- `features/optimization/form/*` owns target, dataset, reflection, and advanced
+  run configuration.
+- `features/optimization/run-history/*` and `run-details/*` own run browsing
+  and detailed inspection.
+- `lib/rlm-api/optimization.ts` is the typed client boundary for
+  `/api/v1/optimization/*`.
 
 ## Volumes Spec
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -43,7 +43,7 @@ Basic liveness check.
 ```json
 {
   "ok": true,
-  "version": "0.5.40"
+  "version": "0.6.0"
 }
 ```
 
@@ -1209,7 +1209,7 @@ The following endpoints have been removed from the API:
 |----------|--------|-------|
 | `/api/v1/chat` | Removed | Use `WS /api/v1/ws/execution` instead |
 | `/api/v1/auth/login` | Removed | Authentication via bearer tokens only |
-| `/api/v1/auth/logout` | Removed | Not applicable for token-based auth |
+| Legacy auth logout route | Removed | Not applicable for token-based auth |
 | `/api/v1/tasks*` | Removed | Task management discontinued |
 | `/api/v1/taxonomy*` | Removed | Taxonomy feature discontinued |
 | `/api/v1/skills*` | Removed | Skills feature discontinued |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -37,7 +37,7 @@ Implementation-facing contracts, interfaces, and current-state facts.
 - [ADR-003: Neon/Postgres with RLS](adr/003-neon-postgres-rls-persistence.md)
   Serverless PostgreSQL with Row-Level Security for multi-tenant persistence.
 - [ADR-004: Dual Auth Modes](adr/004-dual-auth-modes.md)
-  Development and Entra authentication modes.
+  Development, Entra, and Neon authentication lineage.
 
 ## Historical Reference Material
 

--- a/docs/reference/module-map.md
+++ b/docs/reference/module-map.md
@@ -15,7 +15,7 @@ graph TB
     API --> UI["ui/"]
 
     RUNTIME --> DAYTONA["integrations/daytona/"]
-    RUNTIME --> QUALITY["runtime/quality/"]
+    RUNTIME --> QUALITY["quality/"]
 ```
 
 ## Runtime Surfaces
@@ -31,27 +31,27 @@ graph TB
 
 ```mermaid
 graph LR
-    REQUEST["Workspace task request"] --> STREAM["api/routers/ws/stream.py"]
-    STREAM --> AGENT["runtime/factory.py"]
-    AGENT --> CHAT["runtime/agent/agent.py"]
+    REQUEST["Workspace task request"] --> WS["api/routers/ws/endpoint.py + connection_loop.py"]
+    WS --> RUNTIME_FACTORY["runtime/factory.py"]
+    RUNTIME_FACTORY --> CHAT["runtime/agent/agent.py"]
     CHAT --> EXEC["runtime/execution/*"]
     EXEC --> DAYTONA_INTERPRETER["integrations/daytona/interpreter.py"]
     EXEC --> DAYTONA_RUNTIME["integrations/daytona/runtime.py"]
-    CHAT --> MODELS["runtime/models/*"]
-    CHAT --> QUALITY["runtime/quality/*"]
+    CHAT --> MODULES["runtime/modules/*"]
+    CHAT --> QUALITY["quality/*"]
 ```
 
 ### Key dependencies
 
 | From | To | Purpose |
 | --- | --- | --- |
-| `api/routers/ws/stream.py` | `runtime/agent/*` | Stream prepared workspace work through the shared runtime agent |
+| `api/routers/ws/endpoint.py`, `connection_loop.py`, `turn_setup.py`, `turn_runner.py`, `stream_loop.py` | `runtime/agent/*` | Authenticate, prepare, run, and stream workspace turns through the shared runtime agent |
 | `runtime/agent/agent.py` | `runtime/tools/*` | Tool list assembly and tool dispatch |
 | `runtime/agent/agent.py` | `runtime/execution/*` | Streaming turn execution and interpreter support |
 | `runtime/agent/runtime.py` | `integrations/daytona/*` | Recursive child execution over the Daytona substrate |
 | `runtime/execution/*` | `integrations/daytona/interpreter.py`, `integrations/daytona/sandbox_executor.py`, `integrations/daytona/runtime.py` | Stateful interpreter/session backend integration |
-| `runtime/models/*` | `runtime/agent/*` | Builder, registry, and runtime-model exports |
-| `runtime/quality/*` | `runtime/agent/*`, `runtime/models/*` | Offline evaluation and optimization against the live runtime graph |
+| `runtime/modules/*` | `runtime/agent/*` | DSPy module builders, registry, escalation, workspace phases, and RLM routing |
+| `quality/*` | `runtime/agent/*`, `runtime/modules/*` | Offline evaluation and optimization against the live runtime graph |
 
 ## API and Host Map
 
@@ -60,10 +60,12 @@ graph LR
     APP["api/main.py"]
     ROUTERS["api/routers/"]
     WS_ENDPOINT["api/routers/ws/endpoint.py"]
-    WS_STREAM["api/routers/ws/stream.py"]
+    WS_CONNECTION["api/routers/ws/connection_loop.py"]
     WS_SESSION["api/routers/ws/session.py"]
     WS_TURN_SETUP["api/routers/ws/turn_setup.py"]
-    WS_COMPLETION["api/routers/ws/completion.py"]
+    WS_TURN_RUNNER["api/routers/ws/turn_runner.py"]
+    WS_STREAM_LOOP["api/routers/ws/stream_loop.py"]
+    WS_SUMMARY["api/routers/ws/stream_summary.py"]
     RUNTIME_SERVICES["api/runtime_services/*"]
     EVENTS["api/events/*"]
     RUNTIME["runtime/*"]
@@ -72,11 +74,13 @@ graph LR
     ROUTERS --> WS_ENDPOINT
     ROUTERS --> RUNTIME_SERVICES
     ROUTERS --> EVENTS
-    WS_ENDPOINT --> WS_STREAM
+    WS_ENDPOINT --> WS_CONNECTION
     WS_ENDPOINT --> WS_SESSION
     WS_ENDPOINT --> WS_TURN_SETUP
-    WS_ENDPOINT --> WS_COMPLETION
-    WS_STREAM --> RUNTIME
+    WS_CONNECTION --> WS_TURN_RUNNER
+    WS_TURN_RUNNER --> WS_STREAM_LOOP
+    WS_TURN_RUNNER --> WS_SUMMARY
+    WS_STREAM_LOOP --> RUNTIME
 ```
 
 ### Key dependencies
@@ -87,7 +91,7 @@ graph LR
 | `api/routers/ws/*` | `api/runtime_services/*` | Runtime orchestration, execution events, and startup/repl bridging |
 | `api/runtime_services/settings.py` | `integrations/config/*` | Runtime settings mutation and env/config synchronization |
 | `api/runtime_services/diagnostics.py` | `integrations/config/*`, `integrations/daytona/*` | Runtime diagnostics, status, and provider connectivity tests |
-| `api/runtime_services/volumes.py` | `integrations/daytona/filesystem.py` | Volume browsing |
+| `api/runtime_services/volumes.py` | `integrations/daytona/file_browser.py`, `integrations/daytona/sdk_ops.py` | Volume browsing |
 | `api/events/*` | `runtime/execution/streaming_events.py`, frontend workspace stores | Event shaping for passive execution subscriptions and workbench hydration |
 
 ## Integration Packages
@@ -95,7 +99,7 @@ graph LR
 | Package | Role | Notable files |
 | --- | --- | --- |
 | `integrations/config/` | App/env/runtime settings | `env.py`, `runtime_settings.py`, `_env_utils.py`, `config.yaml` |
-| `integrations/database/` | Persistence boundary | `engine.py`, `fleet_repository.py`, `models_base.py`, `models_enums.py`, `models_identity.py`, `models_jobs.py`, `models_memory.py`, `models_optimization.py`, `models_runs.py`, `models_sandbox.py`, `repository_chat.py`, `repository_identity.py`, `repository_jobs.py`, `repository_memory.py`, `repository_optimization.py`, `repository_shared.py`, `types.py` |
+| `integrations/database/` | Persistence boundary | `engine.py`, `fleet_repository.py`, `models_base.py`, `models_enums.py`, `models_identity.py`, `models_jobs.py`, `models_llm_profiles.py`, `models_memory.py`, `models_optimization.py`, `models_runs.py`, `models_sandbox.py`, `repository_chat.py`, `repository_identity.py`, `repository_jobs.py`, `repository_memory.py`, `repository_optimization.py`, `repository_shared.py` |
 | `integrations/local_store.py` | Local sidecar persistence | session history, turn transcripts, optimization-run tracking |
 
 | `integrations/observability/` | Telemetry and tracing | `posthog_callback.py`, `mlflow_runtime.py`, `mlflow_traces.py`, `trace_context.py` |

--- a/docs/reference/source-layout.md
+++ b/docs/reference/source-layout.md
@@ -11,7 +11,8 @@ This document reflects the current backend package structure in `src/fleet_rlm/`
 | `api/` | FastAPI transport, auth, schemas, routers, websocket lifecycle, runtime services, and event shaping. |
 | `cli/` | `fleet` / `fleet-rlm` entrypoints, command registration, runtime helpers, and terminal UX. |
 | `integrations/` | Config, database, observability, Daytona, and local-store integrations. |
-| `runtime/` | Shared agent loop, execution helpers, content processing, tools, runtime models, and offline quality. |
+| `runtime/` | Shared agent loop, execution helpers, content processing, tools, runtime modules, and runtime models. |
+| `quality/` | Offline DSPy evaluation and GEPA optimization. |
 | `ui/` | Packaged frontend build assets used by installed distributions. |
 | `utils/` | Small shared helpers. |
 
@@ -37,7 +38,11 @@ This document reflects the current backend package structure in `src/fleet_rlm/`
 | `routers/auth.py` | Auth identity endpoint. |
 | `routers/health.py` | Health and readiness endpoints. |
 | `routers/runtime.py` | Runtime settings, diagnostics, and Daytona volume browsing routes. |
-| `routers/optimization.py` | GEPA/optimization routes. |
+| `routers/info.py` | API metadata endpoints. |
+| `routers/llm_profiles.py` | Local LLM profile and role management routes. |
+| `routers/optimization/` | GEPA optimization status, run, and dataset routes. |
+| `routers/runs.py` | Execution run-step lookup routes. |
+| `routers/sandboxes.py` | Daytona sandbox listing, detail, delete, and archive routes. |
 | `routers/sessions.py` | Session state, history, transcript, archive, and export routes. |
 | `routers/traces.py` | Feedback and trace-reporting routes. |
 | `routers/ws/` | Websocket transport for execution and execution-event subscriptions. |
@@ -47,16 +52,17 @@ This document reflects the current backend package structure in `src/fleet_rlm/`
 | Path | Description |
 | --- | --- |
 | `endpoint.py` | `/api/v1/ws/execution` and `/api/v1/ws/execution/events` entrypoints. |
-| `stream.py` | Execution turn streaming and message loop coordination. |
-| `session.py` | Runtime preparation and session restore/switch helpers. |
-| `turn_setup.py` | Converts a websocket payload into a prepared runtime turn. |
+| `connection_loop.py` | Connection-scoped conversational websocket loop and in-flight task control. |
+| `turn_setup.py` | Converts a websocket payload into a prepared runtime turn and session context. |
+| `turn_runner.py` | Runs one prepared turn, emits terminal events, and persists completion/failure. |
+| `stream_loop.py` | Runtime event iteration and websocket delivery. |
+| `stream_events.py` | Runtime-event serialization and terminal semantics. |
+| `stream_summary.py` | Completion summary and workbench hydration payload assembly. |
 | `commands.py` | Command-frame dispatch and run lifecycle initialization. |
-| `messages.py` | Websocket message parsing and validation. |
-| `terminal.py` | Terminal event shaping and ordering. |
-| `completion.py` | Completion summary and workbench hydration payload assembly. |
-| `manifest.py` | Session manifest handling. |
+| `transport.py` | Authentication, ticket handling, message parsing, close/send helpers, and startup errors. |
+| `session.py` | Session id normalization and cache helpers. |
+| `repl_bridge.py` | Interpreter callback forwarding into execution-event flow. |
 | `artifacts.py` | Artifact event helpers. |
-| `errors.py`, `helpers.py`, `lifecycle.py`, `types.py` | Focused helpers for errors, shutdown, request normalization, and websocket utility code. |
 
 ## `runtime/`
 
@@ -66,8 +72,7 @@ This document reflects the current backend package structure in `src/fleet_rlm/`
 | `agent/` | Shared DSPy orchestration, chat/session state, delegation policy, memory, and command helpers. |
 | `execution/` | Interpreter support, streaming helpers, runtime factory glue, and execution profiles. |
 | `content/` | Chunking, ingestion, and execution-log processing helpers. |
-| `models/` | Shared runtime/streaming models plus runtime-module assembly. |
-| `quality/` | DSPy evaluation and optimization. |
+| `modules/` | DSPy module assembly, escalation, workspace phases, module registry, and prompt/routing helpers. |
 | `tools/` | Typed tool adapters exposed to the shared runtime. |
 
 ### Runtime warmup policy
@@ -83,7 +88,6 @@ This document reflects the current backend package structure in `src/fleet_rlm/`
 | `config/` | App/env/runtime settings helpers and defaults. |
 | `database/` | Database manager, SQLModel models, repository, and DB-facing types. |
 | `local_store.py` | Local session/history/optimization persistence. |
-
 | `observability/` | PostHog and MLflow integrations plus trace/request-context helpers. |
 | `daytona/` | Daytona interpreter facade, workspace/session manager, sandbox executor, child delegation, bridge/runtime helpers, diagnostics, and volume access. |
 

--- a/docs/specs/frontend-simplification-design.md
+++ b/docs/specs/frontend-simplification-design.md
@@ -9,10 +9,10 @@ This is a structural cleanup, not a visual redesign and not a frontend/backend c
 ## Target Shape
 
 - Keep `src/frontend/src/components/ui/*` as the only `ui` namespace. It remains the canonical shadcn/Base UI primitive layer.
-- Keep `src/frontend/src/components/ai-elements/*` as the canonical registry-owned AI layer.
-- Keep `src/frontend/src/components/product/*` small and curated. It should contain only proven reusable Fleet compositions built from `ui/*` and `ai-elements/*`.
+- Keep `src/frontend/src/components/agent-elements/*` as the canonical Agent Elements layer.
+- Keep `src/frontend/src/components/product/*` small and curated. It should contain only proven reusable Fleet compositions built from `ui/*` and `agent-elements/*`.
 - Remove `src/frontend/src/features/workspace/ui/`.
-- Replace it with responsibility-named workspace modules such as `screen`, `conversation`, `composer`, `inspection`, `workbench`, and `session`.
+- Replace it with responsibility-named workspace modules such as `screen`, `conversation`, `inspection`, `workbench`, and `session`; the chat input is composed through Agent Elements input primitives rather than a resurrected composer folder.
 - Keep `src/frontend/src/lib/workspace/*` as the owner of non-visual runtime/store/event shaping.
 - Keep route files thin and continue pointing directly at feature entrypoints.
 

--- a/src/fleet_rlm/AGENTS.md
+++ b/src/fleet_rlm/AGENTS.md
@@ -73,6 +73,8 @@ Preserve these command surfaces:
 Important CLI/runtime nuances:
 
 - `fleet web` is a thin entrypoint that delegates into `fleet-rlm serve-api --host 0.0.0.0 --port 8000`
+- `fleet-rlm chat` owns the interactive terminal TUI; preserve the prompt_toolkit boxed input,
+  scrollable transcript, and visible thinking/connection states when editing `chat.py`
 - Daytona websocket requests do not accept request-side `max_depth`; schema enforcement happens server-side
 - `/ready` reports critical server readiness only; optional LM and observability warmup status belongs in runtime diagnostics/status
 
@@ -132,8 +134,13 @@ Auth, persistence, and observability constraints:
 
 - Supported auth modes are `dev`, `entra`, and `neon`
 - `AUTH_MODE=entra` and `AUTH_MODE=neon` require repository-backed tenant admission in addition to token validation
+- Neon Auth tokens are EdDSA-signed; backend JWT decoding must explicitly allow `EdDSA`
+  and continue validating issuer, audience, timestamps, and repository admission.
 - Neon Auth browser WebSockets must use the short-lived `/api/v1/auth/ws-ticket` exchange; do not put raw Neon JWTs in WebSocket query strings
 - `DATABASE_URL` is the pooled runtime connection; `DATABASE_ADMIN_URL` is the direct connection for Alembic and admin/debug tasks
+- Postgres Row-Level Security depends on transaction-local `app.tenant_id`,
+  `app.user_id`, and `app.workspace_id` context set through the repository boundary.
+  Do not bypass `FleetRepository` or route browser product data directly through Neon Data API.
 - `PATCH /api/v1/runtime/settings` is blocked unless `APP_ENV=local`
 - PostHog and MLflow are live codepaths when configured and should not be treated as no-ops
 - In local development, MLflow may auto-start when configured for localhost unless `MLFLOW_AUTO_START=false`

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -164,7 +164,7 @@ sidepanel.
   are embedded in Fleet layouts.
 - `auth-provider.tsx` owns token refresh and query-cache clearing. Keep proactive refresh before
   profile/session sync so display names and admission state update without a manual reload.
-- `typed-client.ts` must normalize API base URLs without trailing slashes to avoid duplicated slash,
+- `typed-client.ts` must normalize API base URLs without trailing slashes to avoid duplicate slashes,
   routing, or CORS mismatches.
 
 **Do not** create feature-local `ui/` folders; `src/components/ui/*` is the only primitive `ui` namespace.

--- a/src/frontend/AGENTS.md
+++ b/src/frontend/AGENTS.md
@@ -20,23 +20,25 @@ Before editing:
 
 ## Source-of-Truth Files
 
-| Concern                 | File(s)                                                                |
-| ----------------------- | ---------------------------------------------------------------------- |
-| Scripts & validation    | `package.json`                                                         |
-| Lint/build/import rules | `vite.config.ts`                                                       |
-| Style token guard       | `scripts/check-style-tokens.mjs`                                       |
-| Routes & surfaces       | `src/routes/*`                                                         |
-| App chrome / layout     | `src/features/layout/*`                                                |
-| Product surfaces        | `src/features/{workspace,optimization,volumes,settings}/index.ts`      |
-| UI primitives           | `src/components/ui/*` (shadcn/Base UI)                                 |
-| Agent Elements (chat)   | `src/components/agent-elements/*`                                      |
-| Product compositions    | `src/components/product/*`                                             |
-| API clients & types     | `src/lib/rlm-api/*`                                                    |
-| Workspace adapters      | `src/lib/workspace/*`                                                  |
-| Theme / tokens          | `src/styles/globals.css`, `src/components/agent-elements/agent-ui.css` |
-| shadcn config           | `components.json`                                                      |
-| API contract            | `openapi.yaml`, `src/lib/rlm-api/generated/openapi.ts`                 |
-| Dead-code analysis      | `knip.json`                                                            |
+| Concern                 | File(s)                                                                 |
+| ----------------------- | ----------------------------------------------------------------------- |
+| Scripts & validation    | `package.json`                                                          |
+| Lint/build/import rules | `vite.config.ts`                                                        |
+| Style token guard       | `scripts/check-style-tokens.mjs`                                        |
+| Routes & surfaces       | `src/routes/*`                                                          |
+| Client entry/hydration  | `src/client.tsx`                                                        |
+| App chrome / layout     | `src/features/layout/*`                                                 |
+| Product surfaces        | `src/features/{workspace,optimization,volumes,settings}/index.ts`       |
+| UI primitives           | `src/components/ui/*` (shadcn/Base UI)                                  |
+| Agent Elements (chat)   | `src/components/agent-elements/*`                                       |
+| Product compositions    | `src/components/product/*`                                              |
+| Auth/session restore    | `src/lib/auth/auth-provider.tsx`, `src/features/layout/app-sidebar.tsx` |
+| API clients & types     | `src/lib/rlm-api/*`                                                     |
+| Workspace adapters      | `src/lib/workspace/*`                                                   |
+| Theme / tokens          | `src/styles/globals.css`, `src/components/agent-elements/agent-ui.css`  |
+| shadcn config           | `components.json`                                                       |
+| API contract            | `openapi.yaml`, `src/lib/rlm-api/generated/openapi.ts`                  |
+| Dead-code analysis      | `knip.json`                                                             |
 
 ### Generated / Synced — Do Not Hand-Edit
 
@@ -63,8 +65,8 @@ Before editing:
 
 The following layers were removed and must not be reintroduced:
 
-- **`src/components/ai-elements`** — **deleted**. All primitives have been either merged into `ui/` (code-block), rewritten on `agent-elements/` (trajectory-chain), or removed as dead code (prompt-input, chain-of-thought, reasoning). Do not install `@ai-elements` registry components.
-- **`src/features/workspace/composer`** — **deleted**. The orphaned `workspace-composer.tsx` and its legacy `PromptInput` dependency have been removed. The canonical composer is `InputBar` from `agent-elements/input-bar.tsx`.
+- **Legacy AI Elements layer** — **deleted**. All primitives have been either merged into `ui/` (code-block), rewritten on `agent-elements/` (trajectory-chain), or removed as dead code (prompt-input, chain-of-thought, reasoning). Do not install legacy AI registry components.
+- **Legacy workspace composer layer** — **deleted**. The orphaned composer wrapper and its legacy prompt input dependency have been removed. The canonical composer is `InputBar` from `agent-elements/input-bar.tsx`.
 - **`src/screens`** — never existed. The stale `@/screens/*` lint rule has been removed from `vite.config.ts`.
 - **`components/tool-ui`** — retired. Tool transcript UI belongs under `components/agent-elements/tools/*`.
 
@@ -93,6 +95,17 @@ backend WS frames
 - `src/router.tsx` owns the router instance.
 - `src/routes/` defines file-based routes. Keep route wrappers thin; compose feature entry modules through `src/features/*/index.ts`.
 - `src/routeTree.gen.ts` is generated.
+
+### Route Data and Hydration
+
+- Client entry `src/client.tsx` owns the static/SSR hydration split. Keep the static path on
+  `createRoot`, keep SSR hydration on `hydrateRoot`, preserve the `window.__hydrated` test signal,
+  and leave `PostHogProvider` mounted unconditionally.
+- Route loaders for backend-backed surfaces should await TanStack Query work before returning.
+  Prefer shared `queryOptions(...)` factories with `queryClient.ensureQueryData(...)` or
+  `queryClient.prefetchQuery(...)` so loaders and hooks share keys, functions, and type inference.
+- Do not leave route-loader prefetches floating. Empty-cache transitions should not flicker or
+  reflow because a route rendered before its blocking data was scheduled.
 
 ### Workspace Structure
 
@@ -131,13 +144,36 @@ tree/preview split. The routed `/app/volumes` page remains the full-page
 durable volume browser and should not be collapsed into the workspace
 sidepanel.
 
+### Session Persistence and Restore
+
+- `workspace-screen.tsx` owns first-message chat session creation and uses `lastSavedStateRef` to
+  avoid redundant state writes.
+- `use-workspace-runtime.ts` captures `db_session_id` from `execution_started.summary` and binds
+  local workspace state to the durable backend session id.
+- `app-sidebar.tsx` starts authenticated background session sync. On logout or token expiration,
+  clear TanStack Query state before showing another tenant/user's cached session data.
+- Keep FastAPI plus `FleetRepository` as the runtime authorization boundary; do not move product
+  session reads or writes to direct Neon Data API calls from the browser.
+
+### Neon Auth UI
+
+- Branded login/signup pages render granular Neon Auth forms (`SignInForm`, `SignUpForm`) directly.
+  Keep catch-all routes `auth.$pathname.tsx` and `account.$pathname.tsx` for Neon internal flows.
+- Strip default Neon form chrome with
+  `classNames={{ base: "border-0 bg-transparent p-0 shadow-none w-full !max-w-none" }}` when forms
+  are embedded in Fleet layouts.
+- `auth-provider.tsx` owns token refresh and query-cache clearing. Keep proactive refresh before
+  profile/session sync so display names and admission state update without a manual reload.
+- `typed-client.ts` must normalize API base URLs without trailing slashes to avoid duplicated slash,
+  routing, or CORS mismatches.
+
 **Do not** create feature-local `ui/` folders; `src/components/ui/*` is the only primitive `ui` namespace.
 
 ---
 
 ## Tech Stack
 
-- **Package manager:** `pnpm` 10.33.0 (always `pnpm install --frozen-lockfile`)
+- **Package manager:** `pnpm` 11.8.0 from `package.json` (always `pnpm install --frozen-lockfile`)
 - **Build / lint / format:** Vite+ (`vp`) via `pnpm run ...`
 - **Framework:** React 19 + TypeScript 5.9+
 - **Router:** TanStack Router (file-based)
@@ -145,6 +181,10 @@ sidepanel.
 - **Styling:** Tailwind CSS v4 + `tw-animate-css` + `@theme inline`
 - **Testing:** Vitest (unit), Playwright (e2e)
 - **Dead-code analysis:** knip (`pnpm run lint:dead-code`)
+
+Do not add legacy pnpm build-trust fields such as `onlyBuiltDependencies` or
+`trustedDependencies` to `package.json`; keep package-manager security settings in the current
+pnpm-supported config surface when one is introduced.
 
 ---
 
@@ -225,6 +265,17 @@ pnpm run check
 - Theme primitives live in `src/styles/globals.css` and `src/components/agent-elements/agent-ui.css`. Keep the Tailwind v4 baseline canonical.
 - Use **semantic tokens and shared variants** — avoid arbitrary colors or local token layers.
 - **Eliminate arbitrary Tailwind values**. The project maintains token-backed `@utility` classes for all font sizes, radii, and common dimensions. Do not introduce new `text-[Npx]`, `w-[Npx]`, `h-[Npx]`, `rounded-[Npx]`, `leading-[...]`, or `tracking-[...]` values. If a size is missing, add a design token and `@utility` in `globals.css` or `agent-ui.css` rather than using an arbitrary value.
+- For analytical canvases, use direct absolute markdown links to `.canvas.tsx` files in chat/reporting
+  output so the IDE Canvas opens reliably.
+- Align complex dashboards with base UI/shadcn primitives: standard `text-sm` tabs, `variant="elevated"`
+  cards for major containers, and standard `h-9` form controls unless a shared token utility exists.
+- Preserve focus indicators on core forms such as `input-bar.tsx`; sidebar-specific focus suppression
+  belongs only under targeted sidebar selectors.
+- Generic tree primitives such as `TreeView` must implement keyboard tree behavior (`role="tree"`,
+  focus management, arrow keys, Enter/Space, Home/End) and keep mouse clicks synchronized with
+  `focusedId`.
+- Target visual JSON wrapping with scoped selectors such as `.visual-json-tree`; never add global
+  `[role="tree"]` CSS that could affect filesystem trees or other ARIA tree widgets.
 
 ### Style Token Enforcement
 
@@ -301,6 +352,7 @@ Dynamic colors (e.g. from `STEP_TYPE_META`) must use CSS custom properties set v
 Shared visual recipes belong in `src/components/product/*` or `src/components/agent-elements/input/*`, not duplicated locally. Current recipe components:
 
 - `NodeBadge` — small badge/pill for graph nodes and execution metadata
+- `TreeView` — keyboard-accessible product tree primitive for volume/filesystem-style trees
 - `ToolActionButton` — CVA primary/ghost/ghostSoft × sm/md/mdWide button for tool cards, approval footers, and question prompts
 - `CenteredErrorShell` — card-wrapped full-height centered error/empty-state shell (404, route-error-screen)
 - `PopoverSurface` / `popoverSurfaceClass` — shared popover surface recipe for input-bar, model-picker, mode-selector
@@ -348,8 +400,6 @@ VITE_FLEET_WS_URL
 VITE_FLEET_WORKSPACE_ID
 VITE_FLEET_USER_ID
 VITE_AGENTATION_ENDPOINT
-VITE_ENTRA_CLIENT_ID
-VITE_ENTRA_SCOPES
 VITE_PUBLIC_POSTHOG_API_KEY
 VITE_PUBLIC_POSTHOG_HOST
 ```
@@ -459,3 +509,6 @@ Wire backend tools through `agent-chat-adapter.ts` → `ToolRenderer`. Shared no
 - `code-block` lives in `ui/code-block.tsx` — both the simple (`CodeBlock`/`CodeBlockCode`/`CodeBlockGroup`) and rich (`CodeBlockViewer`/`CodeBlockHeader`/`CodeBlockFilename`/`CodeBlockCopyButton`/`CodeBlockActions`/`CodeBlockContent`) APIs.
 - `trajectory-chain.tsx` uses `agent-elements` `Collapsible` primitives directly — do not reintroduce `chain-of-thought` from `@ai-elements`.
 - The orphaned `workspace-composer.tsx` and its legacy `PromptInput` dependency have been deleted; do not recreate them.
+- Empty-state suggestions in `workspace-message-list.tsx` use the Agent Elements `Suggestion` chip
+  component with neutral icon fills and the larger "Qredence Fleet" title; avoid card-like empty
+  states or colored icon accents.


### PR DESCRIPTION
## Summary
- compact the root agent map and move durable learned facts into subsystem/reference docs
- refresh active frontend docs for current routed surfaces, Agent Elements ownership, TanStack/session behavior, and current env/package-manager details
- refresh backend docs against the current `src/fleet_rlm` tree, including websocket split, runtime modules, top-level quality package, auth modes, database repositories, and optimization/sandbox/LLM profile routes

## Validation
- `UV_NO_SYNC=1 uv run python scripts/check_docs_quality.py`
- `UV_NO_SYNC=1 uv run python scripts/check_harness_engineering.py`
- `UV_NO_SYNC=1 uv run python scripts/check_agents_md_freshness.py`
- `UV_NO_SYNC=1 make check-docs`
- `git diff --check`
