### PR TITLE
fix(observability): use span.set_inputs/set_outputs instead of update…

### DIFF
--- a/src/fleet_rlm/observability/turn_tracing.py
+++ b/src/fleet_rlm/observability/turn_tracing.py
@@ -36,27 +36,32 @@ def annotate_trace_io(
     """Fail-soft: propagate request/response to the active root trace for MLflow judges.
 
     MLflow LLM judges (Safety, Completeness, RelevanceToQuery) read from the
-    trace-level request/response fields. Without this, judges either fail or
-    fall back to expensive trace-based parsing of all spans.
+    root span\'s inputs/outputs. Without this, judges either fail or fall back
+    to expensive trace-based parsing of all spans.
+
+    Uses span.set_inputs()/set_outputs() on the current active span (which is
+    the fleet_turn root span when called from TurnCoordinator._execute_traced).
 
     Must never raise — trace annotation failures are not Turn failures.
     """
     try:
         import mlflow
 
+        span = mlflow.get_current_active_span()
+        if span is None:
+            return
+
+        span.set_inputs({"request": request})
+
         response: dict[str, object] = {}
         if response_text is not None:
             response["answer"] = response_text
         if response_outputs is not None:
-            # Only include declared public output fields; exclude large internals
             for key in ("answer", "final_reasoning"):
                 if key in response_outputs:
                     response[key] = response_outputs[key]
 
-        mlflow.update_current_trace(
-            request={"request": request},
-            response=response or {"answer": response_text or ""},
-        )
+        span.set_outputs(response or {"answer": response_text or ""})
     except Exception:
         logger.debug("annotate_trace_io failed; continuing without root span I/O", exc_info=True)
 

--- a/src/fleet_rlm/observability/turn_tracing.py
+++ b/src/fleet_rlm/observability/turn_tracing.py
@@ -36,7 +36,7 @@ def annotate_trace_io(
     """Fail-soft: propagate request/response to the active root trace for MLflow judges.
 
     MLflow LLM judges (Safety, Completeness, RelevanceToQuery) read from the
-    root span\'s inputs/outputs. Without this, judges either fail or fall back
+    root span's inputs/outputs. Without this, judges either fail or fall back
     to expensive trace-based parsing of all spans.
 
     Uses span.set_inputs()/set_outputs() on the current active span (which is

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -19,7 +19,20 @@ def _install_fake_mlflow(monkeypatch: pytest.MonkeyPatch, *, explode: bool = Fal
         start_span_names=[],
         update_kwargs=[],
         get_trace_calls=0,
+        span_inputs=[],
+        span_outputs=[],
     )
+
+    class _FakeSpan:
+        request_id = "tr-from-span"
+
+        def set_inputs(self, payload: dict[str, object]) -> None:
+            calls.span_inputs.append(payload)
+
+        def set_outputs(self, payload: dict[str, object]) -> None:
+            calls.span_outputs.append(payload)
+
+    active_span = _FakeSpan()
 
     @contextmanager
     def start_span(*, name: str = "span", span_type: Any = None, **_kwargs: Any) -> Iterator[Any]:
@@ -27,7 +40,7 @@ def _install_fake_mlflow(monkeypatch: pytest.MonkeyPatch, *, explode: bool = Fal
         if explode:
             raise RuntimeError("span boom")
         calls.start_span_names.append(name)
-        yield SimpleNamespace(request_id="tr-from-span")
+        yield active_span
 
     def update_current_trace(**kwargs: Any) -> None:
         calls.update_kwargs.append(kwargs)
@@ -36,10 +49,14 @@ def _install_fake_mlflow(monkeypatch: pytest.MonkeyPatch, *, explode: bool = Fal
         calls.get_trace_calls += 1
         return "tr-active-123"
 
+    def get_current_active_span() -> _FakeSpan:
+        return active_span
+
     mlflow = ModuleType("mlflow")
     mlflow.start_span = start_span  # type: ignore[attr-defined]
     mlflow.update_current_trace = update_current_trace  # type: ignore[attr-defined]
     mlflow.get_last_active_trace_id = get_last_active_trace_id  # type: ignore[attr-defined]
+    mlflow.get_current_active_span = get_current_active_span  # type: ignore[attr-defined]
 
     entities = ModuleType("mlflow.entities")
     entities.SpanType = SimpleNamespace(CHAIN="CHAIN")  # type: ignore[attr-defined]
@@ -111,11 +128,12 @@ def test_annotate_trace_io_updates_trace_request_response(monkeypatch: pytest.Mo
         },
     )
 
-    assert calls.update_kwargs[-1] == {
-        "request": {"request": "how are you?"},
-        "response": {"answer": "public answer", "final_reasoning": "public reasoning"},
+    assert calls.span_inputs[-1] == {"request": "how are you?"}
+    assert calls.span_outputs[-1] == {
+        "answer": "public answer",
+        "final_reasoning": "public reasoning",
     }
-    assert "internal_payload" not in calls.update_kwargs[-1]["response"]
+    assert "internal_payload" not in calls.span_outputs[-1]
 
 
 def test_annotate_trace_io_falls_back_to_empty_answer(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -123,7 +141,5 @@ def test_annotate_trace_io_falls_back_to_empty_answer(monkeypatch: pytest.Monkey
 
     annotate_trace_io(request="hello")
 
-    assert calls.update_kwargs[-1] == {
-        "request": {"request": "hello"},
-        "response": {"answer": ""},
-    }
+    assert calls.span_inputs[-1] == {"request": "hello"}
+    assert calls.span_outputs[-1] == {"answer": ""}


### PR DESCRIPTION
…_current_trace

The previous fix used mlflow.update_current_trace(request=..., response=...) which silently failed because that API does not accept request/response kwargs. The actual signature only supports request_preview/response_preview (strings).

Switch to the correct approach: get the current active span via mlflow.get_current_active_span() and call span.set_inputs()/span.set_outputs() directly. This is what MLflow LLM judges read from.

Root cause of silent failure: annotate_trace_io's try/except caught the TypeError from the invalid kwargs and logged at DEBUG level only.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] Relevant local validation passed (`make test-fast` for backend-only work, `make quality-gate` for shared-contract work)
- [ ] Frontend changes passed repo checks (`cd src/frontend && pnpm run api:check && pnpm run type-check && pnpm run lint:robustness && pnpm run test:unit && pnpm run build`)
- [ ] Pre-commit and pre-push hooks are installed locally (`uv run pre-commit install` and `uv run pre-commit install --hook-type pre-push`)
- [ ] Documentation updated (README, AGENTS.md, docstrings)
- [ ] Commit messages follow conventions
- [ ] PR description clearly explains the change
- [ ] Link related issues in the PR description
