### PR TITLE
feat(runtime): Bound session history and harden workspace tools

### DIFF
--- a/docs/adr/0001-coordinated-turn-contract.md
+++ b/docs/adr/0001-coordinated-turn-contract.md
@@ -109,14 +109,16 @@ length and SHA-256 before response.
 
 ### DSPy boundary
 
-DSPy remains pinned to `3.3.0b1` behind one local compatibility adapter. Fleet
-uses public `dspy.RLM` construction and `acall`, `dspy.context`, typed
-Signatures, Tools/callables, `SandboxSerializable`, and stock `dspy.LM`.
+DSPy remains pinned to `3.3.0b1` behind local compatibility adapters in
+`rlm/`. Fleet uses public `dspy.RLM` construction and `acall`, `dspy.context`,
+typed Signatures, Tools/callables, `SandboxSerializable`, and stock `dspy.LM`.
 
-Exactly two private overrides remain: `_aexecute_iteration` for nonblocking
-iteration detail and `_make_llm_tools` for bounded built-in Sub Model tools.
-The private `_strip_code_fences` helper is the only private helper import.
-Fingerprint and differential contract tests gate all three seams. Fleet does
+`rlm.dspy_contract` owns version assertion, native construction, Prediction
+extraction, trajectory normalization, and usage. `rlm.dspy_interpreter_contract`
+owns the pinned inject extras beyond public `CodeInterpreter` (`output_fields`,
+`_tools_registered` reinjection semantics, and `FinalOutput`). Concrete
+interpreters remain under `fleet_rlm.daytona`; they call the interpreter
+contract helpers rather than importing `dspy.primitives` directly. Fleet does
 not fork RLM, subclass `BaseLM`, or call LiteLLM directly.
 
 ### Environments, persistence, and generated contracts

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,13 +3,16 @@
 ## Commands
 
 ```bash
-uv run fleet cli [--host 127.0.0.1] [--port 8000] [--reload] [-- <pi-tui args>]
-uv run fleet deno [--host 127.0.0.1] [--port 8000] [--reload] [-- <pi-tui args>]
+uv run fleet cli [--host 127.0.0.1] [--port 8000] [--reload] [--allow-non-loopback-bind] [-- <pi-tui args>]
+uv run fleet deno [--host 127.0.0.1] [--port 8000] [--reload] [--allow-non-loopback-bind] [-- <pi-tui args>]
 uv run fleet doctor daytona
-uv run fleet web [--host 127.0.0.1] [--port 8000] [--reload]
-uv run fleet-rlm serve-api [--host 127.0.0.1] [--port 8000] [--reload]
+uv run fleet web [--host 127.0.0.1] [--port 8000] [--reload] [--allow-non-loopback-bind]
+uv run fleet-rlm serve-api [--host 127.0.0.1] [--port 8000] [--reload] [--allow-non-loopback-bind]
 ```
 
+Fleet has no caller authentication. Launchers default to `127.0.0.1` and reject
+non-loopback hosts (`0.0.0.0`, LAN addresses, hostnames other than `localhost`)
+unless `--allow-non-loopback-bind` is supplied deliberately.
 `fleet cli` forces Daytona; `fleet deno` forces Deno. Each starts the backend in
 its own process group, waits up to 30 seconds for readiness, and runs pi-tui in
 the foreground. Node 22.19+, pnpm, the installed TUI workspace, and an unused

--- a/src/fleet_rlm/AGENTS.md
+++ b/src/fleet_rlm/AGENTS.md
@@ -15,9 +15,10 @@ them for backend work. Current code and tests outrank the local phase record in
   in-memory bundled Skill catalog. Lifespan composition installs and disposes
   one complete Deno, Daytona, or explicitly injected private-test inventory.
 - Keep Daytona SDK imports inside `daytona/`.
-- Create a fresh native DSPy RLM per Turn through `rlm.dspy_contract`. Daytona
-  supplies a fresh custom interpreter; Deno passes `interpreter=None` so DSPy
-  creates its default Deno/Pyodide interpreter. Call only the supported
+- Create a fresh native DSPy RLM per Turn through `rlm.dspy_contract`. Inject and
+  `FinalOutput` protocol knowledge lives in `rlm.dspy_interpreter_contract`.
+  Daytona supplies a fresh custom interpreter; Deno passes `interpreter=None` so
+  DSPy creates its default Deno/Pyodide interpreter. Call only the supported
   `await rlm.acall(**named_inputs)` surface.
 - The default Signature receives request text, bounded `session_context`,
   authorized `skill_cards`, and bounded Attachment metadata. Older committed

--- a/src/fleet_rlm/AGENTS.md
+++ b/src/fleet_rlm/AGENTS.md
@@ -24,8 +24,9 @@ them for backend work. Current code and tests outrank the local phase record in
   messages remain behind the Session-scoped `read_session_history` Tool.
   Custom Task Contracts receive only their declared host-bounded inputs.
 - Runtime-specific Session Workspace availability is bounded inside context;
-  Daytona registers four text workspace Tools and Deno advertises the feature
-  as unavailable.
+  Daytona registers four text workspace Tools (list, stat, read, write with
+  overwrite) and Deno advertises the feature as unavailable. Session Workspace
+  is append/update-only; there is no delete Tool.
 - Compose zero to four exact authorized Skill selections. Skill instructions and
   resources load progressively. The production host `CapabilityRegistry` is an
   empty extension seam; bundled Skills do not register executable capabilities.
@@ -49,7 +50,8 @@ them for backend work. Current code and tests outrank the local phase record in
   sink, and the derivative is not an Artifact or API resource.
 - Session Workspace files are immediate private state under
   `sessions/{session_id}/workspace/`. They survive failed Runs and Sandbox
-  replacement independently of Turn Commit.
+  replacement independently of Turn Commit. Updates replace existing files via
+  `write_workspace_text(..., overwrite=True)`; deletion is not exposed as a Tool.
 - Alembic owns live schema evolution. `create_tables` is test/local SQLite only.
 - Do not add `/api/v1`, WebSocket, legacy-backend, auth, or environment aliases.
 

--- a/src/fleet_rlm/cli/bind_safety.py
+++ b/src/fleet_rlm/cli/bind_safety.py
@@ -1,0 +1,37 @@
+"""Reject unauthenticated non-loopback API binds unless explicitly opted in."""
+
+from __future__ import annotations
+
+import ipaddress
+
+
+class UnsafeBindError(ValueError):
+    """Raised when the API would listen beyond loopback without an unsafe opt-in."""
+
+
+def is_loopback_bind_host(host: str) -> bool:
+    """Return True when *host* is a loopback literal safe for the no-auth product."""
+    normalized = host.strip().lower()
+    if normalized in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+    return bool(address.is_loopback)
+
+
+def require_safe_bind_host(host: str, *, allow_non_loopback: bool) -> None:
+    """Reject non-loopback binds unless ``allow_non_loopback`` is True.
+
+    Fleet uses one deterministic local User/Workspace with no caller auth. Binding
+    to a wildcard or remote address without an explicit opt-in would expose
+    Sessions, workspace operations, Attachments, Artifacts, and BYOK model
+    execution on the network.
+    """
+    if allow_non_loopback or is_loopback_bind_host(host):
+        return
+    raise UnsafeBindError(
+        f"refusing to bind unauthenticated Fleet API to non-loopback host {host!r}; "
+        "pass --allow-non-loopback-bind to opt in deliberately"
+    )

--- a/src/fleet_rlm/cli/main.py
+++ b/src/fleet_rlm/cli/main.py
@@ -8,6 +8,8 @@ import os
 from collections.abc import Sequence
 from typing import Any
 
