### PR TITLE
QRE-78: Add P0 MVP characterization contracts

### DIFF
--- a/tests/contracts/backend/test_ai_sdk_ui_turn_contract.py
+++ b/tests/contracts/backend/test_ai_sdk_ui_turn_contract.py
@@ -1,0 +1,69 @@
+"""QRE-78 P0 AI SDK UI turn lifecycle projection contracts."""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+from fleet_rlm.api.sse import AISDKUIProjector, SSEProjector
+from fleet_rlm.rlm.events import (
+    TERMINAL_DETAIL_TYPES,
+    EventRecorder,
+    RunCancelled,
+    RunCompleted,
+    RunFailed,
+    RunStarted,
+    RuntimeEvent,
+    Status,
+    TextCompleted,
+    TextDelta,
+    Usage,
+)
+
+
+def _chunk_types(events: list[RuntimeEvent]) -> list[str]:
+    projector = AISDKUIProjector()
+    return [chunk["type"] for event in events for chunk in projector.project(event)]
+
+
+def test_projected_turn_lifecycle_is_start_chunks_one_terminal_done() -> None:
+    recorder = EventRecorder(run_id=uuid4(), session_id=uuid4())
+    events = [
+        recorder.record(RunStarted("live")),
+        recorder.record(Status("execution", "running")),
+        recorder.record(Usage({"iterations": 1})),
+        recorder.record(TextDelta("ok")),
+        recorder.record(TextCompleted("ok")),
+        recorder.record(RunCompleted(1, "live")),
+    ]
+
+    terminal_events = [event for event in events if isinstance(event.detail, TERMINAL_DETAIL_TYPES)]
+    assert len(terminal_events) == 1
+    assert terminal_events[0] is events[-1]
+
+    frames = list(SSEProjector().project(events)) + [SSEProjector().done()]
+    chunks = [json.loads(frame.removeprefix("data: ")) for frame in frames[:-1]]
+    types = [chunk["type"] for chunk in chunks]
+    assert types[0] == "start"
+    assert types[-1] == "finish"
+    assert types.count("finish") == 1
+    assert not any(chunk_type in {"finish", "abort", "error"} for chunk_type in types[1:-1])
+    assert frames[-1] == "data: [DONE]\n\n"
+
+
+def test_error_terminal_projects_error_then_finish_as_single_runtime_terminal() -> None:
+    recorder = EventRecorder(run_id=uuid4(), session_id=uuid4())
+    events = [recorder.record(RunStarted("live")), recorder.record(RunFailed("execution_failed", "Turn failed"))]
+
+    assert len([event for event in events if isinstance(event.detail, TERMINAL_DETAIL_TYPES)]) == 1
+    assert isinstance(events[-1].detail, TERMINAL_DETAIL_TYPES)
+    assert _chunk_types(events) == ["start", "error", "finish"]
+
+
+def test_abort_terminal_projects_abort_as_single_runtime_terminal() -> None:
+    recorder = EventRecorder(run_id=uuid4(), session_id=uuid4())
+    events = [recorder.record(RunStarted("live")), recorder.record(RunCancelled())]
+
+    assert len([event for event in events if isinstance(event.detail, TERMINAL_DETAIL_TYPES)]) == 1
+    assert isinstance(events[-1].detail, TERMINAL_DETAIL_TYPES)
+    assert _chunk_types(events) == ["start", "abort"]

