### PR TITLE
mutation(rlm-07): drop stack-dump short-circuit

### DIFF
--- a/src/fleet_rlm/rlm/sanitize.py
+++ b/src/fleet_rlm/rlm/sanitize.py
@@ -132,8 +132,6 @@ def sanitize_public_error(exc: BaseException | str) -> str:
     cleaned = _DSNISH.sub("[redacted-dsn]", cleaned)
     cleaned = _PATHISH.sub("[path]", cleaned)
     cleaned = _PROMPTISH.sub("[redacted-prompt]", cleaned)
-    if _STACKISH.search(cleaned) or "Traceback" in cleaned or "\n  File " in cleaned:
-        return "Turn failed"
     # Cap length so stack-like dumps never fill SSE frames.
     if len(cleaned) > 240:
         cleaned = cleaned[:237] + "..."


### PR DESCRIPTION
Mutation-testing survivor. Local ruff/ty + targeted tests pass; this PR triggers CircleCI to verify the mutant survives (test-coverage gap). Fixed commit: `.venv` symlink removed so CI's `uv sync` succeeds.