### PR TITLE
feat(observability): harden MLflow trace metadata

### DIFF
--- a/src/fleet_rlm/api/dependencies.py
+++ b/src/fleet_rlm/api/dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Annotated, Protocol
 
 from fastapi import Depends, HTTPException, Request
@@ -22,6 +23,27 @@ from fleet_rlm.files.models import (
 from fleet_rlm.files.volume_storage import WorkspaceVolumeGateway
 from fleet_rlm.files.workspace_access import WorkspaceFileService
 from fleet_rlm.sessions.catalog import SessionCatalog
+
+
+def require_loopback_client(request: Request) -> None:
+    """Keep filesystem/compute administration local even on an unsafe API bind."""
+    # Reject requests that carry proxy-forwarding headers: a local reverse proxy
+    # connecting from 127.0.0.1 would make non-local clients appear loopback.
+    if request.headers.get("x-forwarded-for") or request.headers.get("forwarded"):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "settings_local_only", "message": "Available only from the local machine"},
+        )
+    host = request.client.host if request.client is not None else ""
+    try:
+        is_loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        is_loopback = False
+    if not is_loopback:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "settings_local_only", "message": "Available only from the local machine"},
+        )
 
 
 class AttachmentLifecyclePort(Protocol):

--- a/src/fleet_rlm/api/dependencies.py
+++ b/src/fleet_rlm/api/dependencies.py
@@ -29,7 +29,9 @@ def require_loopback_client(request: Request) -> None:
     """Keep filesystem/compute administration local even on an unsafe API bind."""
     # Reject requests that carry proxy-forwarding headers: a local reverse proxy
     # connecting from 127.0.0.1 would make non-local clients appear loopback.
-    if request.headers.get("x-forwarded-for") or request.headers.get("forwarded"):
+    # Reject by header presence (even empty values), not truthiness.
+    forwarding_headers = ("x-forwarded-for", "forwarded", "x-real-ip")
+    if any(header in request.headers for header in forwarding_headers):
         raise HTTPException(
             status_code=403,
             detail={"code": "settings_local_only", "message": "Available only from the local machine"},

--- a/src/fleet_rlm/api/routes/settings.py
+++ b/src/fleet_rlm/api/routes/settings.py
@@ -2,37 +2,14 @@
 
 from __future__ import annotations
 
-import ipaddress
+from fastapi import APIRouter, Depends, HTTPException
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-
-from fleet_rlm.api.dependencies import ConfigPolicyDep
+from fleet_rlm.api.dependencies import ConfigPolicyDep, require_loopback_client
 from fleet_rlm.api.schemas import SettingsPolicyPatchRequest, SettingsPolicyResponse
 from fleet_rlm.config import FleetConfigurationError
 from fleet_rlm.config_policy import PolicyAccessError, PolicyConflictError
 
 router = APIRouter(tags=["settings"])
-
-
-def require_loopback_client(request: Request) -> None:
-    """Keep filesystem policy administration local even on an unsafe API bind."""
-    # Reject requests that carry proxy-forwarding headers: a local reverse proxy
-    # connecting from 127.0.0.1 would make non-local clients appear loopback.
-    if request.headers.get("x-forwarded-for") or request.headers.get("forwarded"):
-        raise HTTPException(
-            status_code=403,
-            detail={"code": "settings_local_only", "message": "Settings are available only from the local machine"},
-        )
-    host = request.client.host if request.client is not None else ""
-    try:
-        is_loopback = ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        is_loopback = False
-    if not is_loopback:
-        raise HTTPException(
-            status_code=403,
-            detail={"code": "settings_local_only", "message": "Settings are available only from the local machine"},
-        )
 
 
 def _response(snapshot) -> SettingsPolicyResponse:

--- a/src/fleet_rlm/chat/turn_coordinator.py
+++ b/src/fleet_rlm/chat/turn_coordinator.py
@@ -180,13 +180,15 @@ class TurnCoordinator:
     ) -> CommittedTurnReceipt | FailedRunReceipt:
         """Settle one executed Turn and expose only its terminal status to MLflow."""
         terminal_status = resolution.terminal_status
