### PR TITLE
mut per-09: drop cancel idempotency guard

### DIFF
--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -661,8 +661,6 @@ class SqlAlchemyTurnStateStore:
                 raise TurnNotFoundError("Turn not found")
             if run.status != "running":
                 return "already_terminal"
-            if run.cancel_requested_at is not None:
-                return "already_requested"
             run.cancel_requested_at = datetime.now(UTC)
             return "requested"
 


### PR DESCRIPTION
Mutation-testing survivor (#TODO). Applied mutation; local ruff/ty + targeted tests pass. This PR exists only to trigger CircleCI and verify the mutant survives CI (test-coverage gap).