--- a/tests/contracts/backend/test_mvp_characterization.py
+++ b/tests/contracts/backend/test_mvp_characterization.py
@@ -1,0 +1,130 @@
+"""QRE-78 P0 MVP characterization contracts for current backend turn behavior."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import dspy
+import pytest
+import pytest_asyncio
+
+from fleet_rlm.chat.commands import OpenTurnCommand
+from fleet_rlm.chat.hermetic_run_environment import HermeticTurnPreparation
+from fleet_rlm.chat.turn_coordinator import TurnCoordinator
+from fleet_rlm.chat.turn_lifecycle import TurnLifecycleModule
+from fleet_rlm.files.models import PreparedAttachments
+from fleet_rlm.persistence.repositories import InMemorySessionCatalog, InMemoryTurnStateStore
+from fleet_rlm.rlm.budgets import RunBudget
+from fleet_rlm.rlm.events import TERMINAL_DETAIL_TYPES, RunCancelled, RunCompleted, RunStarted, RuntimeEvent
+from fleet_rlm.rlm.runner import RLMRunner
+from fleet_rlm.sessions.committed_turn import TextPart, UsagePart
+from fleet_rlm.sessions.models import AssistantTurnRecord, TurnAccess, TurnInput, UserTurnRecord
+
+
+class _NoAttachments:
+    async def prepare_run(self, access, attachment_ids, run, sink) -> PreparedAttachments:
+        del access, attachment_ids, run, sink
+        return PreparedAttachments((), ())
+
+
+@dataclass
+class _DeterministicRLM:
+    calls: Counter[str]
+
+    async def acall(self, **kwargs):
+        del kwargs
+        self.calls["acall"] += 1
+        return dspy.Prediction(answer="ok")
+
+
+@dataclass
+class _DeterministicRLMFactory:
+    calls: Counter[str]
+
+    def create(self, **kwargs):
+        del kwargs
+        self.calls["create"] += 1
+        return _DeterministicRLM(self.calls)
+
+
+async def _collect(stream: AsyncIterator[RuntimeEvent]) -> list[RuntimeEvent]:
+    return [event async for event in stream]
+
+
+@pytest_asyncio.fixture
+async def mvp_turn_harness():
+    access = TurnAccess(uuid4(), uuid4())
+    store = InMemoryTurnStateStore()
+    session = await InMemorySessionCatalog(store).create(
+        user_id=access.user_id,
+        workspace_id=access.workspace_id,
+        title="MVP characterization",
+    )
+    calls: Counter[str] = Counter()
+    lifecycle = TurnLifecycleModule(store, max_artifact_bytes=1024)
+    coordinator = TurnCoordinator(
+        lifecycle=lifecycle,
+        preparation=HermeticTurnPreparation(attachments=_NoAttachments(), budget=RunBudget(max_iterations=1)),
+        runner=RLMRunner(factory=_DeterministicRLMFactory(calls)),
+    )
+    return access, store, session.id, coordinator, calls
+
+
+@pytest.mark.asyncio
+async def test_mvp_success_commits_one_user_one_assistant_usage_text_and_terminal_event(mvp_turn_harness) -> None:
+    access, store, session_id, coordinator, calls = mvp_turn_harness
+    run_id = uuid4()
+
+    events = await _collect(
+        await coordinator.open(OpenTurnCommand(access, session_id, TurnInput("hello"), "mvp-success", run_id))
+    )
+
+    terminal_events = [event for event in events if isinstance(event.detail, TERMINAL_DETAIL_TYPES)]
+    assert len(terminal_events) == 1
+    assert terminal_events[0] is events[-1]
+    assert terminal_events[0].detail == RunCompleted(checkpoint_version=1, delivery="live")
+    assert isinstance(events[0].detail, RunStarted)
+    assert calls["acall"] == 1
+
+    records = await store.turn_records(session_id, access)
+    assert len(records) == 2
+    assert isinstance(records[0], UserTurnRecord)
+    assert records[0].content == "hello"
+    assert isinstance(records[1], AssistantTurnRecord)
+    assert records[1].committed.text == "ok"
+    assert [type(part) for part in records[1].committed.parts].count(UsagePart) == 1
+    assert [type(part) for part in records[1].committed.parts].count(TextPart) == 1
+
+
+@pytest.mark.asyncio
+async def test_mvp_idempotent_replay_executes_once_without_duplicate_committed_events(mvp_turn_harness) -> None:
+    access, store, session_id, coordinator, calls = mvp_turn_harness
+    run_id = uuid4()
+    command = OpenTurnCommand(access, session_id, TurnInput("hello"), "mvp-replay", run_id)
+
+    first_events = await _collect(await coordinator.open(command))
+    replay_events = await _collect(await coordinator.open(command))
+
+    assert calls["create"] == 1
+    assert calls["acall"] == 1
+    assert len(await store.turn_records(session_id, access)) == 2
+    first_terminals = [event for event in first_events if isinstance(event.detail, TERMINAL_DETAIL_TYPES)]
+    replay_terminals = [event for event in replay_events if isinstance(event.detail, TERMINAL_DETAIL_TYPES)]
+    assert len(first_terminals) == 1
+    assert len(replay_terminals) == 1
+    assert first_terminals[0] is first_events[-1]
+    assert replay_terminals[0] is replay_events[-1]
+    assert replay_terminals[0].detail == RunCompleted(checkpoint_version=1, delivery="replay")
+
+
+def test_mvp_cancelled_runtime_event_has_one_abort_terminal_path() -> None:
+    from fleet_rlm.api.sse import AISDKUIProjector
+    from fleet_rlm.rlm.events import EventRecorder
+
+    event = EventRecorder(run_id=uuid4(), session_id=uuid4()).record(RunCancelled())
+
+    assert isinstance(event.detail, TERMINAL_DETAIL_TYPES)
+    assert AISDKUIProjector().project(event) == [{"type": "abort", "reason": "Turn cancelled"}]


### PR DESCRIPTION
### Motivation
- Add P0 characterization contracts to lock in current backend turn behavior for the MVP (per PLANS.md lines 236–308) so future refactors preserve observed semantics. 
- The tests codify expected deterministic RLM behavior: a native `dspy.Prediction(answer="ok")`, exactly one user record, one assistant record, one usage part, one text part, and a single terminal Runtime Event emitted last. 
- Capture idempotent replay and cancellation projection behavior without changing production implementation or starting P1/P2 work.

### Description
- Create `tests/contracts/backend/test_mvp_characterization.py` which adds an async harness using a deterministic in-process RLM factory that returns `dspy.Prediction(answer="ok")` and asserts the canonical committed Turn shape, single terminal event, and idempotent replay semantics. 
- Create `tests/contracts/backend/test_ai_sdk_ui_turn_contract.py` which asserts AI SDK UI projection ordering for success (`start -> chunks -> finish -> [DONE]`), error terminal (`error` then `finish`), and abort terminal (`abort`).
- Use a small hermetic attachments stub and `HermeticTurnPreparation` for deterministic preparation and add a `pytest_asyncio` fixture to wire the async harness; no production code or runtime behavior was modified.
- Keep changes strictly limited to test artifacts and characterization scaffolding; no authentication, composition, or RLM runtime changes were implemented.

### Testing
- Syntax/compile check: `python -m py_compile tests/contracts/backend/test_mvp_characterization.py tests/contracts/backend/test_ai_sdk_ui_turn_contract.py` succeeded. 
- Ran `uv run pytest tests/contracts/backend/test_mvp_characterization.py tests/contracts/backend/test_ai_sdk_ui_turn_contract.py -q -n 0` but the run was blocked by environment package resolution failures (unable to fetch `ruff`, `setuptools`, and `wheel` due to network/tunnel errors), so full test execution could not complete. 
- `make test-contract` and `make test-deno` were attempted and failed in this environment due to pytest plugin/arg issues and the same package resolution constraints. 
- No production tests were changed; the PR only adds characterization contracts and their harnesses and should be runnable in CI or an environment with normal package resolution and pytest plugins installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a57511b64e0832f8c04e32d60abae77)