-        with turn_phase_span(
-            "Turn.settlement",
-            inputs={
-                "terminal_status": terminal_status,
-                "has_prediction": isinstance(resolution, RLMOutcome) and resolution.prediction is not None,
-            },
-        ):
+        settlement_inputs: dict[str, object] = {
+            "terminal_status": terminal_status,
+            "has_prediction": isinstance(resolution, RLMOutcome) and resolution.prediction is not None,
+        }
+        if isinstance(resolution, RLMOutcome):
+            settlement_inputs["duration_ms"] = resolution.duration_ms
+            settlement_inputs["artifact_candidate_count"] = len(resolution.artifact_candidates)
+            settlement_inputs["iterations"] = resolution.usage.get("iterations")
+        with turn_phase_span("Turn.settlement", inputs=settlement_inputs):
             return await self._lifecycle.finish(
                 turn,
                 resolution,

--- a/src/fleet_rlm/observability/tracing.py
+++ b/src/fleet_rlm/observability/tracing.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import socket
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, cast
@@ -37,6 +38,7 @@ _TRACING_CONFIGURED = False
 _TRACING_ACTIVE = False
 _DEFAULT_TRACKING_URI = "databricks"
 _TRACE_DESTINATION_TAG = "mlflow.experiment.databricksTraceDestinationPath"
+_CREDENTIAL_KEYS = frozenset({"api_key", "authorization", "credential", "password", "secret", "token"})
 _CONTENT_BEARING_KEYS = frozenset(
     {
         "answer",
@@ -64,6 +66,31 @@ _CONTENT_BEARING_KEYS = frozenset(
         "tool_output",
     }
 )
+_OPERATIONAL_TEXT_KEYS = frozenset(
+    {
+        "cache",
+        "engine",
+        "failure_category",
+        "kind",
+        "model",
+        "model_type",
+        "name",
+        "phase_status",
+        "provider",
+        "provider_type",
+        "role",
+        "status",
+        "termination_mode",
+        "type",
+    }
+)
+
+
+def _normalize_trace_key(key: str | None) -> str:
+    """Normalize dotted, hyphenated, and camel-case span keys for policy checks."""
+    raw = (key or "").strip()
+    raw = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", raw)
+    return re.sub(r"[^a-zA-Z0-9]+", "_", raw).strip("_").lower()
 
 
 def _trace_digest(value: object) -> str:
@@ -79,7 +106,7 @@ def _sanitize_mlflow_value(value: object, *, key: str | None = None, depth: int 
     """Preserve operational metadata while replacing content-bearing trace values."""
     if depth >= 8:
         return "[redacted depth]"
-    normalized_key = (key or "").strip().lower().replace("-", "_")
+    normalized_key = _normalize_trace_key(key)
     if normalized_key in _CONTENT_BEARING_KEYS or normalized_key.endswith(
         ("_input", "_output", "_prompt", "_response")
     ):
@@ -94,9 +121,13 @@ def _sanitize_mlflow_value(value: object, *, key: str | None = None, depth: int 
     if isinstance(value, str):
         from fleet_rlm.rlm.sanitize import sanitize_public_text
 
-        if normalized_key in {"token", "api_key", "authorization", "credential", "password", "secret"}:
+        if normalized_key in _CREDENTIAL_KEYS:
             return "[redacted]"
-        return sanitize_public_text(value, max_len=256)
+        if normalized_key in _OPERATIONAL_TEXT_KEYS:
+            return sanitize_public_text(value, max_len=256)
+        # DSPy signatures may use arbitrary field names, so unknown string
+        # fields must be treated as content rather than exported by default.
+        return _trace_digest(value)
     if value is None or isinstance(value, (bool, int, float)):
         return value
     return type(value).__name__

--- a/src/fleet_rlm/observability/tracing.py
+++ b/src/fleet_rlm/observability/tracing.py
@@ -17,9 +17,12 @@ Databricks auth remains outside FLEET secrets (SDK/CLI conventions):
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 import socket
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
@@ -34,6 +37,69 @@ _TRACING_CONFIGURED = False
 _TRACING_ACTIVE = False
 _DEFAULT_TRACKING_URI = "databricks"
 _TRACE_DESTINATION_TAG = "mlflow.experiment.databricksTraceDestinationPath"
+_CONTENT_BEARING_KEYS = frozenset(
+    {
+        "answer",
+        "arguments",
+        "candidate",
+        "code",
+        "content",
+        "error",
+        "exception",
+        "feedback",
+        "input",
+        "inputs",
+        "instruction",
+        "message",
+        "output",
+        "outputs",
+        "prompt",
+        "query",
+        "reasoning",
+        "request",
+        "response",
+        "result",
+        "text",
+        "tool_input",
+        "tool_output",
+    }
+)
+
+
+def _trace_digest(value: object) -> str:
+    """Return a stable digest marker without exporting the original value."""
+    try:
+        encoded = json.dumps(value, sort_keys=True, default=lambda item: type(item).__name__, separators=(",", ":"))
+    except (TypeError, ValueError):
+        encoded = type(value).__name__
+    return f"[redacted sha256={hashlib.sha256(encoded.encode()).hexdigest()}]"
+
+
+def _sanitize_mlflow_value(value: object, *, key: str | None = None, depth: int = 0) -> object:
+    """Preserve operational metadata while replacing content-bearing trace values."""
+    if depth >= 8:
+        return "[redacted depth]"
+    normalized_key = (key or "").strip().lower().replace("-", "_")
+    if normalized_key in _CONTENT_BEARING_KEYS or normalized_key.endswith(
+        ("_input", "_output", "_prompt", "_response")
+    ):
+        return _trace_digest(value)
+    if isinstance(value, Mapping):
+        return {
+            str(item_key)[:128]: _sanitize_mlflow_value(item, key=str(item_key), depth=depth + 1)
+            for item_key, item in list(value.items())[:50]
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_mlflow_value(item, depth=depth + 1) for item in list(value)[:50]]
+    if isinstance(value, str):
+        from fleet_rlm.rlm.sanitize import sanitize_public_text
+
+        if normalized_key in {"token", "api_key", "authorization", "credential", "password", "secret"}:
+            return "[redacted]"
+        return sanitize_public_text(value, max_len=256)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return type(value).__name__
 
 
 def _sanitize_mlflow_span(span: object) -> None:
@@ -46,25 +112,25 @@ def _sanitize_mlflow_span(span: object) -> None:
         span (object): MLflow span to sanitize.
     """
     try:
-        from fleet_rlm.observability.turn_tracing import _trace_mapping, _trace_value
-
         inputs = getattr(span, "inputs", None)
         if inputs is not None:
             setter = getattr(span, "set_inputs", None)
             if callable(setter):
-                setter(_trace_value(inputs))
+                setter(_sanitize_mlflow_value(inputs))
 
         outputs = getattr(span, "outputs", None)
         if outputs is not None:
             setter = getattr(span, "set_outputs", None)
             if callable(setter):
-                setter(_trace_value(outputs))
+                setter(_sanitize_mlflow_value(outputs))
 
         attributes = getattr(span, "attributes", None)
-        if isinstance(attributes, dict):
+        if isinstance(attributes, Mapping):
             setter = getattr(span, "set_attributes", None)
             if callable(setter):
-                setter(_trace_mapping(attributes))
+                sanitized = _sanitize_mlflow_value(attributes)
+                if isinstance(sanitized, dict):
+                    setter(sanitized)
     except Exception:
         # A processor must never change the Turn outcome or break trace export.
         logger.debug("MLflow span sanitization failed; continuing", exc_info=True)

--- a/src/fleet_rlm/observability/tracing.py
+++ b/src/fleet_rlm/observability/tracing.py
@@ -121,7 +121,9 @@ def _sanitize_mlflow_value(value: object, *, key: str | None = None, depth: int 
     if isinstance(value, str):
         from fleet_rlm.rlm.sanitize import sanitize_public_text
 
-        if normalized_key in _CREDENTIAL_KEYS:
+        if normalized_key in _CREDENTIAL_KEYS or normalized_key.endswith(
+            tuple(f"_{credential_key}" for credential_key in _CREDENTIAL_KEYS)
+        ):
             return "[redacted]"
         if normalized_key in _OPERATIONAL_TEXT_KEYS:
             return sanitize_public_text(value, max_len=256)

--- a/src/fleet_rlm/rlm/recursive_calls.py
+++ b/src/fleet_rlm/rlm/recursive_calls.py
@@ -201,19 +201,20 @@ class RecursiveRLMExecutor:
             )
             return answer
 
-        interpreter = self._child_interpreter_factory() if self._child_interpreter_factory is not None else None
-        child_executor = RecursiveRLMExecutor(
-            models=self._models,
-            options=self._options,
-            child_interpreter_factory=self._child_interpreter_factory,
-            deadline=self._deadline,
-            depth=child_depth,
-            state=self._state,
-            observer=self._observer,
-        )
+        interpreter: Any | None = None
         failed = False
         completion_outputs: dict[str, object] | None = None
         try:
+            interpreter = self._child_interpreter_factory() if self._child_interpreter_factory is not None else None
+            child_executor = RecursiveRLMExecutor(
+                models=self._models,
+                options=self._options,
+                child_interpreter_factory=self._child_interpreter_factory,
+                deadline=self._deadline,
+                depth=child_depth,
+                state=self._state,
+                observer=self._observer,
+            )
             child = build_native_rlm(
                 signature=RecursiveSubtaskSignature,
                 options=RLMOptions(

--- a/src/fleet_rlm/rlm/recursive_calls.py
+++ b/src/fleet_rlm/rlm/recursive_calls.py
@@ -212,6 +212,7 @@ class RecursiveRLMExecutor:
             observer=self._observer,
         )
         failed = False
+        completion_outputs: dict[str, object] | None = None
         try:
             child = build_native_rlm(
                 signature=RecursiveSubtaskSignature,
@@ -254,10 +255,7 @@ class RecursiveRLMExecutor:
                 else "typed_submit"
             )
             self._state.termination_modes.append(mode)
-            span.finish(
-                phase_status="completed",
-                outputs={"termination_mode": mode, "child_iterations": child_iterations},
-            )
+            completion_outputs = {"termination_mode": mode, "child_iterations": child_iterations}
             return result.display_text
         except Exception as exc:
             failed = True
@@ -271,9 +269,15 @@ class RecursiveRLMExecutor:
             if interpreter is not None:
                 try:
                     interpreter.shutdown()
-                except Exception:
+                except Exception as exc:
                     if not failed:
+                        span.finish(
+                            phase_status="failed",
+                            outputs={"failure_category": trace_failure_category(exc)},
+                        )
                         raise
+            if not failed and completion_outputs is not None:
+                span.finish(phase_status="completed", outputs=completion_outputs)
 
     def _plain_sub_lm(self, prompt: str) -> str:
         """Use the configured Sub LM at the depth cap.

--- a/src/fleet_rlm/rlm/recursive_calls.py
+++ b/src/fleet_rlm/rlm/recursive_calls.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import dspy
 
+from fleet_rlm.observability.failure_diagnostics import trace_failure_category
+from fleet_rlm.observability.turn_tracing import start_turn_span
 from fleet_rlm.rlm.dspy_contract import RLMOptions, _RLMTraceCallback, build_native_rlm, prediction_result
 from fleet_rlm.rlm.errors import RLMConfigError
 from fleet_rlm.rlm.model_bundle import RLMModelBundle
@@ -174,10 +176,29 @@ class RecursiveRLMExecutor:
         self._state.delegated_prompt_chars += len(prompt)
         self._state.maximum_prompt_chars = max(self._state.maximum_prompt_chars, len(prompt))
         child_depth = self._depth + 1
+        span = start_turn_span(
+            "RLM.recursive_call",
+            inputs={
+                "recursive_depth": child_depth,
+                "call_index": self._state.call_count,
+                "prompt_chars": len(prompt),
+            },
+        )
         if child_depth >= self._options.max_depth:
             self._state.depth_fallback_count += 1
-            answer = self._plain_sub_lm(prompt)
+            try:
+                answer = self._plain_sub_lm(prompt)
+            except Exception as exc:
+                span.finish(
+                    phase_status="failed",
+                    outputs={"failure_category": trace_failure_category(exc)},
+                )
+                raise
             self._state.termination_modes.append("depth_fallback")
+            span.finish(
+                phase_status="completed",
+                outputs={"termination_mode": "depth_fallback"},
+            )
             return answer
 
         interpreter = self._child_interpreter_factory() if self._child_interpreter_factory is not None else None
@@ -225,17 +246,26 @@ class RecursiveRLMExecutor:
                 max_output_chars=self._options.child_max_output_chars,
             )
             trajectory = getattr(prediction, "trajectory", ())
-            self._state.child_iterations += len(trajectory) if isinstance(trajectory, list) else 0
+            child_iterations = len(trajectory) if isinstance(trajectory, list) else 0
+            self._state.child_iterations += child_iterations
             mode = (
                 "native_extraction_fallback"
                 if getattr(prediction, "final_reasoning", None) == "Extract forced final output"
                 else "typed_submit"
             )
             self._state.termination_modes.append(mode)
+            span.finish(
+                phase_status="completed",
+                outputs={"termination_mode": mode, "child_iterations": child_iterations},
+            )
             return result.display_text
-        except Exception:
+        except Exception as exc:
             failed = True
             self._state.termination_modes.append("child_error")
+            span.finish(
+                phase_status="failed",
+                outputs={"failure_category": trace_failure_category(exc)},
+            )
             raise
         finally:
             if interpreter is not None:

--- a/tests/contracts/backend/test_settings_api.py
+++ b/tests/contracts/backend/test_settings_api.py
@@ -61,6 +61,15 @@ def test_settings_policy_is_loopback_only_and_revision_checked(monkeypatch, tmp_
         assert proxied.status_code == 403
         assert proxied.json()["code"] == "settings_local_only"
 
+        real_ip = client.get("/api/settings", headers={"X-Real-IP": "192.0.2.10"})
+        assert real_ip.status_code == 403
+        assert real_ip.json()["code"] == "settings_local_only"
+
+        for header in ("X-Forwarded-For", "Forwarded", "X-Real-IP"):
+            empty = client.get("/api/settings", headers={header: ""})
+            assert empty.status_code == 403, header
+            assert empty.json()["code"] == "settings_local_only"
+
     remote_app = create_testing_app(settings=Settings(_env_file=None, run_environment="daytona"))
     with TestClient(remote_app, client=("192.0.2.10", 50000)) as client:
         denied = client.get("/api/settings")

--- a/tests/unit/backend/test_mlflow_tracing_config.py
+++ b/tests/unit/backend/test_mlflow_tracing_config.py
@@ -278,6 +278,23 @@ def test_mlflow_span_processor_redacts_autolog_content_fields() -> None:
     assert span.attributes["tool_output"].startswith("[redacted sha256=")
 
 
+def test_mlflow_span_processor_redacts_namespaced_and_unknown_text_fields() -> None:
+    sanitized = tracing._sanitize_mlflow_value(
+        {
+            "gen_ai.prompt": "private prompt",
+            "mlflow.spanInputs": "private input",
+            "custom_question": "private question",
+            "model": "openai/gpt-5",
+        }
+    )
+
+    assert isinstance(sanitized, dict)
+    assert sanitized["gen_ai.prompt"].startswith("[redacted sha256=")
+    assert sanitized["mlflow.spanInputs"].startswith("[redacted sha256=")
+    assert sanitized["custom_question"].startswith("[redacted sha256=")
+    assert sanitized["model"] == "openai/gpt-5"
+
+
 def test_configure_tracing_local_server_needs_only_experiment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/backend/test_mlflow_tracing_config.py
+++ b/tests/unit/backend/test_mlflow_tracing_config.py
@@ -284,6 +284,8 @@ def test_mlflow_span_processor_redacts_namespaced_and_unknown_text_fields() -> N
             "gen_ai.prompt": "private prompt",
             "mlflow.spanInputs": "private input",
             "custom_question": "private question",
+            "openai_api_key": "private key",
+            "access_token": "private token",
             "model": "openai/gpt-5",
         }
     )
@@ -292,6 +294,8 @@ def test_mlflow_span_processor_redacts_namespaced_and_unknown_text_fields() -> N
     assert sanitized["gen_ai.prompt"].startswith("[redacted sha256=")
     assert sanitized["mlflow.spanInputs"].startswith("[redacted sha256=")
     assert sanitized["custom_question"].startswith("[redacted sha256=")
+    assert sanitized["openai_api_key"] == "[redacted]"
+    assert sanitized["access_token"] == "[redacted]"
     assert sanitized["model"] == "openai/gpt-5"
 
 

--- a/tests/unit/backend/test_mlflow_tracing_config.py
+++ b/tests/unit/backend/test_mlflow_tracing_config.py
@@ -239,10 +239,43 @@ def test_mlflow_315_span_processor_bounds_and_redacts_values() -> None:
 
     assert span.inputs["token"] == "[redacted]"
     assert isinstance(span.inputs["body"], str)
-    assert len(span.inputs["body"]) <= 1_000
-    assert isinstance(span.outputs["answer"], str)
-    assert len(span.outputs["answer"]) <= 1_000
+    assert len(span.inputs["body"]) <= 256
+    assert span.outputs["answer"].startswith("[redacted sha256=")
     assert span.attributes["api_key"] == "[redacted]"
+
+
+def test_mlflow_span_processor_redacts_autolog_content_fields() -> None:
+    class Span:
+        def __init__(self) -> None:
+            self.inputs: dict[str, object] = {
+                "prompt": "candidate instruction must never be exported",
+                "token_usage": 42,
+            }
+            self.outputs: dict[str, object] = {
+                "response": "provider body must never be exported",
+                "duration_ms": 15,
+            }
+            self.attributes: dict[str, object] = {"engine": "gepa", "tool_output": "private tool result"}
+
+        def set_inputs(self, value: object) -> None:
+            self.inputs = value
+
+        def set_outputs(self, value: object) -> None:
+            self.outputs = value
+
+        def set_attributes(self, value: dict[str, object]) -> None:
+            self.attributes = value
+
+    span = Span()
+
+    tracing._sanitize_mlflow_span(span)
+
+    assert span.inputs["prompt"].startswith("[redacted sha256=")
+    assert span.inputs["token_usage"] == 42
+    assert span.outputs["response"].startswith("[redacted sha256=")
+    assert span.outputs["duration_ms"] == 15
+    assert span.attributes["engine"] == "gepa"
+    assert span.attributes["tool_output"].startswith("[redacted sha256=")
 
 
 def test_configure_tracing_local_server_needs_only_experiment(

--- a/tests/unit/backend/test_mlflow_tracing_config.py
+++ b/tests/unit/backend/test_mlflow_tracing_config.py
@@ -299,6 +299,27 @@ def test_mlflow_span_processor_redacts_namespaced_and_unknown_text_fields() -> N
     assert sanitized["model"] == "openai/gpt-5"
 
 
+def test_mlflow_span_processor_bounds_collection_size_and_depth() -> None:
+    mapping = tracing._sanitize_mlflow_value({str(index): index for index in range(60)})
+    values = tracing._sanitize_mlflow_value(list(range(60)))
+
+    assert isinstance(mapping, dict)
+    assert len(mapping) == 50
+    assert isinstance(values, list)
+    assert len(values) == 50
+
+    nested: object = {"value": "private"}
+    for _ in range(8):
+        nested = {"nested": nested}
+    sanitized_nested = tracing._sanitize_mlflow_value(nested)
+    assert isinstance(sanitized_nested, dict)
+    cursor: object = sanitized_nested
+    for _ in range(8):
+        assert isinstance(cursor, dict)
+        cursor = cursor["nested"]
+    assert cursor == "[redacted depth]"
+
+
 def test_configure_tracing_local_server_needs_only_experiment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -492,6 +492,42 @@ def test_recursive_child_span_records_bounded_metadata(monkeypatch: pytest.Monke
     assert "child-ok" not in str(recursive_outputs)
 
 
+def test_recursive_child_span_marks_shutdown_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time
+
+    from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
+    from fleet_rlm.rlm.model_bundle import RLMModelBundle
+    from fleet_rlm.rlm.recursive_calls import RecursiveRLMExecutor, RecursiveRLMOptions
+
+    calls = _install_fake_mlflow(monkeypatch)
+    adapter = dspy.JSONAdapter()
+    executor = RecursiveRLMExecutor(
+        models=RLMModelBundle(
+            dspy.utils.DummyLM(
+                [{"reasoning": "submit", "code": "SUBMIT(answer='child-ok')"}],
+                adapter=adapter,
+            ),
+            dspy.utils.DummyLM([{"answer": "fallback"}], adapter=adapter),
+        ),
+        options=RecursiveRLMOptions(),
+        child_interpreter_factory=lambda: DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+        deadline=time.monotonic() + 30,
+    )
+
+    def _shutdown_boom(self: DaytonaCodeInterpreter) -> None:
+        del self
+        raise RuntimeError("shutdown failed")
+
+    monkeypatch.setattr(DaytonaCodeInterpreter, "shutdown", _shutdown_boom)
+
+    with pytest.raises(RuntimeError, match="shutdown failed"), turn_trace(uuid4(), uuid4(), enabled=True):
+        executor.tool(prompt="classify selected row")
+
+    recursive_outputs = [payload for payload in calls.span_outputs if payload.get("phase_status")]
+    assert recursive_outputs[-1]["phase_status"] == "failed"
+    assert recursive_outputs[-1]["failure_category"] == "unknown"
+
+
 def test_recursive_depth_fallback_span_records_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     import time
 

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -528,6 +528,39 @@ def test_recursive_child_span_marks_shutdown_failure(monkeypatch: pytest.MonkeyP
     assert recursive_outputs[-1]["failure_category"] == "unknown"
 
 
+def test_recursive_child_span_marks_native_setup_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time
+
+    from fleet_rlm.rlm.model_bundle import RLMModelBundle
+    from fleet_rlm.rlm.recursive_calls import RecursiveRLMExecutor, RecursiveRLMOptions
+
+    calls = _install_fake_mlflow(monkeypatch)
+    adapter = dspy.JSONAdapter()
+
+    def _raise_setup_error() -> None:
+        raise RuntimeError("interpreter setup failed")
+
+    executor = RecursiveRLMExecutor(
+        models=RLMModelBundle(
+            dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
+            dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
+        ),
+        options=RecursiveRLMOptions(),
+        child_interpreter_factory=_raise_setup_error,
+        deadline=time.monotonic() + 30,
+    )
+
+    with pytest.raises(RuntimeError, match="interpreter setup failed"), turn_trace(uuid4(), uuid4(), enabled=True):
+        executor.tool(prompt="slice")
+
+    failed_outputs = [
+        payload
+        for payload in calls.span_outputs
+        if payload.get("phase_status") == "failed" and "failure_category" in payload
+    ]
+    assert failed_outputs[-1]["failure_category"] == "unknown"
+
+
 def test_recursive_depth_fallback_span_records_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     import time
 

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -444,3 +444,110 @@ def test_turn_phase_span_without_active_trace_preserves_body_exception(
         raise expected
 
     assert raised.value is expected
+
+
+def test_recursive_child_span_records_bounded_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time
+
+    from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
+    from fleet_rlm.rlm.model_bundle import RLMModelBundle
+    from fleet_rlm.rlm.recursive_calls import RecursiveRLMExecutor, RecursiveRLMOptions
+
+    calls = _install_fake_mlflow(monkeypatch)
+    adapter = dspy.JSONAdapter()
+    executor = RecursiveRLMExecutor(
+        models=RLMModelBundle(
+            dspy.utils.DummyLM(
+                [{"reasoning": "submit", "code": "SUBMIT(answer='child-ok')"}],
+                adapter=adapter,
+            ),
+            dspy.utils.DummyLM([{"answer": "fallback"}], adapter=adapter),
+        ),
+        options=RecursiveRLMOptions(),
+        child_interpreter_factory=lambda: DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+        deadline=time.monotonic() + 30,
+    )
+
+    with turn_trace(uuid4(), uuid4(), enabled=True):
+        assert executor.tool(prompt="classify selected row") == "child-ok"
+
+    assert calls.start_span_names[:2] == ["fleet_turn", "RLM.recursive_call"]
+    recursive_inputs = [
+        payload
+        for payload in calls.span_inputs
+        if "recursive_depth" in payload and "prompt_chars" in payload and "role" not in payload
+    ]
+    assert recursive_inputs == [
+        {
+            "recursive_depth": 1,
+            "call_index": 1,
+            "prompt_chars": len("classify selected row"),
+        }
+    ]
+    recursive_outputs = [payload for payload in calls.span_outputs if payload.get("termination_mode")]
+    assert recursive_outputs[-1]["termination_mode"] == "typed_submit"
+    assert recursive_outputs[-1]["child_iterations"] == 1
+    assert recursive_outputs[-1]["phase_status"] == "completed"
+    assert "classify selected row" not in str(recursive_inputs)
+    assert "child-ok" not in str(recursive_outputs)
+
+
+def test_recursive_depth_fallback_span_records_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time
+
+    from fleet_rlm.rlm.model_bundle import RLMModelBundle
+    from fleet_rlm.rlm.recursive_calls import RecursiveRLMExecutor, RecursiveRLMOptions
+
+    calls = _install_fake_mlflow(monkeypatch)
+    adapter = dspy.JSONAdapter()
+    executor = RecursiveRLMExecutor(
+        models=RLMModelBundle(
+            dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
+            dspy.utils.DummyLM([{"answer": "fallback-answer"}], adapter=adapter),
+        ),
+        options=RecursiveRLMOptions(max_depth=1),
+        child_interpreter_factory=None,
+        deadline=time.monotonic() + 30,
+    )
+
+    with turn_trace(uuid4(), uuid4(), enabled=True):
+        assert executor.tool(prompt="outer slice") == "fallback-answer"
+
+    assert calls.start_span_names[:2] == ["fleet_turn", "RLM.recursive_call"]
+    outputs = [payload for payload in calls.span_outputs if payload.get("termination_mode")]
+    assert any(payload["termination_mode"] == "depth_fallback" for payload in outputs)
+
+
+def test_recursive_call_span_marks_failure_with_bounded_category(monkeypatch: pytest.MonkeyPatch) -> None:
+    import time
+
+    from fleet_rlm.rlm.model_bundle import RLMModelBundle
+    from fleet_rlm.rlm.recursive_calls import RecursiveRLMExecutor, RecursiveRLMOptions
+
+    calls = _install_fake_mlflow(monkeypatch)
+    adapter = dspy.JSONAdapter()
+    executor = RecursiveRLMExecutor(
+        models=RLMModelBundle(
+            dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
+            dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
+        ),
+        options=RecursiveRLMOptions(max_depth=1),
+        child_interpreter_factory=None,
+        deadline=time.monotonic() + 30,
+    )
+
+    def _boom(self: RecursiveRLMExecutor, prompt: str) -> str:
+        del self, prompt
+        raise TimeoutError("child timed out")
+
+    monkeypatch.setattr(RecursiveRLMExecutor, "_plain_sub_lm", _boom)
+
+    with pytest.raises(TimeoutError), turn_trace(uuid4(), uuid4(), enabled=True):
+        executor.tool(prompt="slice")
+
+    failed_outputs = [
+        payload
+        for payload in calls.span_outputs
+        if payload.get("phase_status") == "failed" and "failure_category" in payload
+    ]
+    assert failed_outputs[-1]["failure_category"] == "timeout"


### PR DESCRIPTION
## Summary

Harden MLflow trace observability for the first quality-loop stack layer.

- Sanitize MLflow and DSPy span inputs, outputs, attributes, namespaced fields, and credential-like keys without exporting raw content.
- Keep recursive-call and Turn-settlement annotations bounded and fail-soft, including cleanup/setup failures.
- Centralize loopback-only settings protection and reject forwarded identity headers by presence.
- No HTTP route, OpenAPI, or SSE schema changes.

## Validation

- `make check`
- Focused tracing/settings suite: 40 passed
- Ruff check and format check
- `git diff --check`

This PR is the bottom draft layer of the stack, based on `dev-0.7`.