### PR TITLE
fix(rlm): use native JSON adapter per Turn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   python:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13.13
     working_directory: ~/project
     environment:
       UV_CACHE_DIR: ~/.cache/uv

--- a/docs/how-to-guides/dspy-integration.md
+++ b/docs/how-to-guides/dspy-integration.md
@@ -18,6 +18,19 @@ clients cannot provide models, Signatures, or executable capabilities.
   structured result, and a commit-gated private `result.json` snapshot.
 - Session Workspace files are immediate private Volume state. They survive
   later Runs and Sandbox replacement; interpreter globals do not.
+- Fleet scopes `dspy.JSONAdapter(use_native_function_calling=True)` to each Turn
+  alongside the Root Model. Native structured output applies to the RLM action
+  (`reasoning` and `code`) and final extraction without changing process-global
+  DSPy settings.
+- Fleet remains on DSPy's public program and LM call surfaces: `rlm.acall()`
+  delegates request and response normalization to stock DSPy. Application code
+  does not call LM `forward()` methods, construct provider-shaped requests, or
+  opt into DSPy's experimental typed LM API while `dspy==3.3.0b1` is pinned.
+  See DSPy's
+  [normalized LM API migration](https://dspy.ai/community/normalized-lm-api-migration/).
+- Do not replace the Turn-scoped adapter with global `dspy.configure()`.
+  Composition may execute independent Turns with different scoped models, and
+  Fleet must not mutate shared DSPy defaults.
 
 ## Typed startup inputs
 

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -583,7 +583,11 @@ class RLMRunner:
             attachments=context.attachments,
             workspace=spec.workspace,
         )
