### PR TITLE
mut per-07: sessions has_more always false

### DIFF
--- a/src/fleet_rlm/api/routes/sessions.py
+++ b/src/fleet_rlm/api/routes/sessions.py
@@ -97,7 +97,7 @@ async def list_sessions(
         total=page.total,
         offset=offset,
         limit=limit,
-        has_more=offset + len(page.items) < page.total,
+        has_more=False,
     )
 
 


### PR DESCRIPTION
Mutation-testing survivor (#TODO). Applied mutation; local ruff/ty + targeted tests pass. This PR exists only to trigger CircleCI and verify the mutant survives CI (test-coverage gap).