### PR TITLE
test: close top-6 mutation coverage gaps (TLS, redirects, ownership, traversal, token redaction, field keys)

### DIFF
--- a/tests/unit/backend/files/test_url_tool.py
+++ b/tests/unit/backend/files/test_url_tool.py
@@ -473,3 +473,94 @@ def test_public_fetcher_closes_pool_when_response_processing_fails(monkeypatch: 
         UrllibPublicTextFetcher().fetch("https://example.com/report", max_bytes=1_024)
 
     assert calls == {"released": True, "response_closed": True, "pool_closed": True}
+
+
+def test_public_fetcher_requires_tls_certificate_verification(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.files.url_tool.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(0, 0, 0, "", ("93.184.216.34", 443))],
+    )
+    pool_kwargs: dict[str, object] = {}
+
+    class Response:
+        status = 200
+        headers: ClassVar[dict[str, str]] = {"Content-Type": "text/plain; charset=utf-8"}
+
+        def stream(self, _size: int, *, decode_content: bool):
+            del decode_content
+            return iter((b"ok",))
+
+        def release_conn(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    class Pool:
+        def __init__(self, _host: str, **kwargs: object) -> None:
+            pool_kwargs.update(kwargs)
+
+        def close(self) -> None:
+            pass
+
+        def urlopen(self, _method: str, _target: str, **_kwargs: object) -> Response:
+            return Response()
+
+    monkeypatch.setattr("fleet_rlm.files.url_tool.urllib3.HTTPSConnectionPool", Pool)
+
+    result = UrllibPublicTextFetcher().fetch("https://example.com/report", max_bytes=1_024)
+
+    assert result.text == "ok"
+    assert pool_kwargs["cert_reqs"] == "CERT_REQUIRED"
+    assert pool_kwargs["assert_hostname"] == "example.com"
+    assert pool_kwargs["server_hostname"] == "example.com"
+
+
+def test_public_fetcher_stops_at_configured_redirect_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "fleet_rlm.files.url_tool.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(0, 0, 0, "", ("93.184.216.34", 443))],
+    )
+
+    class Redirect:
+        def __init__(self, location: str) -> None:
+            self.status = 302
+            self.headers = {"Location": location}
+
+        def release_conn(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    class Ok:
+        status = 200
+        headers: ClassVar[dict[str, str]] = {"Content-Type": "text/plain; charset=utf-8"}
+
+        def stream(self, _size: int, *, decode_content: bool):
+            del decode_content
+            return iter((b"ok",))
+
+        def release_conn(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    responses = iter([Redirect(f"https://example.com/next/{index}") for index in range(4)] + [Ok()])
+
+    class Pool:
+        def __init__(self, _host: str, **_kwargs: object) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        def urlopen(self, _method: str, _target: str, **_kwargs: object) -> Redirect | Ok:
+            """Serve one hop per connection: redirects, then a terminal 200 response."""
+            return next(responses)
+
+    monkeypatch.setattr("fleet_rlm.files.url_tool.urllib3.HTTPSConnectionPool", Pool)
+
+    with pytest.raises(UrlToolError, match="redirect limit"):
+        UrllibPublicTextFetcher(max_redirects=3).fetch("https://example.com/start", max_bytes=1_024)

--- a/tests/unit/backend/rlm/test_sanitize.py
+++ b/tests/unit/backend/rlm/test_sanitize.py
@@ -51,3 +51,23 @@ def test_error_redaction_remains_a_transforming_boundary() -> None:
     from fleet_rlm.rlm.sanitize import sanitize_public_error
 
     assert sanitize_public_error("provider token=actual-secret-value") == "provider [redacted]"
+
+
+def test_sanitize_public_error_redacts_bare_provider_token() -> None:
+    from fleet_rlm.rlm.sanitize import sanitize_public_error
+
+    token = "sk-ant-api03-0123456789abcdef0123456789abcdef0123456789abcdef"
+    result = sanitize_public_error(f"authentication error: {token}")
+
+    assert token not in result
+    assert "[redacted]" in result
+
+
+def test_sanitize_public_error_redacts_trailing_bearer_token() -> None:
+    from fleet_rlm.rlm.sanitize import sanitize_public_error
+
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQifQ.fakeSignature"
+    result = sanitize_public_error(f"provider: unauthorized Bearer {jwt}")
+
+    assert jwt not in result
+    assert "[redacted]" in result

--- a/tests/unit/backend/test_artifact_reader_and_promotion.py
+++ b/tests/unit/backend/test_artifact_reader_and_promotion.py
@@ -96,3 +96,68 @@ def test_artifact_promotion_validates_the_complete_owned_candidate_batch() -> No
     assert policy.validate((candidate,), access=access, session_id=session_id, run_id=run_id) == (candidate,)
     with pytest.raises(ArtifactValidationError):
         policy.validate((candidate, candidate), access=access, session_id=session_id, run_id=run_id)
+
+
+@pytest.mark.parametrize("field", ["user_id", "workspace_id", "session_id", "run_id"])
+def test_artifact_promotion_rejects_candidate_owned_by_another_identity(field: str) -> None:
+    from fleet_rlm.artifacts.errors import ArtifactValidationError
+    from fleet_rlm.artifacts.models import ArtifactAccess, ArtifactCandidate
+    from fleet_rlm.artifacts.promotion import ArtifactPromotion
+
+    access = ArtifactAccess(user_id=uuid4(), workspace_id=uuid4())
+    session_id, run_id = uuid4(), uuid4()
+    kwargs = dict(
+        id=uuid4(),
+        user_id=access.user_id,
+        workspace_id=access.workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        kind="text",
+        title=None,
+        media_type="text/plain",
+        byte_size=3,
+        checksum_sha256="ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        staging_path="runs/input/candidate.txt",
+        durable_path="artifacts/output.txt",
+    )
+    kwargs[field] = uuid4()
+    candidate = ArtifactCandidate(**kwargs)
+    policy = ArtifactPromotion(max_bytes=8)
+
+    with pytest.raises(ArtifactValidationError, match="ownership is invalid"):
+        policy.validate((candidate,), access=access, session_id=session_id, run_id=run_id)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["../outside.txt", "runs/../../escape", "back\\slash.txt", "nul\x00.bin"],
+    ids=["dotdot-prefix", "nested-dotdot", "backslash", "nul-byte"],
+)
+@pytest.mark.parametrize("location", ["staging_path", "durable_path"])
+def test_artifact_promotion_rejects_traversal_in_candidate_locations(path: str, location: str) -> None:
+    from fleet_rlm.artifacts.errors import ArtifactValidationError
+    from fleet_rlm.artifacts.models import ArtifactAccess, ArtifactCandidate
+    from fleet_rlm.artifacts.promotion import ArtifactPromotion
+
+    access = ArtifactAccess(user_id=uuid4(), workspace_id=uuid4())
+    session_id, run_id = uuid4(), uuid4()
+    kwargs = dict(
+        id=uuid4(),
+        user_id=access.user_id,
+        workspace_id=access.workspace_id,
+        session_id=session_id,
+        run_id=run_id,
+        kind="text",
+        title=None,
+        media_type="text/plain",
+        byte_size=3,
+        checksum_sha256="ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        staging_path="runs/input/candidate.txt",
+        durable_path="artifacts/output.txt",
+    )
+    kwargs[location] = path
+    candidate = ArtifactCandidate(**kwargs)
+    policy = ArtifactPromotion(max_bytes=8)
+
+    with pytest.raises(ArtifactValidationError, match="location is invalid"):
+        policy.validate((candidate,), access=access, session_id=session_id, run_id=run_id)

--- a/tests/unit/optimization/test_dataset.py
+++ b/tests/unit/optimization/test_dataset.py
@@ -57,3 +57,11 @@ def test_load_export_requires_versioned_container() -> None:
     payload["schema"] = "wrong"
     with pytest.raises(OptimizationDatasetError, match="schema"):
         load_export(payload)
+
+
+def test_validate_records_rejects_forbidden_field_keys() -> None:
+    records = [_record(index) for index in range(25)]
+    records[0]["provenance"]["file_path"] = "exports/summary.json"
+
+    with pytest.raises(OptimizationDatasetError, match="forbidden raw-state field"):
+        validate_records(records)


### PR DESCRIPTION
Closes 6 coverage gaps identified by the mutation-testing campaign on `dev-0.7` (ledger: 27 CI-verified survivors). Each regression test **fails on the corresponding survivor branch** and **passes on clean code** (verified via kill-matrix).

| Gap | Severity | Regression test | Closes survivor PR |
|-----|----------|-----------------|--------------------|
| SEC-01 TLS cert verification disabled | Critical-High | `test_public_fetcher_requires_tls_certificate_verification` | #390 |
| SEC-03 unbounded redirects | High | `test_public_fetcher_stops_at_configured_redirect_limit` | #392 |
| PER-03 promotion ownership bypass | High | `test_artifact_promotion_rejects_candidate_owned_by_another_identity` | #387 |
| PER-04 path traversal in candidate locations | High | `test_artifact_promotion_rejects_traversal_in_candidate_locations` | #388 |
| RLM-06 bare `sk-`/`Bearer` token leak | High | `test_sanitize_public_error_redacts_bare_provider_token` / `...redacts_trailing_bearer_token` | #377 |
| RLM-08 forbidden field-keys pass | High | `test_validate_records_rejects_forbidden_field_keys` | #379 |

## Verification

- **6/6 kill-matrix**: every new test FAILS on its mutant branch (SEC-01/03, PER-03/04, RLM-06, RLM-08).
- All 4 changed test files green on clean code (53 tests, 4 files).
- `ruff check` + `ruff format --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)