### PR TITLE
mutation(rlm-03): zero duration_ms (success path)

### DIFF
--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -419,7 +419,7 @@ class RLMRunner:
         started = time.perf_counter()
         prediction: list[Any] = []
         try:
-            async for event in self._run_success(context, outcome, ownership, prediction, started):
+            async for event in self._run_success(context, outcome, ownership, prediction):
                 yield event
         except (GeneratorExit, asyncio.CancelledError):
             duration_ms = int((time.perf_counter() - started) * 1000)
@@ -460,7 +460,6 @@ class RLMRunner:
         outcome: list[RLMOutcome],
         ownership: _WorkerOwnership,
         prediction: list[Any],
-        started: float,
     ) -> AsyncIterator[RuntimeEvent]:
         observations = _ObservationBuffer(EventRecorder(context.run_id, context.session_id))
         async for event in self._initial_events(context, observations):
@@ -476,7 +475,7 @@ class RLMRunner:
             raise TurnIntegrityFailureError
         async for event in self._prediction_events(context, observations, prediction[-1]):
             yield event
-        duration_ms = int((time.perf_counter() - started) * 1000)
+        duration_ms = 0
         result = prediction_result(
             prediction[-1],
             spec.signature,


### PR DESCRIPTION
Mutation-testing survivor. Local ruff/ty + targeted tests pass; this PR triggers CircleCI to verify the mutant survives (test-coverage gap). Fixed commit: `.venv` symlink removed so CI's `uv sync` succeeds.