-        with dspy.context(lm=context.models.root_lm, track_usage=True):
+        with dspy.context(
+            lm=context.models.root_lm,
+            adapter=dspy.JSONAdapter(use_native_function_calling=True),
+            track_usage=True,
+        ):
             return await rlm.acall(**kwargs)
 
     async def _execute_rlm_in_worker(

--- a/src/fleet_rlm/skills/bundled/dspy-rlm/references/rlm-contract.md
+++ b/src/fleet_rlm/skills/bundled/dspy-rlm/references/rlm-contract.md
@@ -47,6 +47,9 @@ Fleet maps these via `FLEET_RLM_MAX_ITERATIONS`, `FLEET_RLM_MAX_LLM_CALLS`, and 
 
 - Every primary Turn builds a fresh native `dspy.RLM` with the active Fleet Signature. The default is
   `FleetRLMSignature` (`answer: str`), but a selected Skill may supply additional required output fields.
+- Fleet scopes DSPy's stock native `JSONAdapter` to each Turn. RLM action output
+  contains `reasoning` and `code`; `completed` is internal loop state, not a
+  Signature output field.
 - **Daytona** (primary durable path): custom interpreter, Session Workspace tools, Artifact candidates promoted on Turn Commit.
 - **Deno**: vanilla local interpreter path without durable Artifact promotion; do not invent Deno-specific workflows here.
 - Declared `answer` JSON must fit the Turn commit budget. Oversized SUBMIT fails with public message `Turn output is too large`. Prefer writing long reports to Session Workspace, then SUBMIT a short summary.

--- a/tests/contracts/backend/test_dspy_rlm_constructor.py
+++ b/tests/contracts/backend/test_dspy_rlm_constructor.py
@@ -65,14 +65,19 @@ def test_dspy_rlm_accepts_file_tool_names_and_fresh_custom_interpreters() -> Non
     assert second._interpreter is second_interpreter  # noqa: SLF001 - installed DSPy contract
 
 
-def test_pinned_chat_adapter_formats_validated_json_inputs_for_typed_signature() -> None:
+def test_pinned_json_adapter_formats_typed_inputs_and_native_rlm_action_outputs() -> None:
     from fleet_rlm.rlm.signature import FleetRLMSignature
     from tests.unit.backend.rlm.test_signature_inputs import _payload
 
-    messages = dspy.ChatAdapter().format(FleetRLMSignature, [], _payload())
+    adapter = dspy.JSONAdapter(use_native_function_calling=True)
+    messages = adapter.format(FleetRLMSignature, [], _payload())
     assert messages[0]["role"] == "system"
     assert "session_context" in messages[-1]["content"]
     assert "report-builder" in messages[-1]["content"]
+
+    rlm = dspy.RLM(FleetRLMSignature)
+    assert set(rlm.generate_action.signature.output_fields) == {"reasoning", "code"}
+    assert "completed" not in rlm.generate_action.signature.output_fields
 
 
 @pytest.mark.asyncio

--- a/tests/unit/backend/rlm/test_runner_execution.py
+++ b/tests/unit/backend/rlm/test_runner_execution.py
@@ -108,6 +108,7 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
     main_thread = threading.get_ident()
     contexts: list[dict[str, object]] = []
     original_context = dspy.context
+    global_adapter = dspy.settings.adapter
 
     def tracked_context(**kwargs):
         contexts.append(kwargs)
@@ -166,7 +167,13 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
     assert stream.outcome.usage["iterations"] == 1
     assert stream.outcome.usage["observed_lm_usage"] == {"root": {"prompt_tokens": 4, "completion_tokens": 2}}
     assert set(stream.outcome.usage) == {"iterations", "observed_lm_usage", "duration_ms"}
-    assert contexts == [{"lm": context.models.root_lm, "track_usage": True}]
+    assert len(contexts) == 1
+    assert contexts[0]["lm"] is context.models.root_lm
+    assert contexts[0]["track_usage"] is True
+    adapter = contexts[0]["adapter"]
+    assert type(adapter) is dspy.JSONAdapter
+    assert adapter.use_native_function_calling is True
+    assert dspy.settings.adapter is global_adapter
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_litellm_invariant.py
+++ b/tests/unit/test_litellm_invariant.py
@@ -2,11 +2,12 @@
 
 Two-part policy, both mechanically enforced here:
 
-1. No source file under ``src/fleet_rlm/`` may import or call litellm directly.
-   fleet-rlm interacts with language models exclusively through DSPy's
-   normalized LM API (``dspy.LM``, ``dspy.settings.lm``, ``dspy.configure``).
-   litellm is a transitive dependency of DSPy and remains DSPy's internal
-   compatibility layer (see
+1. No source file under ``src/fleet_rlm/`` may import or call litellm directly,
+   or bypass DSPy's public LM call boundary with a direct ``forward()`` or
+   ``aforward()`` call on an LM-shaped receiver. Fleet interacts with language
+   models exclusively through stock DSPy public entry points. litellm is a
+   transitive dependency of DSPy and remains DSPy's internal compatibility
+   layer (see
    https://dspy.ai/community/normalized-lm-api-migration/ — "Removing the
    legacy BaseLM.forward contract does not necessitate removing LiteLLM").
 
@@ -69,6 +70,28 @@ def _directly_imports_or_uses_litellm(path: Path) -> list[str]:
     return violations
 
 
+def _directly_calls_lm_forward(path: Path) -> list[str]:
+    """Return direct calls that bypass DSPy's public LM compatibility boundary."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError:
+        return []
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr not in {"forward", "aforward"}:
+            continue
+
+        receiver = node.func.value
+        receiver_name = receiver.id if isinstance(receiver, ast.Name) else ""
+        if receiver_name == "lm" or receiver_name.endswith("_lm"):
+            violations.append(f"{path}:{node.lineno}: {receiver_name}.{node.func.attr}(...)")
+
+    return violations
+
+
 @pytest.mark.parametrize("py_file", _iter_python_files(_SRC_ROOT), ids=lambda p: str(p.relative_to(_SRC_ROOT)))
 def test_no_direct_litellm_usage(py_file: Path) -> None:
     """No source file in fleet_rlm may import or call litellm directly."""
@@ -76,6 +99,17 @@ def test_no_direct_litellm_usage(py_file: Path) -> None:
     assert not violations, (
         "fleet-rlm must not use litellm directly — go through dspy.LM / dspy.settings.lm. "
         "Found violations:\n  " + "\n  ".join(violations)
+    )
+
+
+@pytest.mark.parametrize("py_file", _iter_python_files(_SRC_ROOT), ids=lambda p: str(p.relative_to(_SRC_ROOT)))
+def test_no_direct_lm_forward_calls(py_file: Path) -> None:
+    """Fleet calls stock DSPy LMs through __call__/acall, never forward directly."""
+    violations = _directly_calls_lm_forward(py_file)
+    assert not violations, (
+        "fleet-rlm must not bypass DSPy's normalized LM compatibility boundary. "
+        "Call dspy.LM through its public __call__/acall surface. Found violations:\n  "
+        + "\n  ".join(violations)
     )
 
 

--- a/tests/unit/test_litellm_invariant.py
+++ b/tests/unit/test_litellm_invariant.py
@@ -102,10 +102,13 @@ def test_no_direct_litellm_usage(py_file: Path) -> None:
     )
 
 
-@pytest.mark.parametrize("py_file", _iter_python_files(_SRC_ROOT), ids=lambda p: str(p.relative_to(_SRC_ROOT)))
-def test_no_direct_lm_forward_calls(py_file: Path) -> None:
+def test_no_direct_lm_forward_calls() -> None:
     """Fleet calls stock DSPy LMs through __call__/acall, never forward directly."""
-    violations = _directly_calls_lm_forward(py_file)
+    violations = [
+        violation
+        for py_file in _iter_python_files(_SRC_ROOT)
+        for violation in _directly_calls_lm_forward(py_file)
+    ]
     assert not violations, (
         "fleet-rlm must not bypass DSPy's normalized LM compatibility boundary. "
         "Call dspy.LM through its public __call__/acall surface. Found violations:\n  "


### PR DESCRIPTION
## Summary
- use the native DSPy JSON adapter per Turn
- align constructor, runner, bundled contract, and regression tests
- document the integration contract and preserve the no-litellm invariant

## Validation
- `git diff --check`

CI and review will be monitored after creation.