### PR TITLE
mutation(rlm-06): drop tokenish redaction

### DIFF
--- a/src/fleet_rlm/rlm/sanitize.py
+++ b/src/fleet_rlm/rlm/sanitize.py
@@ -127,8 +127,7 @@ def sanitize_public_error(exc: BaseException | str) -> str:
     else:
         raw = str(exc).strip() or "Turn failed"
 
-    cleaned = _TOKENISH.sub("[redacted]", raw)
-    cleaned = _SECRETISH.sub("[redacted]", cleaned)
+    cleaned = _SECRETISH.sub("[redacted]", raw)
     cleaned = _DSNISH.sub("[redacted-dsn]", cleaned)
     cleaned = _PATHISH.sub("[path]", cleaned)
     cleaned = _PROMPTISH.sub("[redacted-prompt]", cleaned)


### PR DESCRIPTION
Mutation-testing survivor. Local ruff/ty + targeted tests pass; this PR triggers CircleCI to verify the mutant survives (test-coverage gap). Fixed commit: `.venv` symlink removed so CI's `uv sync` succeeds.