### PR TITLE
mutation(rlm-02): remove workspace-integrity gate

### DIFF
--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -26,7 +26,6 @@ from fleet_rlm.rlm.dspy_contract import (
 )
 from fleet_rlm.rlm.errors import (
     TurnCancelledError,
-    TurnIntegrityFailureError,
     TurnTerminalError,
 )
 from fleet_rlm.rlm.events import (
@@ -466,14 +465,12 @@ class RLMRunner:
         async for event in self._initial_events(context, observations):
             yield event
         spec = context.capabilities.spec
-        spec, relay, guards, task = self._start_worker(context)
+        spec, relay, _guards, task = self._start_worker(context)
         ownership.task = task
         monitor = _WorkerMonitor(task, relay, context, lambda: self._drain_capability_details(context))
         async for event in self._worker_events(context, observations, relay, monitor):
             yield event
         prediction.append(task.result())
-        if guards.integrity.unresolved:
-            raise TurnIntegrityFailureError
         async for event in self._prediction_events(context, observations, prediction[-1]):
             yield event
         duration_ms = int((time.perf_counter() - started) * 1000)


### PR DESCRIPTION
Mutation-testing survivor. Local ruff/ty + targeted tests pass; this PR triggers CircleCI to verify the mutant survives (test-coverage gap). Fixed commit: `.venv` symlink removed so CI's `uv sync` succeeds.