### PR TITLE
fix(observability): propagate request/response to root trace span

### DIFF
--- a/src/fleet_rlm/chat/turn_coordinator.py
+++ b/src/fleet_rlm/chat/turn_coordinator.py
@@ -29,7 +29,7 @@ from fleet_rlm.chat.turn_preparation import (
     TurnPreparationCancelledError,
     TurnPreparationTimeoutError,
 )
-from fleet_rlm.observability.turn_tracing import turn_trace
+from fleet_rlm.observability.turn_tracing import annotate_trace_io, turn_trace
 from fleet_rlm.rlm.context import RLMExecutionContext
 from fleet_rlm.rlm.dspy_contract import empty_rlm_usage
 from fleet_rlm.rlm.events import (
@@ -336,6 +336,16 @@ class TurnCoordinator:
             outcome = stream.outcome or RLMOutcome(
                 terminal_status="failed",
                 public_error_message="Turn failed",
+            )
+            # Propagate request/response to root trace span for MLflow judges
+            annotate_trace_io(
+                request=prepared.execution.request,
+                response_text=(
+                    outcome.prediction.display_text if outcome.prediction else outcome.public_error_message
+                ),
+                response_outputs=(
+                    dict(outcome.prediction.outputs) if outcome.prediction else None
+                ),
             )
             if outcome.terminal_status in {"timeout", "cancelled"}:
                 status = "timeout" if outcome.terminal_status == "timeout" else "cancelled"

--- a/src/fleet_rlm/chat/turn_coordinator.py
+++ b/src/fleet_rlm/chat/turn_coordinator.py
@@ -319,6 +319,10 @@ class TurnCoordinator:
                     )
                     heartbeat = None
                     settled = True
+                    annotate_trace_io(
+                        request=prepared.execution.request,
+                        response_text="Turn failed",
+                    )
                     yield recorder.record(RunFailed(code="unavailable", message="Turn failed"))
                     return
                 if heartbeat_lost is not None:
@@ -403,6 +407,10 @@ class TurnCoordinator:
                     )
                     heartbeat = None
                     settled = True
+                    annotate_trace_io(
+                        request=prepared.execution.request,
+                        response_text="Turn failed",
+                    )
                     yield recorder.record(RunFailed(code="unavailable", message="Turn failed"))
                     return
                 else:

--- a/src/fleet_rlm/observability/turn_tracing.py
+++ b/src/fleet_rlm/observability/turn_tracing.py
@@ -27,6 +27,40 @@ class TraceHandle:
     trace_id: str | None
 
 
+def annotate_trace_io(
+    *,
+    request: str,
+    response_text: str | None = None,
+    response_outputs: dict[str, object] | None = None,
+) -> None:
+    """Fail-soft: propagate request/response to the active root trace for MLflow judges.
+
+    MLflow LLM judges (Safety, Completeness, RelevanceToQuery) read from the
+    trace-level request/response fields. Without this, judges either fail or
+    fall back to expensive trace-based parsing of all spans.
+
+    Must never raise — trace annotation failures are not Turn failures.
+    """
+    try:
+        import mlflow
+
+        response: dict[str, object] = {}
+        if response_text is not None:
+            response["answer"] = response_text
+        if response_outputs is not None:
+            # Only include declared public output fields; exclude large internals
+            for key in ("answer", "final_reasoning"):
+                if key in response_outputs:
+                    response[key] = response_outputs[key]
+
+        mlflow.update_current_trace(
+            request={"request": request},
+            response=response or {"answer": response_text or ""},
+        )
+    except Exception:
+        logger.debug("annotate_trace_io failed; continuing without root span I/O", exc_info=True)
+
+
 def current_turn_trace_id() -> str | None:
     """Return the active Turn trace id for this context, if any."""
     return _current_trace_id.get()

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -115,6 +115,7 @@ def test_annotate_trace_io_updates_trace_request_response(monkeypatch: pytest.Mo
         "request": {"request": "how are you?"},
         "response": {"answer": "public answer", "final_reasoning": "public reasoning"},
     }
+    assert "internal_payload" not in calls.update_kwargs[-1]["response"]
 
 
 def test_annotate_trace_io_falls_back_to_empty_answer(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import pytest
 
-from fleet_rlm.observability.turn_tracing import current_turn_trace_id, turn_trace
+from fleet_rlm.observability.turn_tracing import annotate_trace_io, current_turn_trace_id, turn_trace
 
 
 def _install_fake_mlflow(monkeypatch: pytest.MonkeyPatch, *, explode: bool = False) -> SimpleNamespace:
@@ -96,3 +96,33 @@ def test_turn_trace_respects_expose_flag(monkeypatch: pytest.MonkeyPatch) -> Non
     with turn_trace(uuid4(), uuid4(), enabled=True, expose_trace_id=False) as handle:
         assert handle.trace_id is None
         assert current_turn_trace_id() is None
+
+
+def test_annotate_trace_io_updates_trace_request_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fake_mlflow(monkeypatch)
+
+    annotate_trace_io(
+        request="how are you?",
+        response_text="display answer",
+        response_outputs={
+            "answer": "public answer",
+            "final_reasoning": "public reasoning",
+            "internal_payload": {"secret": "value"},
+        },
+    )
+
+    assert calls.update_kwargs[-1] == {
+        "request": {"request": "how are you?"},
+        "response": {"answer": "public answer", "final_reasoning": "public reasoning"},
+    }
+
+
+def test_annotate_trace_io_falls_back_to_empty_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fake_mlflow(monkeypatch)
+
+    annotate_trace_io(request="hello")
+
+    assert calls.update_kwargs[-1] == {
+        "request": {"request": "hello"},
+        "response": {"answer": ""},
+    }


### PR DESCRIPTION
The fleet_turn root span had empty inputs/outputs, causing MLflow LLM judges (Completeness, Safety, RelevanceToQuery) to either fail entirely or fall back to expensive trace-based parsing mode.

Add annotate_trace_io() in turn_tracing.py — a fail-soft helper that calls mlflow.update_current_trace(request=..., response=...) after the RLM outcome is determined. Called from TurnCoordinator._execute_traced after the runner stream completes.

Design:
- Fail-soft: wrapped in try/except, uses logger.debug on failure
- Only includes declared public fields (request, answer, final_reasoning)
- No PII/secrets/attachment content in trace annotations
- Trace annotation failures never affect Turn outcomes

Fixes:
- Completeness scorer failing 7/7 with 'Could not extract inputs/outputs'
- Safety/Relevance using slow trace-based fallback instead of fast path
- Empty Request/Response columns in MLflow traces table UI

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] Relevant local validation passed (`make test-fast` for backend-only work, `make quality-gate` for shared-contract work)
- [ ] Frontend changes passed repo checks (`cd src/frontend && pnpm run api:check && pnpm run type-check && pnpm run lint:robustness && pnpm run test:unit && pnpm run build`)
- [ ] Pre-commit and pre-push hooks are installed locally (`uv run pre-commit install` and `uv run pre-commit install --hook-type pre-push`)
- [ ] Documentation updated (README, AGENTS.md, docstrings)
- [ ] Commit messages follow conventions
- [ ] PR description clearly explains the change
- [ ] Link related issues in the PR description
