### PR TITLE
mut per-10: supervisor ignores TUI crash

### DIFF
--- a/src/fleet_rlm/cli/supervisor.py
+++ b/src/fleet_rlm/cli/supervisor.py
@@ -379,12 +379,6 @@ def _run_backend_and_tui(
                     if tui_returncode is not None:
                         break
                     time.sleep(0.1)
-                if received_signal is None and tui_returncode not in {
-                    0,
-                    128 + signal.SIGINT,
-                    -signal.SIGINT,
-                }:
-                    raise SupervisorError(f"Fleet pi-tui TUI exited with status {tui_returncode}")
             finally:
                 if tui is not None:
                     _stop_process_group(tui)


### PR DESCRIPTION
Mutation-testing survivor (#TODO). Applied mutation; local ruff/ty + targeted tests pass. This PR exists only to trigger CircleCI and verify the mutant survives CI (test-coverage gap).