+from fleet_rlm.cli.bind_safety import UnsafeBindError, require_safe_bind_host
+
 
 def _add_serve_command(
     subcommands: Any,
@@ -21,6 +23,14 @@ def _add_serve_command(
     serve.add_argument("--host", default="127.0.0.1")
     serve.add_argument("--port", type=int, default=8000)
     serve.add_argument("--reload", action="store_true")
+    serve.add_argument(
+        "--allow-non-loopback-bind",
+        action="store_true",
+        help=(
+            "allow binding to a non-loopback address; Fleet has no caller "
+            "authentication and will expose the local API on the network"
+        ),
+    )
     if supervise_tui:
         serve.add_argument("tui_args", nargs=argparse.REMAINDER)
     serve.set_defaults(run_environment=run_environment, supervise_tui=supervise_tui)
@@ -66,6 +76,14 @@ def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> 
     if args.command == "doctor":
         _run_doctor(parser, args.doctor_provider)
         return
+
+    try:
+        require_safe_bind_host(
+            args.host,
+            allow_non_loopback=bool(args.allow_non_loopback_bind),
+        )
+    except UnsafeBindError as exc:
+        parser.exit(1, f"fleet: error: {exc}\n")
     if args.supervise_tui:
         from fleet_rlm.cli.supervisor import SupervisorError, supervise
 

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -16,7 +16,6 @@ from collections.abc import Callable, Mapping
 from typing import Any, Protocol
 
 import dspy
-from dspy.primitives.code_interpreter import FinalOutput
 
 from fleet_rlm.daytona.errors import (
     DaytonaAdapterError,
@@ -26,6 +25,15 @@ from fleet_rlm.daytona.errors import (
 from fleet_rlm.daytona.http_broker import DaytonaHttpToolBroker
 from fleet_rlm.daytona.in_process import BackendExecutionResult, InProcessInterpreterBackend
 from fleet_rlm.daytona.submit import extract_final_payload
+from fleet_rlm.rlm.dspy_interpreter_contract import (
+    PUBLIC_FINAL_OUTPUT_LABEL,
+    copy_output_fields,
+    initial_tools_registered,
+    is_final_output,
+    mark_tools_registered,
+    needs_tool_reinjection,
+    wrap_final_output,
+)
 from fleet_rlm.rlm.events import ObservationObserver, RLMCode, RLMOutput, StepFinished, StepStarted
 from fleet_rlm.rlm.sanitize import truncate_public_text
 from fleet_rlm.rlm.tool_observer import ToolEventView, observe_tool
@@ -116,8 +124,8 @@ class DaytonaCodeInterpreter:
         self._backend = backend
         self._tools: dict[str, Callable[..., Any]] = dict(tools or {})
         self._bound_tools: dict[str, Callable[..., Any]] = {}
-        self.output_fields: list[dict[str, Any]] | None = list(output_fields) if output_fields is not None else None
-        self._tools_registered = False
+        self.output_fields: list[dict[str, Any]] | None = copy_output_fields(output_fields)
+        self._tools_registered = initial_tools_registered()
         self._started = False
         self._shutdown = False
         self._http_broker: DaytonaHttpToolBroker | None = None
@@ -150,8 +158,8 @@ class DaytonaCodeInterpreter:
             return
 
     def _public_output(self, result: Any) -> str:
-        if isinstance(result, FinalOutput):
-            return "FINAL submitted"
+        if is_final_output(result):
+            return PUBLIC_FINAL_OUTPUT_LABEL
         if isinstance(result, _RepairFeedback):
             return "Execution error"
         return truncate_public_text(str(result or ""), max_len=self._observation_max_chars)
@@ -239,21 +247,22 @@ class DaytonaCodeInterpreter:
         if isinstance(backend, InProcessInterpreterBackend):
             backend.bind_host_tools(tools)
             backend.ensure_submit(self.output_fields)
-            self._tools_registered = True
+            self._tools_registered = mark_tools_registered()
             return
         if not isinstance(backend, _SandboxCodeInterpreterBackend):
-            self._tools_registered = True
+            self._tools_registered = mark_tools_registered()
             return
-        # dspy.RLM sets `_tools_registered = False` before each inject so fresh
-        # llm_query callables bind; skip only when already registered this cycle.
-        if self._tools_registered and self._http_broker is not None:
+        if not needs_tool_reinjection(
+            tools_registered=self._tools_registered,
+            http_broker_ready=self._http_broker is not None,
+        ):
             return
         if self._http_broker is None:
             self._http_broker = DaytonaHttpToolBroker(sandbox=backend.sandbox)
             self._http_broker.ensure_started()
         self._http_broker.register_tools(tools)
         backend.run(self._http_broker.submit_setup_code(self.output_fields))
-        self._tools_registered = True
+        self._tools_registered = mark_tools_registered()
 
     def _execute_with_http_broker(
         self,
@@ -290,11 +299,11 @@ class DaytonaCodeInterpreter:
             if raw.error:
                 return _RepairFeedback(f"[Error] {sanitize_provider_message(raw.error)}")
             if raw.final is not None:
-                return FinalOutput(raw.final)
+                return wrap_final_output(raw.final)
             return raw.stdout
         final = extract_final_payload(str(raw))
         if final is not None:
-            return FinalOutput(final)
+            return wrap_final_output(final)
         return raw
 
 

--- a/src/fleet_rlm/daytona/workspace_fs.py
+++ b/src/fleet_rlm/daytona/workspace_fs.py
@@ -2,18 +2,32 @@
 
 from __future__ import annotations
 
+import base64
 import json
+from collections.abc import Mapping
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Any, cast
 
-from fleet_rlm.files.workspace_models import WorkspaceEntry
+from fleet_rlm.files.workspace_models import WorkspaceEntry, WorkspaceListResult
 from fleet_rlm.files.workspace_validation import normalize_workspace_path
 
 
-def _is_not_found(exc: BaseException) -> bool:
-    if isinstance(exc, FileNotFoundError):
-        return True
-    return getattr(exc, "status_code", None) == 404
+def _entry_from_payload(raw: Mapping[str, object]) -> WorkspaceEntry:
+    byte_size = raw.get("byte_size")
+    modified_at = raw.get("modified_at")
+    parsed_byte_size: int | None
+    if byte_size is None:
+        parsed_byte_size = None
+    elif isinstance(byte_size, int):
+        parsed_byte_size = byte_size
+    else:
+        parsed_byte_size = int(str(byte_size))
+    return WorkspaceEntry(
+        path=str(raw["path"]),
+        kind="directory" if raw.get("kind") == "directory" else "file",
+        byte_size=parsed_byte_size,
+        modified_at=str(modified_at) if modified_at else None,
+    )
 
 
 class DaytonaSessionWorkspaceFS:
@@ -51,55 +65,65 @@ class DaytonaSessionWorkspaceFS:
     def root(self) -> str:
         return self._root
 
-    def list_entries(self, path: str, *, limit: int = 100) -> tuple[WorkspaceEntry, ...]:
+    def list_entries(self, path: str, *, limit: int = 100) -> WorkspaceListResult:
         relative = normalize_workspace_path(path, allow_root=True)
         if limit < 1 or limit > 100:
             raise ValueError("workspace list limit must be between 1 and 100")
-        self._guard(relative, allow_missing=relative == ".")
-        absolute = self._absolute(relative)
-        info = self._info(absolute)
-        if info is None:
-            if relative == ".":
-                return ()
-            raise FileNotFoundError(relative)
-        if not bool(getattr(info, "is_dir", False)):
-            raise NotADirectoryError(relative)
-        values = self._sandbox.fs.list_files(absolute, depth=1)
-        entries = [self._entry_from_info(item, parent=relative) for item in values]
-        return tuple(sorted(entries, key=lambda item: item.path)[:limit])
+        payload = self._atomic_run(
+            operation="list",
+            relative=relative,
+            allow_missing=relative == ".",
+            max_bytes=0,
+            limit=limit,
+            overwrite=False,
+            content_b64="",
+        )
+        raw_entries = payload.get("entries")
+        entries: list[WorkspaceEntry] = []
+        if isinstance(raw_entries, list):
+            for item in raw_entries:
+                if isinstance(item, dict):
+                    entries.append(_entry_from_payload(cast(Mapping[str, object], item)))
+        return WorkspaceListResult(entries=tuple(entries), truncated=bool(payload.get("truncated")))
 
     def stat(self, path: str) -> WorkspaceEntry | None:
         relative = normalize_workspace_path(path, allow_root=True)
-        self._guard(relative, allow_missing=True)
-        info = self._info(self._absolute(relative))
-        if info is None:
+        payload = self._atomic_run(
+            operation="stat",
+            relative=relative,
+            allow_missing=True,
+            max_bytes=0,
+            limit=0,
+            overwrite=False,
+            content_b64="",
+        )
+        if payload.get("entry") is None:
             if relative == ".":
                 return WorkspaceEntry(".", "directory", None, None)
             return None
-        return self._entry_from_info(info, exact=relative)
+        entry = payload["entry"]
+        if not isinstance(entry, dict):
+            raise RuntimeError("workspace stat returned invalid entry")
+        return _entry_from_payload(cast(Mapping[str, object], entry))
 
     def read_text(self, path: str, *, max_bytes: int) -> str:
         relative = normalize_workspace_path(path)
         bound = min(self._max_file_bytes, int(max_bytes))
         if bound < 1:
             raise ValueError("workspace read bound must be positive")
-        self._guard(relative, allow_missing=False)
-        absolute = self._absolute(relative)
-        info = self._info(absolute)
-        if info is None:
-            raise FileNotFoundError(relative)
-        if bool(getattr(info, "is_dir", False)):
-            raise IsADirectoryError(relative)
-        if int(getattr(info, "size", 0)) > bound:
-            raise ValueError("workspace file exceeds read bound")
-        raw = self._sandbox.fs.download_file(absolute)
-        data = raw if isinstance(raw, bytes) else bytes(raw)
-        if len(data) > bound:
-            raise ValueError("workspace file exceeds read bound")
-        try:
-            return data.decode("utf-8", errors="strict")
-        except UnicodeDecodeError as exc:
-            raise ValueError("workspace file is not valid UTF-8") from exc
+        payload = self._atomic_run(
+            operation="read",
+            relative=relative,
+            allow_missing=False,
+            max_bytes=bound,
+            limit=0,
+            overwrite=False,
+            content_b64="",
+        )
+        content = payload.get("content")
+        if not isinstance(content, str):
+            raise RuntimeError("workspace read returned invalid content")
+        return content
 
     def write_text(self, path: str, content: str, *, overwrite: bool) -> WorkspaceEntry:
         relative = normalize_workspace_path(path)
@@ -108,111 +132,166 @@ class DaytonaSessionWorkspaceFS:
         data = content.encode("utf-8")
         if len(data) > self._max_file_bytes:
             raise ValueError("workspace file exceeds maximum size")
-        self._guard(relative, allow_missing=True)
-        absolute = self._absolute(relative)
-        current = self._info(absolute)
-        if current is not None:
-            if bool(getattr(current, "is_dir", False)):
-                raise IsADirectoryError(relative)
-            if not overwrite:
-                raise FileExistsError(relative)
-        self._ensure_parents(relative)
-        self._guard(relative, allow_missing=True)
-        self._sandbox.fs.upload_file(data, absolute)
-        info = self._info(absolute)
-        if info is None:
-            raise RuntimeError("workspace write did not create a file")
-        return self._entry_from_info(info, exact=relative)
+        payload = self._atomic_run(
+            operation="write",
+            relative=relative,
+            allow_missing=True,
+            max_bytes=self._max_file_bytes,
+            limit=0,
+            overwrite=overwrite,
+            content_b64=base64.b64encode(data).decode("ascii"),
+        )
+        entry = payload.get("entry")
+        if not isinstance(entry, dict):
+            raise RuntimeError("workspace write returned invalid entry")
+        return _entry_from_payload(cast(Mapping[str, object], entry))
 
     def _absolute(self, relative: str) -> str:
         return self._root if relative == "." else str(PurePosixPath(self._root) / relative)
 
-    def _info(self, absolute: str) -> Any | None:
-        try:
-            return self._sandbox.fs.get_file_info(absolute)
-        except Exception as exc:  # noqa: BLE001 - SDK file-not-found is typed at runtime
-            if _is_not_found(exc):
-                return None
-            raise
-
-    def _ensure_parents(self, relative: str) -> None:
-        root_info = self._info(self._root)
-        if root_info is None:
-            self._sandbox.fs.create_folder(self._root, "700")
-        elif not bool(getattr(root_info, "is_dir", False)):
-            raise NotADirectoryError(".")
-        current = PurePosixPath(self._root)
-        for part in PurePosixPath(relative).parent.parts:
-            if part == ".":
-                continue
-            current /= part
-            absolute = str(current)
-            info = self._info(absolute)
-            if info is None:
-                self._sandbox.fs.create_folder(absolute, "700")
-            elif not bool(getattr(info, "is_dir", False)):
-                raise NotADirectoryError(str(current.relative_to(self._root)))
-
-    def _entry_from_info(
+    def _atomic_run(
         self,
-        info: Any,
         *,
-        exact: str | None = None,
-        parent: str | None = None,
-    ) -> WorkspaceEntry:
-        if exact is not None:
-            relative = exact
-        else:
-            name = str(getattr(info, "name", ""))
-            relative = name if parent in {None, "."} else f"{parent}/{name}"
-            relative = normalize_workspace_path(relative)
-        is_dir = bool(getattr(info, "is_dir", False))
-        modified_at = getattr(info, "modified_at", None) or getattr(info, "mod_time", None)
-        return WorkspaceEntry(
-            path=relative,
-            kind="directory" if is_dir else "file",
-            byte_size=None if is_dir else int(getattr(info, "size", 0)),
-            modified_at=str(modified_at) if modified_at else None,
-        )
-
-    def _guard(self, relative: str, *, allow_missing: bool) -> None:
+        operation: str,
+        relative: str,
+        allow_missing: bool,
+        max_bytes: int,
+        limit: int,
+        overwrite: bool,
+        content_b64: str,
+    ) -> dict[str, object]:
         target = self._absolute(relative)
-        code = "\n".join(
-            (
-                "import json, os, stat",
-                f"volume_root = {self._volume_root!r}",
-                f"root = {self._root!r}",
-                f"target = {target!r}",
-                f"allow_missing = {allow_missing!r}",
-                "safe = True",
-                "reason = None",
-                "try:",
-                "    volume_real = os.path.realpath(volume_root)",
-                "    target_real = os.path.realpath(target)",
-                "    if os.path.commonpath([volume_root, root]) != volume_root:",
-                "        safe, reason = False, 'root_escape'",
-                "    elif os.path.commonpath([root, target]) != root:",
-                "        safe, reason = False, 'root_escape'",
-                "    elif os.path.commonpath([volume_real, target_real]) != volume_real:",
-                "        safe, reason = False, 'root_escape'",
-                "    else:",
-                "        current = volume_root",
-                "        relative_parts = os.path.relpath(target, volume_root).split(os.sep)",
-                "        for part in ([] if relative_parts == ['.'] else relative_parts):",
-                "            current = os.path.join(current, part)",
-                "            if not os.path.lexists(current):",
-                "                if allow_missing:",
-                "                    break",
-                "                safe, reason = False, 'missing'",
-                "                break",
-                "            if stat.S_ISLNK(os.lstat(current).st_mode):",
-                "                safe, reason = False, 'symlink'",
-                "                break",
-                "except Exception:",
-                "    safe, reason = False, 'validation_failed'",
-                "print(json.dumps({'safe': safe, 'reason': reason}))",
-            )
-        )
+        code = "\n".join((
+            "import base64, heapq, json, os, stat, time",
+            f"volume_root = {self._volume_root!r}",
+            f"root = {self._root!r}",
+            f"target = {target!r}",
+            f"relative = {relative!r}",
+            f"allow_missing = {allow_missing!r}",
+            f"operation = {operation!r}",
+            f"max_bytes = {int(max_bytes)!r}",
+            f"limit = {int(limit)!r}",
+            f"overwrite = {overwrite!r}",
+            f"content_b64 = {content_b64!r}",
+            "def respond(payload):",
+            "    print(json.dumps(payload))",
+            "    raise SystemExit(0)",
+            "def fail(error, **extra):",
+            "    respond({'ok': False, 'error': error, **extra})",
+            "def guard_path(path, *, allow_missing_path):",
+            "    volume_real = os.path.realpath(volume_root)",
+            "    target_real = os.path.realpath(path)",
+            "    if os.path.commonpath([volume_root, root]) != volume_root:",
+            "        fail('unsafe')",
+            "    if os.path.commonpath([root, path]) != root:",
+            "        fail('unsafe')",
+            "    if os.path.commonpath([volume_real, target_real]) != volume_real:",
+            "        fail('unsafe')",
+            "    current = volume_root",
+            "    relative_parts = os.path.relpath(path, volume_root).split(os.sep)",
+            "    for part in ([] if relative_parts == ['.'] else relative_parts):",
+            "        current = os.path.join(current, part)",
+            "        if not os.path.lexists(current):",
+            "            if allow_missing_path:",
+            "                return",
+            "            fail('not_found')",
+            "        if stat.S_ISLNK(os.lstat(current).st_mode):",
+            "            fail('unsafe')",
+            "def ensure_parents(path):",
+            "    parent = os.path.dirname(path)",
+            "    if parent and parent != path:",
+            "        os.makedirs(parent, mode=0o700, exist_ok=True)",
+            "        guard_path(parent, allow_missing_path=False)",
+            "def entry_for(path):",
+            "    info = os.stat(path, follow_symlinks=False)",
+            "    modified_at = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(info.st_mtime))",
+            "    if stat.S_ISDIR(info.st_mode):",
+            "        return {'path': relative if path == target else os.path.relpath(path, root), 'kind': 'directory', 'byte_size': None, 'modified_at': modified_at}",
+            "    return {'path': relative, 'kind': 'file', 'byte_size': info.st_size, 'modified_at': modified_at}",
+            "try:",
+            "    guard_path(target, allow_missing_path=allow_missing)",
+            "    if operation == 'list':",
+            "        if not os.path.lexists(target):",
+            "            if relative == '.':",
+            "                respond({'ok': True, 'entries': [], 'truncated': False})",
+            "            fail('not_found')",
+            "        if stat.S_ISLNK(os.lstat(target).st_mode):",
+            "            fail('unsafe')",
+            "        if not stat.S_ISDIR(os.stat(target, follow_symlinks=False).st_mode):",
+            "            fail('not_directory')",
+            "        entries = []",
+            "        with os.scandir(target) as scanner:",
+            "            candidates = heapq.nsmallest(limit + 1, scanner, key=lambda item: item.name)",
+            "        truncated = len(candidates) > limit",
+            "        for item in candidates[:limit]:",
+            "            child_relative = item.name if relative == '.' else f'{relative}/{item.name}'",
+            "            child_stat = item.stat(follow_symlinks=False)",
+            "            modified_at = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(child_stat.st_mtime))",
+            "            if stat.S_ISDIR(child_stat.st_mode):",
+            "                entries.append({'path': child_relative, 'kind': 'directory', 'byte_size': None, 'modified_at': modified_at})",
+            "            else:",
+            "                entries.append({'path': child_relative, 'kind': 'file', 'byte_size': child_stat.st_size, 'modified_at': modified_at})",
+            "        respond({'ok': True, 'entries': entries, 'truncated': truncated})",
+            "    if operation == 'stat':",
+            "        if not os.path.lexists(target):",
+            "            respond({'ok': True, 'entry': None})",
+            "        if stat.S_ISLNK(os.lstat(target).st_mode):",
+            "            fail('unsafe')",
+            "        respond({'ok': True, 'entry': entry_for(target)})",
+            "    if operation == 'read':",
+            "        if not os.path.lexists(target):",
+            "            fail('not_found')",
+            "        if stat.S_ISDIR(os.stat(target, follow_symlinks=False).st_mode):",
+            "            fail('is_directory')",
+            "        flags = os.O_RDONLY | getattr(os, 'O_NOFOLLOW', 0)",
+            "        fd = os.open(target, flags)",
+            "        try:",
+            "            data = os.read(fd, max_bytes + 1)",
+            "        finally:",
+            "            os.close(fd)",
+            "        if len(data) > max_bytes:",
+            "            fail('read_bound')",
+            "        try:",
+            "            content = data.decode('utf-8')",
+            "        except UnicodeDecodeError:",
+            "            fail('invalid_utf8')",
+            "        respond({'ok': True, 'content': content})",
+            "    if operation == 'write':",
+            "        ensure_parents(target)",
+            "        guard_path(target, allow_missing_path=True)",
+            "        payload = base64.b64decode(content_b64.encode('ascii'))",
+            "        if len(payload) > max_bytes:",
+            "            fail('too_large')",
+            "        if os.path.lexists(target):",
+            "            if stat.S_ISDIR(os.stat(target, follow_symlinks=False).st_mode):",
+            "                fail('is_directory')",
+            "            if not overwrite:",
+            "                fail('conflict')",
+            "            flags = os.O_WRONLY | getattr(os, 'O_NOFOLLOW', 0)",
+            "            fd = os.open(target, flags)",
+            "            try:",
+            "                os.ftruncate(fd, 0)",
+            "                os.write(fd, payload)",
+            "            finally:",
+            "                os.close(fd)",
+            "        else:",
+            "            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)",
+            "            fd = os.open(target, flags, 0o600)",
+            "            try:",
+            "                os.write(fd, payload)",
+            "            finally:",
+            "                os.close(fd)",
+            "        respond({'ok': True, 'entry': entry_for(target)})",
+            "    fail('unsupported')",
+            "except FileNotFoundError:",
+            "    fail('not_found')",
+            "except FileExistsError:",
+            "    fail('conflict')",
+            "except IsADirectoryError:",
+            "    fail('is_directory')",
+            "except OSError:",
+            "    fail('unsafe')",
+        ))
         response = self._sandbox.process.code_run(code)
         if int(getattr(response, "exit_code", 1)) != 0:
             raise ValueError("workspace path is unsafe")
@@ -220,7 +299,21 @@ class DaytonaSessionWorkspaceFS:
             payload = json.loads(str(getattr(response, "result", "")))
         except (TypeError, ValueError) as exc:
             raise ValueError("workspace path is unsafe") from exc
-        if payload.get("safe") is not True:
-            if payload.get("reason") == "missing" and not allow_missing:
+        if payload.get("ok") is not True:
+            error = payload.get("error")
+            if error == "not_found":
                 raise FileNotFoundError(relative)
+            if error == "conflict":
+                raise FileExistsError(relative)
+            if error == "is_directory":
+                raise IsADirectoryError(relative)
+            if error == "not_directory":
+                raise NotADirectoryError(relative)
+            if error == "read_bound":
+                raise ValueError("workspace file exceeds read bound")
+            if error == "too_large":
+                raise ValueError("workspace file exceeds maximum size")
+            if error == "invalid_utf8":
+                raise ValueError("workspace file is not valid UTF-8")
             raise ValueError("workspace path is unsafe")
+        return payload

--- a/src/fleet_rlm/files/workspace_models.py
+++ b/src/fleet_rlm/files/workspace_models.py
@@ -15,6 +15,12 @@ class WorkspaceEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class WorkspaceListResult:
+    entries: tuple[WorkspaceEntry, ...]
+    truncated: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class WorkspaceCapabilityMetadata:
     available: bool
     root: str
@@ -42,7 +48,7 @@ DENO_WORKSPACE_CAPABILITY = WorkspaceCapabilityMetadata(
 
 
 class SessionWorkspaceFS(Protocol):
-    def list_entries(self, path: str, *, limit: int = 100) -> tuple[WorkspaceEntry, ...]: ...
+    def list_entries(self, path: str, *, limit: int = 100) -> WorkspaceListResult: ...
 
     def stat(self, path: str) -> WorkspaceEntry | None: ...
 

--- a/src/fleet_rlm/files/workspace_tools.py
+++ b/src/fleet_rlm/files/workspace_tools.py
@@ -42,12 +42,13 @@ class WorkspaceToolHost:
         def list_workspace_files(path: str = ".", limit: int = 100) -> dict[str, object]:
             """List immediate entries in this Session's durable workspace."""
             try:
-                entries = self._workspace.list_entries(path, limit=limit)
+                listing = self._workspace.list_entries(path, limit=limit)
                 return {
                     "ok": True,
                     "path": path,
-                    "count": len(entries),
-                    "entries": [_entry(item) for item in entries],
+                    "count": len(listing.entries),
+                    "truncated": listing.truncated,
+                    "entries": [_entry(item) for item in listing.entries],
                 }
             except Exception as exc:  # noqa: BLE001 - tool results never expose internals
                 return _error(exc)
@@ -181,15 +182,13 @@ class WorkspaceToolHost:
             entry = result.get("entry")
             if isinstance(entry, Mapping):
                 entry_values = cast(Mapping[str, JsonValue], entry)
-                projected.update(
-                    {
-                        name: bound_event_text(entry_values[name])
-                        if isinstance(entry_values[name], str)
-                        else entry_values[name]
-                        for name in ("path", "byte_size")
-                        if name in entry_values
-                    }
-                )
+                projected.update({
+                    name: bound_event_text(entry_values[name])
+                    if isinstance(entry_values[name], str)
+                    else entry_values[name]
+                    for name in ("path", "byte_size")
+                    if name in entry_values
+                })
             return projected
 
         def write_input(arguments: Mapping[str, Any]) -> JsonValue:
@@ -199,26 +198,24 @@ class WorkspaceToolHost:
                 "content_chars": len(str(content or "")),
             }
 
-        return MappingProxyType(
-            {
-                "list_workspace_files": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path", "limit"), allow_root=True),
-                    output_projection=lambda result: output(result, ("ok", "error", "path", "count")),
+        return MappingProxyType({
+            "list_workspace_files": ToolEventView(
+                input_projection=lambda arguments: fields(arguments, ("path", "limit"), allow_root=True),
+                output_projection=lambda result: output(result, ("ok", "error", "path", "count", "truncated")),
+            ),
+            "stat_workspace_file": ToolEventView(
+                input_projection=lambda arguments: fields(arguments, ("path",)),
+                output_projection=stat_output,
+            ),
+            "read_workspace_text": ToolEventView(
+                input_projection=lambda arguments: fields(arguments, ("path", "max_chars")),
+                output_projection=lambda result: output(
+                    result,
+                    ("ok", "error", "path", "chars", "byte_size"),
                 ),
-                "stat_workspace_file": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path",)),
-                    output_projection=stat_output,
-                ),
-                "read_workspace_text": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path", "max_chars")),
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "error", "path", "chars", "byte_size"),
-                    ),
-                ),
-                "write_workspace_text": ToolEventView(
-                    input_projection=write_input,
-                    output_projection=lambda result: output(result, ("ok", "error", "path", "byte_size")),
-                ),
-            }
-        )
+            ),
+            "write_workspace_text": ToolEventView(
+                input_projection=write_input,
+                output_projection=lambda result: output(result, ("ok", "error", "path", "byte_size")),
+            ),
+        })

--- a/src/fleet_rlm/rlm/dspy_interpreter_contract.py
+++ b/src/fleet_rlm/rlm/dspy_interpreter_contract.py
@@ -1,0 +1,69 @@
+"""Pinned DSPy 3.3.0b1 interpreter inject and FinalOutput contract.
+
+Public ``CodeInterpreter`` only requires ``tools``, ``start``, ``execute``, and
+``shutdown``. Stock ``dspy.RLM`` additionally probes custom interpreters during
+``_inject_execution_context``:
+
+1. ``interpreter.tools.update(execution_tools)``
+2. If ``hasattr(interpreter, "output_fields")``: assign signature output metadata
+3. If ``hasattr(interpreter, "_tools_registered")``: set ``_tools_registered = False``
+
+Fleet adapters must re-register host tools and SUBMIT when that flag is false (or
+the HTTP broker has not yet been started for this reinjection cycle).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dspy.primitives.code_interpreter import FinalOutput
+
+PUBLIC_FINAL_OUTPUT_LABEL = "FINAL submitted"
+
+
+def copy_output_fields(
+    output_fields: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Return a defensive copy of signature output metadata for interpreter state."""
+    if output_fields is None:
+        return None
+    return list(output_fields)
+
+
+def initial_tools_registered() -> bool:
+    """Return the inject-cycle registration flag before the first reinjection."""
+    return False
+
+
+def needs_tool_reinjection(*, tools_registered: bool, http_broker_ready: bool) -> bool:
+    """Return whether the adapter must register tools and SUBMIT for this cycle."""
+    if not tools_registered:
+        return True
+    return not http_broker_ready
+
+
+def mark_tools_registered() -> bool:
+    """Return the registration flag after tools and SUBMIT are bound."""
+    return True
+
+
+def wrap_final_output(value: Any) -> FinalOutput:
+    """Wrap a SUBMIT payload in the pinned DSPy terminate signal."""
+    return FinalOutput(value)
+
+
+def is_final_output(value: Any) -> bool:
+    """Return whether ``execute()`` returned a successful SUBMIT terminate signal."""
+    return isinstance(value, FinalOutput)
+
+
+__all__ = [
+    "FinalOutput",
+    "PUBLIC_FINAL_OUTPUT_LABEL",
+    "copy_output_fields",
+    "initial_tools_registered",
+    "is_final_output",
+    "mark_tools_registered",
+    "needs_tool_reinjection",
+    "wrap_final_output",
+]

--- a/src/fleet_rlm/sessions/history_tools.py
+++ b/src/fleet_rlm/sessions/history_tools.py
@@ -13,6 +13,8 @@ from fleet_rlm.rlm.events import JsonValue
 from fleet_rlm.rlm.tool_observer import ToolEventView
 from fleet_rlm.sessions.models import SessionHistory
 
+SESSION_HISTORY_RESULT_BYTE_BUDGET = 262_144
+
 
 @dataclass(frozen=True, slots=True)
 class SessionHistoryToolHost:
@@ -25,20 +27,43 @@ class SessionHistoryToolHost:
             """Read a bounded page of canonical committed Session messages."""
             if offset < 0 or limit < 1 or limit > 20:
                 raise ValueError("Session history request is invalid")
-            page = self.history.messages[offset : offset + limit]
-            return {
+            total = len(self.history.messages)
+            selected: list[dict[str, object]] = []
+            bytes_returned = 0
+            truncated = False
+            skipped_ordinal: int | None = None
+            current_offset = offset
+            while len(selected) < limit and current_offset < total:
+                message = self.history.messages[current_offset]
+                ordinal = current_offset + 1
+                content_bytes = len(message.content.encode("utf-8"))
+                if content_bytes > SESSION_HISTORY_RESULT_BYTE_BUDGET:
+                    skipped_ordinal = ordinal
+                    truncated = True
+                    current_offset += 1
+                    continue
+                if bytes_returned + content_bytes > SESSION_HISTORY_RESULT_BYTE_BUDGET:
+                    truncated = True
+                    break
+                selected.append({
+                    "ordinal": ordinal,
+                    "role": message.role,
+                    "content": message.content,
+                })
+                bytes_returned += content_bytes
+                current_offset += 1
+            result: dict[str, object] = {
                 "offset": offset,
-                "next_offset": offset + len(page),
-                "total": len(self.history.messages),
-                "messages": [
-                    {
-                        "ordinal": offset + index + 1,
-                        "role": message.role,
-                        "content": message.content,
-                    }
-                    for index, message in enumerate(page)
-                ],
+                "next_offset": current_offset,
+                "total": total,
+                "messages": selected,
+                "truncated": truncated,
+                "bytes_returned": bytes_returned,
+                "byte_budget": SESSION_HISTORY_RESULT_BYTE_BUDGET,
             }
+            if skipped_ordinal is not None:
+                result["skipped_ordinal"] = skipped_ordinal
+            return result
 
         return (
             dspy.Tool(
@@ -62,16 +87,24 @@ class SessionHistoryToolHost:
             messages = result.get("messages")
             values = cast(Mapping[str, JsonValue], result)
             projected: dict[str, JsonValue] = {
-                key: values[key] for key in ("offset", "next_offset", "total") if key in values
+                key: values[key]
+                for key in (
+                    "offset",
+                    "next_offset",
+                    "total",
+                    "truncated",
+                    "bytes_returned",
+                    "byte_budget",
+                    "skipped_ordinal",
+                )
+                if key in values
             }
             projected["message_count"] = len(messages) if isinstance(messages, list) else 0
             return projected
 
-        return MappingProxyType(
-            {
-                "read_session_history": ToolEventView(
-                    input_projection=project_input,
-                    output_projection=project_output,
-                )
-            }
-        )
+        return MappingProxyType({
+            "read_session_history": ToolEventView(
+                input_projection=project_input,
+                output_projection=project_output,
+            )
+        })

--- a/src/fleet_rlm/skills/skills/workspace-files/SKILL.md
+++ b/src/fleet_rlm/skills/skills/workspace-files/SKILL.md
@@ -13,7 +13,7 @@ Use Fleet's bound tools instead of inventing host paths. The Turn context report
 
 ## Session Workspace
 
-Workspace paths are canonical POSIX-relative paths rooted at `.`. List or inspect before writing, use `overwrite=true` only when replacement is intended, and check each tool's `ok` result.
+Workspace paths are canonical POSIX-relative paths rooted at `.`. List or inspect before writing, use `overwrite=true` only when replacement is intended, and check each tool's `ok` result. Session Workspace is append/update-only: there is no delete Tool; replace content with `write_workspace_text(..., overwrite=True)`.
 
 ```python
 listing = list_workspace_files(path=".", limit=100)

--- a/src/fleet_rlm/skills/skills/workspace-files/references/filesystem-contract.md
+++ b/src/fleet_rlm/skills/skills/workspace-files/references/filesystem-contract.md
@@ -40,4 +40,6 @@ Session and Run directory names are UUID-shaped. The containers exist at acquisi
 
 Workspace, Session, Run, Attachment, and Artifact identities are UUID-shaped opaque values. The workspace tools accept relative paths such as `notes/analysis.md`. Do not pass absolute paths, backslashes, empty segments, `.` or `..` components, repeated slashes, trailing slashes, or the reserved `.fleet` component. Use `.` only as the root argument to `list_workspace_files`.
 
+Session Workspace tools are append/update-only. Fleet exposes list, stat, read, and write (with `overwrite`); there is no delete Tool. To replace a file, call `write_workspace_text(..., overwrite=True)`.
+
 REPL variables are per-Run and are not durable. Authorized clients can retrieve committed Artifact bytes through the Artifact content API, but host storage locations and raw sandbox paths must not appear in client-facing answers.

--- a/tests/contracts/backend/test_host_tool_submit_binding.py
+++ b/tests/contracts/backend/test_host_tool_submit_binding.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from dspy.primitives.code_interpreter import FinalOutput
-
 from fleet_rlm.daytona.in_process import InProcessInterpreterBackend
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter
 from fleet_rlm.daytona.submit import extract_final_payload, remote_submit_setup_code
+from fleet_rlm.rlm.dspy_contract import RLMOptions, build_native_rlm
+from fleet_rlm.rlm.dspy_interpreter_contract import FinalOutput
+from fleet_rlm.rlm.signature import FleetRLMSignature
 
 
 def test_interpreter_declares_rlm_injection_surface() -> None:
@@ -33,3 +34,16 @@ def test_final_output_type_is_dspy_final_output() -> None:
     interp.start()
     result = interp.execute('SUBMIT(answer="ok")')
     assert type(result) is FinalOutput
+
+
+def test_stock_rlm_resets_tools_registered_on_inject() -> None:
+    """Installed DSPy must clear _tools_registered on each inject cycle."""
+    interp = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
+    interp._tools_registered = True  # noqa: SLF001 - simulate prior reinjection cycle
+    rlm = build_native_rlm(
+        signature=FleetRLMSignature,
+        options=RLMOptions(max_iterations=1),
+        interpreter=interp,
+    )
+    rlm._inject_execution_context(interp, {})  # noqa: SLF001 - pinned DSPy inject contract
+    assert interp._tools_registered is False  # noqa: SLF001 - Fleet reinjects when flag is false

--- a/tests/contracts/backend/test_rlm_history_retrieval.py
+++ b/tests/contracts/backend/test_rlm_history_retrieval.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 import dspy
 import pytest
 
+from fleet_rlm.sessions.history_tools import SESSION_HISTORY_RESULT_BYTE_BUDGET
+
 
 @pytest.mark.asyncio
 async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -> None:
@@ -24,12 +26,10 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
     from fleet_rlm.skills.capabilities import TurnCapabilityBlueprint
 
     older_detail = "project codename is cobalt-orchid"
-    history = SessionHistory(
-        (
-            HistoryMessage("user", older_detail),
-            *(HistoryMessage("assistant", f"recent-{index}") for index in range(8)),
-        )
-    )
+    history = SessionHistory((
+        HistoryMessage("user", older_detail),
+        *(HistoryMessage("assistant", f"recent-{index}") for index in range(8)),
+    ))
     session_id = uuid4()
     manifest = build_session_context_manifest(session_id, 4, history)
     assert older_detail not in str(manifest.to_input())
@@ -95,3 +95,94 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
     assert stream.outcome.succeeded
     assert stream.outcome.prediction is not None
     assert stream.outcome.prediction.display_text == older_detail
+
+
+@pytest.mark.asyncio
+async def test_native_rlm_continues_history_across_truncated_pages() -> None:
+    from fleet_rlm.chat.session_context import build_session_context_manifest
+    from fleet_rlm.daytona.in_process import InProcessInterpreterBackend
+    from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter
+    from fleet_rlm.rlm.context import RLMExecutionContext
+    from fleet_rlm.rlm.dspy_contract import RLMOptions
+    from fleet_rlm.rlm.factory import RLMFactory
+    from fleet_rlm.rlm.runner import RLMRunner
+    from fleet_rlm.sessions.history_tools import SessionHistoryToolHost
+    from fleet_rlm.sessions.models import HistoryMessage, SessionHistory, TurnAccess
+    from fleet_rlm.skills.capabilities import TurnCapabilityBlueprint
+
+    chunk = "y" * 150_000
+    history = SessionHistory((
+        HistoryMessage("user", chunk),
+        HistoryMessage("assistant", chunk),
+        HistoryMessage("user", "final-detail"),
+    ))
+    session_id = uuid4()
+    manifest = build_session_context_manifest(session_id, 4, history)
+    (history_tool,) = SessionHistoryToolHost(history).as_tools()
+    first_page = history_tool(offset=0, limit=20)
+    assert first_page["truncated"] is True
+    assert first_page["byte_budget"] == SESSION_HISTORY_RESULT_BYTE_BUDGET
+    second_page = history_tool(offset=first_page["next_offset"], limit=20)
+    assert second_page["messages"][-1]["content"] == "final-detail"
+
+    class Capabilities:
+        blueprint = TurnCapabilityBlueprint(tools=(history_tool,))
+
+        def drain_public_details(self):
+            return ()
+
+        def drain_artifact_candidates(self):
+            return ()
+
+    class Actions:
+        calls = 0
+
+        async def acall(self, **_kwargs):
+            self.calls += 1
+            return dspy.Prediction(
+                reasoning="Retrieve the final detail across truncated pages.",
+                code=(
+                    "first = read_session_history(offset=0, limit=20)\n"
+                    "second = read_session_history(offset=first['next_offset'], limit=20)\n"
+                    "detail = second['messages'][-1]['content']\n"
+                    "print(detail)\n"
+                    "SUBMIT(answer=detail)"
+                ),
+            )
+
+    class Factory:
+        def __init__(self) -> None:
+            self.actions = Actions()
+
+        def create(self, **kwargs):
+            rlm = RLMFactory().create(**kwargs)
+            rlm.generate_action = self.actions
+            return rlm
+
+    async def not_cancelled() -> bool:
+        return False
+
+    context = RLMExecutionContext(
+        run_id=uuid4(),
+        session_id=session_id,
+        access=TurnAccess(uuid4(), uuid4()),
+        request="What is the final detail?",
+        session_context=manifest,
+        models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+        options=RLMOptions(max_iterations=1),
+        deadline=asyncio.get_running_loop().time() + 10,
+        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+        attachments=(),
+        capabilities=Capabilities(),
+        cancellation_requested=not_cancelled,
+        preparation_notices=(),
+    )
+    factory = Factory()
+    stream = RLMRunner(factory=factory).stream(context)
+    _events = [event async for event in stream]
+
+    assert factory.actions.calls == 1
+    assert stream.outcome is not None
+    assert stream.outcome.succeeded
+    assert stream.outcome.prediction is not None
+    assert stream.outcome.prediction.display_text == "final-detail"

--- a/tests/contracts/backend/test_workspace_turn_flow.py
+++ b/tests/contracts/backend/test_workspace_turn_flow.py
@@ -10,7 +10,7 @@ import dspy
 import pytest
 
 from fleet_rlm.chat.session_context import SessionContextManifest
-from fleet_rlm.files.workspace_models import DAYTONA_WORKSPACE_CAPABILITY, WorkspaceEntry
+from fleet_rlm.files.workspace_models import DAYTONA_WORKSPACE_CAPABILITY, WorkspaceEntry, WorkspaceListResult
 from fleet_rlm.files.workspace_tools import WorkspaceToolHost
 from fleet_rlm.rlm.context import RLMExecutionContext
 from fleet_rlm.rlm.dspy_contract import RLMOptions
@@ -25,11 +25,12 @@ class MemoryWorkspace:
         self.session_id = uuid4()
         self.files: dict[str, str] = {}
 
-    def list_entries(self, path: str, *, limit: int = 100) -> tuple[WorkspaceEntry, ...]:
+    def list_entries(self, path: str, *, limit: int = 100) -> WorkspaceListResult:
         del path
-        return tuple(
-            WorkspaceEntry(name, "file", len(content.encode()), None)
-            for name, content in sorted(self.files.items())[:limit]
+        items = sorted(self.files.items())
+        return WorkspaceListResult(
+            entries=tuple(WorkspaceEntry(name, "file", len(content.encode()), None) for name, content in items[:limit]),
+            truncated=len(items) > limit,
         )
 
     def stat(self, path: str) -> WorkspaceEntry | None:

--- a/tests/unit/backend/files/test_workspace_fs.py
+++ b/tests/unit/backend/files/test_workspace_fs.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import json
 from contextlib import redirect_stdout
 from io import StringIO
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -13,94 +12,40 @@ import pytest
 from fleet_rlm.files.workspace_models import WorkspaceEntry
 
 
-class FakeFs:
-    def __init__(self, root: str, *, root_exists: bool = True) -> None:
-        self.directories = {root} if root_exists else set()
-        self.files: dict[str, bytes] = {}
-
-    def get_file_info(self, path: str):
-        if path in self.directories:
-            return SimpleNamespace(
-                path=path,
-                name=PurePosixPath(path).name,
-                is_dir=True,
-                size=0,
-                modified_at="2026-07-16T12:00:00Z",
-            )
-        if path in self.files:
-            return SimpleNamespace(
-                path=path,
-                name=PurePosixPath(path).name,
-                is_dir=False,
-                size=len(self.files[path]),
-                modified_at="2026-07-16T12:00:00Z",
-            )
-        raise FileNotFoundError(path)
-
-    def list_files(self, path: str, depth: int | None = None):
-        assert depth == 1
-        prefix = f"{path.rstrip('/')}/"
-        children = []
-        for candidate in sorted(self.directories | set(self.files)):
-            if candidate == path or not candidate.startswith(prefix):
-                continue
-            relative = candidate[len(prefix) :]
-            if "/" not in relative:
-                children.append(self.get_file_info(candidate))
-        return list(reversed(children))
-
-    def create_folder(self, path: str, mode: str) -> None:
-        assert mode == "700"
-        current = PurePosixPath("/")
-        for part in PurePosixPath(path).parts[1:]:
-            current /= part
-            self.directories.add(str(current))
-
-    def upload_file(self, content: bytes, path: str) -> None:
-        if str(PurePosixPath(path).parent) not in self.directories:
-            raise FileNotFoundError(path)
-        self.files[path] = bytes(content)
-
-    def download_file(self, path: str) -> bytes:
-        if path not in self.files:
-            raise FileNotFoundError(path)
-        return self.files[path]
-
-
-class FakeProcess:
+class LocalProcess:
     def __init__(self) -> None:
-        self.safe = True
         self.calls: list[str] = []
 
     def code_run(self, code: str):
         self.calls.append(code)
-        payload = {"safe": self.safe, "reason": None if self.safe else "symlink"}
-        return SimpleNamespace(exit_code=0, result=json.dumps(payload))
-
-
-class LocalProcess:
-    def code_run(self, code: str):
         output = StringIO()
         with redirect_stdout(output):
-            exec(code, {})  # noqa: S102 - executes only adapter-generated guard code in this test
+            try:
+                exec(code, {})  # noqa: S102 - executes only adapter-generated guard code in this test
+            except SystemExit:
+                pass
         return SimpleNamespace(exit_code=0, result=output.getvalue().strip())
 
 
-def _workspace(*, max_file_bytes: int = 32, root_exists: bool = True):
+def _workspace(tmp_path: Path, *, max_file_bytes: int = 32, root_exists: bool = True):
     from fleet_rlm.daytona.workspace_fs import DaytonaSessionWorkspaceFS
 
-    volume_root = "/home/daytona/fleet"
-    root = "/home/daytona/fleet/sessions/session/workspace"
-    sandbox = SimpleNamespace(fs=FakeFs(root, root_exists=root_exists), process=FakeProcess())
-    return (
-        DaytonaSessionWorkspaceFS(
-            sandbox,
-            volume_root=volume_root,
-            root=root,
-            max_file_bytes=max_file_bytes,
-        ),
+    volume_root = tmp_path / "volume"
+    session_parent = volume_root / "sessions" / "session"
+    root = session_parent / "workspace"
+    if root_exists:
+        root.mkdir(parents=True)
+    else:
+        session_parent.mkdir(parents=True)
+    process = LocalProcess()
+    sandbox = SimpleNamespace(process=process)
+    workspace = DaytonaSessionWorkspaceFS(
         sandbox,
+        volume_root=str(volume_root),
+        root=str(root),
+        max_file_bytes=max_file_bytes,
     )
+    return workspace, sandbox, root, process
 
 
 def test_rejects_workspace_root_outside_trusted_volume() -> None:
@@ -115,24 +60,38 @@ def test_rejects_workspace_root_outside_trusted_volume() -> None:
         )
 
 
-def test_lists_immediate_entries_deterministically_with_limit() -> None:
-    workspace, sandbox = _workspace()
-    sandbox.fs.directories.add(f"{workspace.root}/notes")
-    sandbox.fs.files[f"{workspace.root}/z.txt"] = b"z"
-    sandbox.fs.files[f"{workspace.root}/a.txt"] = b"a"
-    sandbox.fs.files[f"{workspace.root}/notes/nested.txt"] = b"nested"
+def test_lists_immediate_entries_deterministically_with_limit(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path)
+    (root / "notes").mkdir()
+    (root / "z.txt").write_text("z", encoding="utf-8")
+    (root / "a.txt").write_text("a", encoding="utf-8")
+    (root / "notes" / "nested.txt").write_text("nested", encoding="utf-8")
 
-    entries = workspace.list_entries(".", limit=2)
+    result = workspace.list_entries(".", limit=2)
 
-    assert [(entry.path, entry.kind, entry.byte_size) for entry in entries] == [
+    assert [(entry.path, entry.kind, entry.byte_size) for entry in result.entries] == [
         ("a.txt", "file", 1),
         ("notes", "directory", None),
     ]
+    assert result.truncated is True
 
 
-def test_stat_returns_relative_metadata_or_none() -> None:
-    workspace, sandbox = _workspace()
-    sandbox.fs.files[f"{workspace.root}/note.txt"] = b"hello"
+def test_list_marks_truncated_when_directory_exceeds_limit(tmp_path: Path) -> None:
+    workspace, _sandbox, root, process = _workspace(tmp_path)
+    for index in range(5):
+        (root / f"file-{index}.txt").write_text("x", encoding="utf-8")
+
+    result = workspace.list_entries(".", limit=3)
+
+    assert len(result.entries) == 3
+    assert result.truncated is True
+    assert len(process.calls) == 1
+    assert "heapq.nsmallest" in process.calls[0]
+
+
+def test_stat_returns_relative_metadata_or_none(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path)
+    (root / "note.txt").write_text("hello", encoding="utf-8")
 
     entry = workspace.stat("note.txt")
 
@@ -140,12 +99,12 @@ def test_stat_returns_relative_metadata_or_none() -> None:
     assert entry.path == "note.txt"
     assert entry.kind == "file"
     assert entry.byte_size == 5
-    assert entry.modified_at == "2026-07-16T12:00:00Z"
+    assert entry.modified_at is not None
     assert workspace.stat("missing.txt") is None
 
 
-def test_write_creates_parents_and_honors_overwrite() -> None:
-    workspace, sandbox = _workspace()
+def test_write_creates_parents_and_honors_overwrite(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path)
 
     created = workspace.write_text("notes/decision.md", "first", overwrite=False)
 
@@ -156,31 +115,33 @@ def test_write_creates_parents_and_honors_overwrite() -> None:
         workspace.write_text("notes/decision.md", "second", overwrite=False)
     replaced = workspace.write_text("notes/decision.md", "second", overwrite=True)
     assert replaced.byte_size == 6
-    assert sandbox.fs.files[f"{workspace.root}/notes/decision.md"] == b"second"
+    assert (root / "notes" / "decision.md").read_text(encoding="utf-8") == "second"
 
 
-def test_first_write_creates_missing_workspace_root() -> None:
-    workspace, sandbox = _workspace(root_exists=False)
+def test_first_write_creates_missing_workspace_root(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path, root_exists=False)
 
     workspace.write_text("notes/decision.md", "first", overwrite=False)
 
-    assert workspace.root in sandbox.fs.directories
-    assert sandbox.fs.files[f"{workspace.root}/notes/decision.md"] == b"first"
+    assert root.exists()
+    assert (root / "notes" / "decision.md").read_text(encoding="utf-8") == "first"
 
 
-def test_first_root_level_write_creates_missing_workspace_root() -> None:
-    workspace, sandbox = _workspace(root_exists=False)
+def test_first_root_level_write_creates_missing_workspace_root(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path, root_exists=False)
 
     workspace.write_text("decision.md", "first", overwrite=False)
 
-    assert workspace.root in sandbox.fs.directories
-    assert sandbox.fs.files[f"{workspace.root}/decision.md"] == b"first"
+    assert root.exists()
+    assert (root / "decision.md").read_text(encoding="utf-8") == "first"
 
 
-def test_missing_workspace_root_behaves_as_an_empty_virtual_directory() -> None:
-    workspace, _sandbox = _workspace(root_exists=False)
+def test_missing_workspace_root_behaves_as_an_empty_virtual_directory(tmp_path: Path) -> None:
+    workspace, _sandbox, _root, _process = _workspace(tmp_path, root_exists=False)
 
-    assert workspace.list_entries(".") == ()
+    listing = workspace.list_entries(".")
+    assert listing.entries == ()
+    assert listing.truncated is False
     assert workspace.stat(".") == WorkspaceEntry(".", "directory", None, None)
 
 
@@ -191,36 +152,38 @@ def test_real_guard_allows_a_missing_virtual_workspace_root(tmp_path: Path) -> N
     volume_root.mkdir()
     root = volume_root / "sessions" / "session" / "workspace"
     workspace = DaytonaSessionWorkspaceFS(
-        SimpleNamespace(fs=FakeFs(str(root), root_exists=False), process=LocalProcess()),
+        SimpleNamespace(process=LocalProcess()),
         volume_root=str(volume_root),
         root=str(root),
         max_file_bytes=32,
     )
 
-    assert workspace.list_entries(".") == ()
+    listing = workspace.list_entries(".")
+    assert listing.entries == ()
+    assert listing.truncated is False
     assert workspace.stat(".") == WorkspaceEntry(".", "directory", None, None)
 
 
-def test_enforces_write_and_read_byte_bounds_and_strict_utf8() -> None:
-    workspace, sandbox = _workspace(max_file_bytes=4)
+def test_enforces_write_and_read_byte_bounds_and_strict_utf8(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path, max_file_bytes=4)
 
     with pytest.raises(ValueError, match="size"):
         workspace.write_text("large.txt", "12345", overwrite=False)
 
-    path = f"{workspace.root}/invalid.txt"
-    sandbox.fs.files[path] = b"\xff"
+    path = root / "invalid.txt"
+    path.write_bytes(b"\xff")
     with pytest.raises(ValueError, match="UTF-8"):
         workspace.read_text("invalid.txt", max_bytes=4)
 
-    sandbox.fs.files[path] = b"12345"
+    path.write_bytes(b"12345")
     with pytest.raises(ValueError, match="read bound"):
         workspace.read_text("invalid.txt", max_bytes=4)
 
 
-def test_rejects_directories_as_text_and_files_as_list_roots() -> None:
-    workspace, sandbox = _workspace()
-    sandbox.fs.directories.add(f"{workspace.root}/notes")
-    sandbox.fs.files[f"{workspace.root}/note.txt"] = b"hello"
+def test_rejects_directories_as_text_and_files_as_list_roots(tmp_path: Path) -> None:
+    workspace, _sandbox, root, _process = _workspace(tmp_path)
+    (root / "notes").mkdir()
+    (root / "note.txt").write_text("hello", encoding="utf-8")
 
     with pytest.raises(IsADirectoryError):
         workspace.read_text("notes", max_bytes=32)
@@ -228,16 +191,32 @@ def test_rejects_directories_as_text_and_files_as_list_roots() -> None:
         workspace.list_entries("note.txt")
 
 
-def test_provider_guard_blocks_symlink_or_root_escape_before_io() -> None:
-    workspace, sandbox = _workspace()
-    sandbox.process.safe = False
+def test_atomic_write_rejects_symlink_target_before_io(tmp_path: Path) -> None:
+    workspace, _sandbox, root, process = _workspace(tmp_path)
+    secret = root / "secret.txt"
+    secret.write_text("private", encoding="utf-8")
+    alias = root / "notes"
+    alias.symlink_to(secret)
 
     with pytest.raises(ValueError, match="unsafe"):
         workspace.write_text("notes/decision.md", "private", overwrite=False)
 
-    assert sandbox.fs.files == {}
-    assert "realpath" in sandbox.process.calls[0]
-    assert "lstat" in sandbox.process.calls[0]
+    assert not (root / "notes" / "decision.md").exists()
+    assert len(process.calls) == 1
+    assert "O_NOFOLLOW" in process.calls[0] or "os.open" in process.calls[0]
+
+
+def test_atomic_read_uses_single_code_run_and_rejects_symlink_target(tmp_path: Path) -> None:
+    workspace, _sandbox, root, process = _workspace(tmp_path)
+    secret = root / "secret.txt"
+    secret.write_text("private", encoding="utf-8")
+    alias = root / "note.txt"
+    alias.symlink_to(secret)
+
+    with pytest.raises(ValueError, match="unsafe"):
+        workspace.read_text("note.txt", max_bytes=32)
+
+    assert len(process.calls) == 1
 
 
 @pytest.mark.parametrize("link_kind", ["session_ancestor", "workspace_root", "descendant", "target"])
@@ -279,7 +258,7 @@ def test_provider_guard_rejects_symlinks_below_the_trusted_volume(
         (root / "decision.md").symlink_to(target)
         relative = "decision.md"
     workspace = DaytonaSessionWorkspaceFS(
-        SimpleNamespace(fs=SimpleNamespace(), process=LocalProcess()),
+        SimpleNamespace(process=LocalProcess()),
         volume_root=str(volume_root),
         root=str(root),
         max_file_bytes=32,

--- a/tests/unit/backend/files/test_workspace_tools.py
+++ b/tests/unit/backend/files/test_workspace_tools.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 
 import dspy
 
-from fleet_rlm.files.workspace_models import WorkspaceEntry
+from fleet_rlm.files.workspace_models import WorkspaceEntry, WorkspaceListResult
 from fleet_rlm.rlm.tool_observer import observe_tool
 
 
@@ -14,11 +14,15 @@ class FakeWorkspace:
     def __init__(self) -> None:
         self.files: dict[str, str] = {}
 
-    def list_entries(self, path: str, *, limit: int = 100) -> tuple[WorkspaceEntry, ...]:
+    def list_entries(self, path: str, *, limit: int = 100) -> WorkspaceListResult:
         del path
-        return tuple(
-            WorkspaceEntry(name, "file", len(content.encode()), "2026-07-16T12:00:00Z")
-            for name, content in sorted(self.files.items())[:limit]
+        items = sorted(self.files.items())
+        return WorkspaceListResult(
+            entries=tuple(
+                WorkspaceEntry(name, "file", len(content.encode()), "2026-07-16T12:00:00Z")
+                for name, content in items[:limit]
+            ),
+            truncated=len(items) > limit,
         )
 
     def stat(self, path: str) -> WorkspaceEntry | None:
@@ -96,6 +100,7 @@ def test_round_trips_text_with_bounded_json_results() -> None:
         "modified_at": "2026-07-16T12:00:00Z",
     }
     assert listed["count"] == 1
+    assert listed["truncated"] is False
     assert listed["entries"][0]["path"] == "notes/decision.md"
     assert stated["entry"]["byte_size"] == 16
     assert read == {
@@ -137,7 +142,7 @@ def test_workspace_event_views_expose_metadata_without_file_bodies_or_entries() 
         "content_chars": 22,
     }
     assert observed[1].output == {"ok": True, "path": "notes/private.md", "byte_size": 22}
-    assert observed[3].output == {"ok": True, "path": ".", "count": 1}
+    assert observed[3].output == {"ok": True, "path": ".", "count": 1, "truncated": False}
     assert observed[5].output == {
         "ok": True,
         "path": "notes/private.md",
@@ -184,7 +189,7 @@ def test_returns_stable_error_codes_without_exception_details() -> None:
 def test_entry_serialization_does_not_mutate_domain_value() -> None:
     entry = WorkspaceEntry("notes", "directory", None, None)
     workspace, tools = _tools()
-    workspace.list_entries = lambda _path, limit=100: (entry,)  # type: ignore[method-assign]
+    workspace.list_entries = lambda _path, limit=100: WorkspaceListResult((entry,), truncated=False)  # type: ignore[method-assign]
 
     result = tools["list_workspace_files"](path=".", limit=1)
 

--- a/tests/unit/backend/rlm/test_dspy_interpreter_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_interpreter_contract.py
@@ -1,0 +1,48 @@
+"""Contracts for Fleet's pinned DSPy interpreter inject seam."""
+
+from __future__ import annotations
+
+
+def test_wrap_and_is_final_output_round_trip() -> None:
+    from fleet_rlm.rlm.dspy_interpreter_contract import (
+        FinalOutput,
+        is_final_output,
+        wrap_final_output,
+    )
+
+    wrapped = wrap_final_output({"answer": "ok"})
+    assert isinstance(wrapped, FinalOutput)
+    assert wrapped.output == {"answer": "ok"}
+    assert is_final_output(wrapped)
+    assert not is_final_output("stdout")
+
+
+def test_copy_output_fields_defensive_copy() -> None:
+    from fleet_rlm.rlm.dspy_interpreter_contract import copy_output_fields
+
+    fields = [{"name": "answer", "type": "str"}]
+    copied = copy_output_fields(fields)
+    assert copied == fields
+    assert copied is not fields
+    assert copy_output_fields(None) is None
+
+
+def test_needs_tool_reinjection_matches_inject_cycle() -> None:
+    from fleet_rlm.rlm.dspy_interpreter_contract import (
+        initial_tools_registered,
+        mark_tools_registered,
+        needs_tool_reinjection,
+    )
+
+    assert initial_tools_registered() is False
+    assert mark_tools_registered() is True
+    assert needs_tool_reinjection(tools_registered=False, http_broker_ready=False) is True
+    assert needs_tool_reinjection(tools_registered=False, http_broker_ready=True) is True
+    assert needs_tool_reinjection(tools_registered=True, http_broker_ready=False) is True
+    assert needs_tool_reinjection(tools_registered=True, http_broker_ready=True) is False
+
+
+def test_public_final_output_label_is_stable() -> None:
+    from fleet_rlm.rlm.dspy_interpreter_contract import PUBLIC_FINAL_OUTPUT_LABEL
+
+    assert PUBLIC_FINAL_OUTPUT_LABEL == "FINAL submitted"

--- a/tests/unit/backend/sessions/test_history_tool.py
+++ b/tests/unit/backend/sessions/test_history_tool.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 import pytest
 
 from fleet_rlm.rlm.tool_observer import observe_tool
+from fleet_rlm.sessions.history_tools import SESSION_HISTORY_RESULT_BYTE_BUDGET
+
+
+def _budget_fields(*, truncated: bool, bytes_returned: int, skipped_ordinal: int | None = None) -> dict[str, object]:
+    fields: dict[str, object] = {
+        "truncated": truncated,
+        "bytes_returned": bytes_returned,
+        "byte_budget": SESSION_HISTORY_RESULT_BYTE_BUDGET,
+    }
+    if skipped_ordinal is not None:
+        fields["skipped_ordinal"] = skipped_ordinal
+    return fields
 
 
 def test_history_tool_pages_canonical_messages_with_stable_ordinals() -> None:
@@ -25,7 +37,8 @@ def test_history_tool_pages_canonical_messages_with_stable_ordinals() -> None:
         "offset": {"type": "integer", "minimum": 0},
         "limit": {"type": "integer", "minimum": 1, "maximum": 20},
     }
-    assert tool(offset=0, limit=2) == {
+    first_page = tool(offset=0, limit=2)
+    assert first_page == {
         "offset": 0,
         "next_offset": 2,
         "total": 5,
@@ -33,6 +46,7 @@ def test_history_tool_pages_canonical_messages_with_stable_ordinals() -> None:
             {"ordinal": 1, "role": "user", "content": messages[0].content},
             {"ordinal": 2, "role": "assistant", "content": messages[1].content},
         ],
+        **_budget_fields(truncated=False, bytes_returned=sum(len(m.content.encode("utf-8")) for m in messages[:2])),
     }
     assert tool(offset=2, limit=2)["messages"] == [
         {"ordinal": 3, "role": "user", "content": messages[2].content},
@@ -43,13 +57,76 @@ def test_history_tool_pages_canonical_messages_with_stable_ordinals() -> None:
         "next_offset": 5,
         "total": 5,
         "messages": [{"ordinal": 5, "role": "user", "content": messages[4].content}],
+        **_budget_fields(truncated=False, bytes_returned=len(messages[4].content.encode("utf-8"))),
     }
     assert tool(offset=9, limit=3) == {
         "offset": 9,
         "next_offset": 9,
         "total": 5,
         "messages": [],
+        **_budget_fields(truncated=False, bytes_returned=0),
     }
+
+
+def test_history_tool_stops_mid_page_when_byte_budget_exhausted() -> None:
+    from fleet_rlm.sessions.history_tools import SessionHistoryToolHost
+    from fleet_rlm.sessions.models import HistoryMessage, SessionHistory
+
+    chunk = "x" * 150_000
+    messages = (
+        HistoryMessage("user", chunk),
+        HistoryMessage("assistant", chunk),
+        HistoryMessage("user", "tail"),
+    )
+    (tool,) = SessionHistoryToolHost(SessionHistory(messages)).as_tools()
+
+    result = tool(offset=0, limit=20)
+
+    assert result["truncated"] is True
+    assert result["messages"] == [
+        {"ordinal": 1, "role": "user", "content": chunk},
+    ]
+    assert result["next_offset"] == 1
+    assert result["bytes_returned"] == 150_000
+
+    continuation = tool(offset=result["next_offset"], limit=20)
+    assert continuation["messages"] == [
+        {"ordinal": 2, "role": "assistant", "content": chunk},
+        {"ordinal": 3, "role": "user", "content": "tail"},
+    ]
+    assert continuation["truncated"] is False
+    assert continuation["next_offset"] == 3
+
+
+def test_history_tool_skips_oversized_message_and_continues() -> None:
+    from fleet_rlm.sessions.history_tools import SessionHistoryToolHost
+    from fleet_rlm.sessions.models import HistoryMessage, SessionHistory
+
+    oversized = "x" * (SESSION_HISTORY_RESULT_BYTE_BUDGET + 1)
+    messages = (
+        HistoryMessage("user", oversized),
+        HistoryMessage("assistant", "recoverable"),
+    )
+    (tool,) = SessionHistoryToolHost(SessionHistory(messages)).as_tools()
+
+    skipped = tool(offset=0, limit=20)
+    assert skipped == {
+        "offset": 0,
+        "next_offset": 2,
+        "total": 2,
+        "messages": [{"ordinal": 2, "role": "assistant", "content": "recoverable"}],
+        **_budget_fields(
+            truncated=True,
+            bytes_returned=len("recoverable".encode("utf-8")),
+            skipped_ordinal=1,
+        ),
+    }
+
+    recovered = tool(offset=skipped["next_offset"], limit=20)
+    assert recovered["messages"] == []
+    assert recovered["truncated"] is False
+    assert recovered["next_offset"] == 2
+    assert "skipped_ordinal" not in recovered
 
 
 def test_history_event_view_exposes_page_metadata_without_message_bodies() -> None:
@@ -64,7 +141,15 @@ def test_history_event_view_exposes_page_metadata_without_message_bodies() -> No
 
     assert result["messages"][0]["content"] == "private history body"
     assert observed[0].input == {"offset": 0, "limit": 1}
-    assert observed[1].output == {"offset": 0, "next_offset": 1, "total": 1, "message_count": 1}
+    assert observed[1].output == {
+        "offset": 0,
+        "next_offset": 1,
+        "total": 1,
+        "truncated": False,
+        "bytes_returned": len("private history body".encode("utf-8")),
+        "byte_budget": SESSION_HISTORY_RESULT_BYTE_BUDGET,
+        "message_count": 1,
+    }
     assert "private history body" not in str(observed)
 
 

--- a/tests/unit/backend/test_bind_safety.py
+++ b/tests/unit/backend/test_bind_safety.py
@@ -1,0 +1,49 @@
+"""Unit tests for the unauthenticated non-loopback bind safety gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from fleet_rlm.cli.bind_safety import UnsafeBindError, is_loopback_bind_host, require_safe_bind_host
+from fleet_rlm.cli.main import fleet_main, fleet_rlm_main
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "localhost", "LOCALHOST", "::1", " 127.0.0.1 "],
+)
+def test_loopback_hosts_are_allowed(host: str) -> None:
+    assert is_loopback_bind_host(host)
+    require_safe_bind_host(host, allow_non_loopback=False)
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["0.0.0.0", "::", "192.168.1.10", "10.0.0.1", "example.local", "hostname"],
+)
+def test_non_loopback_hosts_require_explicit_opt_in(host: str) -> None:
+    assert not is_loopback_bind_host(host)
+    with pytest.raises(UnsafeBindError, match="--allow-non-loopback-bind"):
+        require_safe_bind_host(host, allow_non_loopback=False)
+    require_safe_bind_host(host, allow_non_loopback=True)
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "argv"),
+    [
+        (fleet_main, ["web", "--host", "0.0.0.0"]),
+        (fleet_rlm_main, ["serve-api", "--host", "0.0.0.0"]),
+        (fleet_main, ["cli", "--host", "0.0.0.0"]),
+        (fleet_main, ["deno", "--host", "::"]),
+    ],
+)
+def test_launchers_reject_non_loopback_without_opt_in(
+    entrypoint: object,
+    argv: list[str],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        entrypoint(argv)  # type: ignore[operator]
+
+    assert error.value.code == 1
+    assert "--allow-non-loopback-bind" in capsys.readouterr().err

--- a/tests/unit/backend/test_cli.py
+++ b/tests/unit/backend/test_cli.py
@@ -129,7 +129,19 @@ def test_fleet_runtime_command_selects_environment_and_supervises_pi_tui(
         lambda **kwargs: calls.append(kwargs),
     )
 
-    fleet_main([command, "--host", "0.0.0.0", "--port", "8123", "--", "--session", "session-id"])
+    fleet_main(
+        [
+            command,
+            "--host",
+            "0.0.0.0",
+            "--allow-non-loopback-bind",
+            "--port",
+            "8123",
+            "--",
+            "--session",
+            "session-id",
+        ]
+    )
 
     assert os.environ["FLEET_RUN_ENVIRONMENT"] == "deno"
     assert calls == [

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from dspy.primitives.code_interpreter import FinalOutput
+
+from fleet_rlm.rlm.dspy_interpreter_contract import FinalOutput
 
 
 class _RecordingTool:

--- a/tests/unit/backend/test_rlm_factory.py
+++ b/tests/unit/backend/test_rlm_factory.py
@@ -142,3 +142,33 @@ def test_dspy_contract_is_only_native_dspy_rlm_call_site_in_rlm_package() -> Non
             if isinstance(func, ast.Name) and func.id == "RLM":
                 offenders.append(path.name)
     assert offenders == [], f"dspy.RLM constructed outside dspy_contract: {offenders}"
+
+
+def test_dspy_primitives_imports_are_confined_to_interpreter_contract() -> None:
+    """Static guard: only dspy_interpreter_contract.py may import dspy.primitives."""
+    import ast
+    from pathlib import Path
+
+    src_root = Path(__file__).resolve().parents[3] / "src" / "fleet_rlm"
+    allowed = {"rlm/dspy_interpreter_contract.py"}
+    offenders: list[str] = []
+    for path in sorted(src_root.rglob("*.py")):
+        rel = path.relative_to(src_root).as_posix()
+        if rel in allowed:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module and node.module.startswith("dspy.primitives"):
+                    offenders.append(rel)
+                    break
+                if node.module == "dspy" and any(alias.name == "primitives" for alias in node.names):
+                    offenders.append(rel)
+                    break
+            if isinstance(node, ast.Import):
+                if any(
+                    alias.name == "dspy.primitives" or alias.name.startswith("dspy.primitives.") for alias in node.names
+                ):
+                    offenders.append(rel)
+                    break
+    assert offenders == [], f"dspy.primitives imported outside interpreter contract: {offenders}"


### PR DESCRIPTION
## Summary

- Add a fixed 256 KiB UTF-8 aggregate byte budget to `read_session_history`, with `truncated`, `bytes_returned`, `byte_budget`, and `skipped_ordinal` continuation metadata.
- Refactor Daytona Session Workspace list/stat/read/write to run path guard + filesystem action in one atomic Sandbox `code_run`, closing the prior TOCTOU gap.
- Return `truncated` from `list_workspace_files` when directories exceed `limit`, using bounded in-sandbox enumeration.
- Formalize Phase 7 as append/update-only (list/stat/read/write with overwrite; no delete Tool) in AGENTS and workspace-files skill docs.

## Test plan

- [x] `uv run pytest tests/unit/backend/sessions/test_history_tool.py tests/contracts/backend/test_rlm_history_retrieval.py -q`
- [x] `uv run pytest tests/unit/backend/files tests/contracts/backend/test_workspace_turn_flow.py -q`
- [x] `make lint typecheck check-docs`
- [x] `make test PYTEST_XDIST_MAX_WORKERS=0`
- [ ] Credentialed Daytona Phase 7 durability check (`FLEET_LIVE=1`) on final SHA before promotion


Made with [Cursor](https://cursor.com)