### PR TITLE
docs(harness)+ref+feat(skills): identity docs, residue flattening, and capability affordances with workspace installs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,7 +62,9 @@ file at the root of the mounted Workspace Volume Scope. The RLM reads the
 bounded newest records on demand through a host-mediated Tool and appends one
   record only when the user explicitly asks to remember something. Appends are
   immediately durable, independent of Turn Commit, and survive failed or
-  cancelled Runs and Sandbox replacement.
+  cancelled Runs and Sandbox replacement. Append serialization is
+  process-local: one Fleet host writes `MEMORIES.md`; concurrent multi-process
+  append is not coordinated.
 _Avoid_: Session History, automatic Turn-start recall, unbounded learned state
 
 **Workspace Volume Tree**:

--- a/docs/agent-harness/architecture-invariants.md
+++ b/docs/agent-harness/architecture-invariants.md
@@ -3,6 +3,27 @@
 If a change violates an invariant, remediate the code or update this document
 and its matching automated check in the same patch.
 
+## Product identity
+
+Fleet is one product: a durable conversational RLM Session. Judge every change
+by whether it makes one of the following substantially better; if it does not,
+question it:
+
+- the conversational RLM agent — one fresh `dspy.RLM` per Turn; DSPy primitives
+  support that agent, they are not peer execution modes
+- Session continuity — a Session is a context boundary: new Sessions start
+  cold, continuity exists only inside one Session; cross-session persistence
+  happens only through explicit workspace-scope actions (Attachments,
+  Artifacts, Workspace Memory), never automatically
+- the Daytona workspace — durable shared Volume state with replaceable Sandbox
+  compute attached to it
+- the single client protocol — AI SDK UI v1 over SSE plus the generated
+  artifacts owned by `make api-sync`
+
+Fleet is not a general DSPy execution platform. Skills steer the agent's
+guidance only; they never register host executables and never gate which tools
+exist.
+
 ## Backend layers
 
 - `api/` owns HTTP identity, dependency aliases, schemas, routes, OpenAPI, and

--- a/docs/how-to-guides/dspy-integration.md
+++ b/docs/how-to-guides/dspy-integration.md
@@ -136,6 +136,33 @@ readable preview policy, while child traces retain structural metadata only:
 role, model, call index, key/count metadata, usage, duration, failure category,
 and termination mode.
 
+## Delegation lanes
+
+Fleet exposes two bounded ways for the RLM to delegate work to a smaller model.
+
+The default lane is DSPy's native sub-LM: `llm_query(prompt)` for one bounded
+semantic judgment or `llm_query_batched(prompts)` for independent judgments in
+one round trip (`rlm/signature.py` guidance). These run inside the Root
+interpreter namespace as plain LM completions against `RLMModelBundle.sub_lm`,
+so they cost one provider call and inherit the Root trust domain. That
+inheritance is acceptable for prompt-only judgments because the Root's own
+generated code already executes in the same Sandbox.
+
+The opt-in isolation lane is the dedicated child Sandbox exposed as `rlm_query`
+only when `[defaults.rlm] recursion_enabled = true` (the
+`[profiles.daytona-recursive]` profile). Each delegation provisions its own
+ephemeral Sandbox running a full native RLM, mounted at the sibling Volume
+scope `recursive/<workspace>/<run>/<call-index>` with no Fleet capabilities,
+credentials, history, or broker state; strict child cleanup gates Root success.
+Cross-sandbox child runtimes are a Fleet feature, not something DSPy 3.3
+provides, so their cost is sandbox provisioning, broker/interpreter startup,
+and the child's own iteration budget — see `scripts/benchmark_daytona_lifecycle.py`
+for measured spin-up numbers.
+
+Choose the sub-LM lane for prompt-only extraction, counting, classification,
+and judgment. Reserve the child lane for sub-problems that need iterative,
+code-executing, file-touching lifecycles in isolation.
+
 ## Typed startup inputs
 
 Fleet keeps domain dataclasses authoritative and validates the bounded

--- a/src/fleet_rlm/AGENTS.md
+++ b/src/fleet_rlm/AGENTS.md
@@ -76,6 +76,10 @@ contracts, and tracked docs remain authoritative.
   state under the fixed `MEMORIES.md` root and are independent of Turn Commit;
   the Daytona-only `/api/volume/tree` route exposes only a bounded read-only
   logical path view, not a general-purpose filesystem browser.
+  Deployment contract: append serialization is process-local to one Fleet
+  host; statefulness lives in the shared Volume and survives Sandbox
+  replacement; appends from multiple host processes are not coordinated
+  today.
 - Daytona composition owns one process-scoped `AsyncDaytona`. Provisioning,
   lifecycle, filesystem, and FastAPI-facing Workspace operations remain native
   async. Only DSPy's synchronous interpreter and host-tool execution receive

--- a/src/fleet_rlm/api/routes/skills.py
+++ b/src/fleet_rlm/api/routes/skills.py
@@ -23,7 +23,7 @@ def _to_response(card: SkillCard) -> SkillCardResponse:
         scope="system",
         version=card.version,
         trust="system",
-        affordances=[],
+        affordances=list(card.affordances),
         resources_available=card.resources_available,
     )
 

--- a/src/fleet_rlm/chat/capability_preparation.py
+++ b/src/fleet_rlm/chat/capability_preparation.py
@@ -92,13 +92,11 @@ async def prepare_host_capabilities(
     *,
     turn: ExecuteTurn,
     skill_catalog: SkillCatalog,
-    files: Any,
     base_tools: Sequence[dspy.Tool],
     base_event_views: Mapping[str, ToolEventView],
     workspace: WorkspaceCapabilityMetadata,
     deadline: float,
 ) -> tuple[RLMExecutionSpec, SkillToolHost | EmptySkillHost, tuple[PreparationNotice, ...]]:
-    del files
     """Resolve history and exact Skills identically for every Run environment."""
     history_host = SessionHistoryToolHost(turn.history)
     history_tools = history_host.as_tools()

--- a/src/fleet_rlm/chat/capability_preparation.py
+++ b/src/fleet_rlm/chat/capability_preparation.py
@@ -11,7 +11,7 @@ import dspy
 
 from fleet_rlm.chat.turn_lifecycle import ExecuteTurn
 from fleet_rlm.chat.turn_preparation import TurnPreparationCancelledError, TurnPreparationTimeoutError
-from fleet_rlm.files.workspace_models import WorkspaceCapabilityMetadata
+from fleet_rlm.files.workspace_models import SessionWorkspaceFS, WorkspaceCapabilityMetadata
 from fleet_rlm.rlm.context import PreparationNotice, RLMExecutionSpec
 from fleet_rlm.rlm.events import AttachmentRead, SkillActivated, SkillLoaded
 from fleet_rlm.rlm.tool_observer import ToolEventView
@@ -95,6 +95,7 @@ async def prepare_host_capabilities(
     base_tools: Sequence[dspy.Tool],
     base_event_views: Mapping[str, ToolEventView],
     workspace: WorkspaceCapabilityMetadata,
+    workspace_fs: SessionWorkspaceFS | None = None,
     deadline: float,
 ) -> tuple[RLMExecutionSpec, SkillToolHost | EmptySkillHost, tuple[PreparationNotice, ...]]:
     """Resolve history and exact Skills identically for every Run environment."""
@@ -128,6 +129,7 @@ async def prepare_host_capabilities(
     skill_host = SkillToolHost(
         skill_catalog,
         allowed_skill_ids=(frozenset(skill.card.id for skill in resolved.selected) if selections else None),
+        workspace=workspace_fs,
     )
     schema_id, schema_version = resolved_schema(resolved)
     spec = RLMExecutionSpec(

--- a/src/fleet_rlm/composition/testing.py
+++ b/src/fleet_rlm/composition/testing.py
@@ -224,7 +224,6 @@ class TestingCapabilityPreparer:
         spec, skill_host, notices = await prepare_host_capabilities(
             turn=turn,
             skill_catalog=self._skill_catalog,
-            files=file_host,
             base_tools=(*file_tools, *url_tools),
             base_event_views={**file_event_views, **url_event_views},
             workspace=UNAVAILABLE_WORKSPACE_CAPABILITY,

--- a/src/fleet_rlm/daytona/http_broker.py
+++ b/src/fleet_rlm/daytona/http_broker.py
@@ -27,11 +27,8 @@ from daytona import SessionExecuteRequest
 
 from fleet_rlm.daytona.broker_source import (
     BROKER_SERVER_CODE,
-    FINAL_OUTPUT_MARKER,
     TOOL_WRAPPER_TEMPLATE,
-    build_submit_setup_code,  # noqa: F401 - compatibility re-export
     extract_final_payload,
-    final_output_frame,  # noqa: F401 - compatibility re-export
     remote_submit_setup_code,
 )
 from fleet_rlm.daytona.errors import (
@@ -50,7 +47,6 @@ DEFAULT_BROKER_PORT = 3000
 _PREVIEW_LINK_RETRY_DELAYS = (0.25, 0.5)
 _BROKER_SERVER_PATH = "/home/daytona/fleet_rlm_broker_server.py"
 _BROKER_SESSION_COMMAND = f"cd /home/daytona && python {_BROKER_SERVER_PATH.rsplit('/', 1)[-1]}"
-_FINAL_OUTPUT_MARKER = FINAL_OUTPUT_MARKER
 _MAX_EXECUTE_REQUEST_BYTES = 2 * 1024 * 1024
 _MAX_EXECUTE_OUTPUT_CHARS = 64 * 1024
 
@@ -68,12 +64,6 @@ class FleetFinalOutputError(Exception):
     def __init__(self, value: dict[str, Any]) -> None:
         self.value = value
         super().__init__("Final output submitted")
-
-
-# Keep the old private names available to diagnostics/tests while the pure
-# source payloads live in ``broker_source``.
-_BROKER_SERVER_CODE = BROKER_SERVER_CODE
-_TOOL_WRAPPER_TEMPLATE = TOOL_WRAPPER_TEMPLATE
 
 
 class DaytonaHttpToolBroker:
@@ -128,7 +118,7 @@ class DaytonaHttpToolBroker:
         if self._broker_url is not None or self._stopped:
             return
         server_code = (
-            _BROKER_SERVER_CODE.replace("__BROKER_SECRET__", repr(self._broker_secret))
+            BROKER_SERVER_CODE.replace("__BROKER_SECRET__", repr(self._broker_secret))
             .replace("__BROKER_PORT__", str(self._broker_port))
             .replace("__MAX_REQUEST_BYTES__", str(_MAX_EXECUTE_REQUEST_BYTES))
             .replace("__MAX_OUTPUT_CHARS__", str(_MAX_EXECUTE_OUTPUT_CHARS))
@@ -620,7 +610,7 @@ class DaytonaHttpToolBroker:
                 kwargs_parts.append(f'"{name}": {name}')
             else:
                 args_list.append(name)
-        return _TOOL_WRAPPER_TEMPLATE.format(
+        return TOOL_WRAPPER_TEMPLATE.format(
             tool_name=tool_name,
             signature=", ".join(sig_parts),
             args_list=", ".join(args_list),

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -342,6 +342,7 @@ class _LiveCapabilityPreparer:
             base_tools=(*file_tools, *workspace_tools, *memory_tools, *url_tools),
             base_event_views=base_views,
             workspace=DAYTONA_WORKSPACE_CAPABILITY,
+            workspace_fs=session_workspace,
             deadline=deadline,
         )
         return LivePreparedCapabilities(

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -339,7 +339,6 @@ class _LiveCapabilityPreparer:
         spec, skill_host, notices = await prepare_host_capabilities(
             turn=turn,
             skill_catalog=self.skill_catalog,
-            files=file_host,
             base_tools=(*file_tools, *workspace_tools, *memory_tools, *url_tools),
             base_event_views=base_views,
             workspace=DAYTONA_WORKSPACE_CAPABILITY,

--- a/src/fleet_rlm/daytona/session_manager.py
+++ b/src/fleet_rlm/daytona/session_manager.py
@@ -507,13 +507,13 @@ class DaytonaSessionManager:
                 raise DaytonaAdapterError(
                     message="sandbox replacement did not produce a sandbox id",
                     cause_type="SandboxReplaceIdentityError",
-                )
+                ) from exc
             replacement_sandbox = await self._get_bound_sandbox(replacement_id)
             if replacement_sandbox is None:
                 raise DaytonaAdapterError(
                     message="replacement sandbox is not retrievable",
                     cause_type="SandboxUnrecoverable",
-                )
+                ) from exc
             return replacement_sandbox
 
     async def _get_bound_sandbox(self, sandbox_id: str) -> Any | None:

--- a/src/fleet_rlm/skills/bundled/README.md
+++ b/src/fleet_rlm/skills/bundled/README.md
@@ -20,3 +20,15 @@ The catalog follows three disclosure levels:
    after that Skill is loaded.
 
 Bundled Skills contain model-facing product workflows only. Repository maintenance, operator diagnostics, browser development, and Skill authoring guidance belong in the development agent catalog and canonical documentation.
+
+## Catalog conventions
+
+- Every Skill Card advertises bounded `affordances` — the capability families
+  the Skill expects (for example `workspace.files`, `artifacts.publish`,
+  `fetch_url`, `llm_query`, `llm_query_batched`). Affordances are guidance only;
+  they never gate which host tools exist.
+- While a Turn has Session Workspace capability, loading a Skill (explicit
+  selection preload or progressive `load_skill`) installs its resources at
+  `skills/<name>/<path>` in the Session Workspace so generated code can read or
+  execute them. Installs are idempotent per Turn, all-or-nothing on failure,
+  and resources remain readable through `read_skill_resource` regardless.

--- a/src/fleet_rlm/skills/catalog.py
+++ b/src/fleet_rlm/skills/catalog.py
@@ -24,6 +24,7 @@ class _BundledSpec:
     version: str
     resources: tuple[tuple[str, str], ...] = ()
     signature: type[dspy.Signature] | None = None
+    affordances: tuple[str, ...] = ()
 
 
 _BUNDLED_SPECS = (
@@ -33,6 +34,7 @@ _BUNDLED_SPECS = (
         "(Recursive Language Model / REPL code agent). Not for RAG or dspy.Retrieve.",
         "1.0.0",
         (("references/rlm-contract.md", "text/markdown"),),
+        affordances=("interpreter", "llm_query"),
     ),
     _BundledSpec(
         "long-context",
@@ -43,23 +45,27 @@ _BUNDLED_SPECS = (
             ("scripts/rank_chunks.py", "text/x-python"),
             ("references/chunking-strategies.md", "text/markdown"),
         ),
+        affordances=("fetch_url", "llm_query_batched", "workspace.files"),
     ),
     _BundledSpec(
         "workspace-files",
         "Use durable Session Workspace, Attachment, and Artifact tools correctly.",
         "1.0.0",
         (("references/filesystem-contract.md", "text/markdown"),),
+        affordances=("workspace.files", "artifacts.publish"),
     ),
     _BundledSpec(
         "data-analysis",
         "Compute and verify descriptive statistics, trends, and qualified anomalies.",
         "1.0.0",
         signature=DataAnalysisSignature,
+        affordances=("artifacts.publish", "llm_query_batched"),
     ),
     _BundledSpec(
         "report-builder",
         "Create, save, read back, and verify reports from trusted source data.",
         "1.0.0",
+        affordances=("workspace.files", "artifacts.publish"),
     ),
 )
 
@@ -117,6 +123,13 @@ def build_bundled_skill_catalog() -> SkillCatalog:
         }
         if spec.signature is not None:
             validate_skill_signature(spec.signature)
-        card = SkillCard(stable_skill_id(spec.name), spec.name, spec.description, spec.version, bool(resources))
+        card = SkillCard(
+            stable_skill_id(spec.name),
+            spec.name,
+            spec.description,
+            spec.version,
+            bool(resources),
+            spec.affordances,
+        )
         definitions.append(SkillDefinition(card, instructions, resources, spec.signature))
     return SkillCatalog(tuple(definitions))

--- a/src/fleet_rlm/skills/models.py
+++ b/src/fleet_rlm/skills/models.py
@@ -12,6 +12,7 @@ from uuid import UUID
 import dspy
 
 _SAFE_NAME = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_SAFE_AFFORDANCE = re.compile(r"^[a-z0-9]+([._-][a-z0-9]+)*$")
 _SAFE_VERSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
 
 
@@ -44,6 +45,7 @@ class SkillCard:
     description: str
     version: str
     resources_available: bool
+    affordances: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not isinstance(self.id, UUID):
@@ -66,6 +68,20 @@ class SkillCard:
             raise ValueError("invalid skill version")
         if not isinstance(self.resources_available, bool):
             raise ValueError("skill resource flag must be boolean")
+        affordances = tuple(self.affordances)
+        if (
+            len(affordances) > 8
+            or len(set(affordances)) != len(affordances)
+            or any(
+                not isinstance(value, str)
+                or not 1 <= len(value) <= 32
+                or not value.isprintable()
+                or _SAFE_AFFORDANCE.fullmatch(value) is None
+                for value in affordances
+            )
+        ):
+            raise ValueError("invalid skill affordances")
+        object.__setattr__(self, "affordances", affordances)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/fleet_rlm/skills/tools.py
+++ b/src/fleet_rlm/skills/tools.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 import dspy
 
+from fleet_rlm.files.workspace_models import SessionWorkspaceFS
 from fleet_rlm.rlm.events import JsonValue
 from fleet_rlm.rlm.tool_observer import ToolEventView, bound_event_text
 from fleet_rlm.skills.catalog import SkillCatalog
@@ -24,7 +25,7 @@ def skill_activated_public_payload(skill: SkillDefinition) -> dict[str, Any]:
         "name": card.name,
         "version": card.version,
         "trust": "system",
-        "affordances": [],
+        "affordances": list(card.affordances),
     }
 
 
@@ -42,13 +43,41 @@ class SkillToolHost:
         *,
         allowed_skill_ids: frozenset[UUID] | None = None,
         max_loaded_skills: int = 4,
+        workspace: SessionWorkspaceFS | None = None,
     ) -> None:
         self._catalog = catalog
         self._allowed_skill_ids = allowed_skill_ids
         self._max_loaded_skills = min(4, max(0, int(max_loaded_skills)))
+        self._workspace = workspace
         self._loaded_ids: set[UUID] = set()
+        self._installed_ids: set[UUID] = set()
         self._pending_events: list[dict[str, Any]] = []
         self._lock = RLock()
+
+    @staticmethod
+    def _installed_paths(skill: SkillDefinition) -> tuple[str, ...]:
+        return tuple(f"skills/{skill.card.name}/{resource.path}" for resource in skill.resources.values())
+
+    def _install_resources(self, skill: SkillDefinition) -> tuple[str, ...]:
+        """Persist loaded Skill resources as addressable Session Workspace files.
+
+        Resources stay read-only UTF-8 text owned by the bundled catalog; the
+        install only surfaces them at `skills/<name>/<path>` so generated code
+        can read or execute them. All-or-nothing: a write failure skips the
+        install (resources remain readable via `read_skill_resource`).
+        """
+        workspace = self._workspace
+        if workspace is None or not skill.resources:
+            return ()
+        if skill.card.id in self._installed_ids:
+            return self._installed_paths(skill)
+        for path, resource in zip(self._installed_paths(skill), skill.resources.values(), strict=True):
+            try:
+                workspace.write_text(path, resource.content, overwrite=True)
+            except Exception:
+                return ()
+        self._installed_ids.add(skill.card.id)
+        return self._installed_paths(skill)
 
     @property
     def loaded_skill_ids(self) -> frozenset[UUID]:
@@ -84,6 +113,7 @@ class SkillToolHost:
             if len(self._loaded_ids) >= self._max_loaded_skills:
                 raise ValueError("too many loaded Skills")
             self._loaded_ids.add(skill.card.id)
+            self._install_resources(skill)
             self._pending_events.extend((skill_activated_public_payload(skill), skill_loaded_public_payload(skill)))
 
     def load_skill(self, skill_id: str, expected_version: str | None = None) -> dict[str, Any]:
@@ -95,8 +125,9 @@ class SkillToolHost:
                 if len(self._loaded_ids) >= self._max_loaded_skills:
                     return {"ok": False, "error": "skill_limit_exceeded"}
                 self.mark_preloaded(skill)
+            installed_paths = self._install_resources(skill)
         card = skill.card
-        return {
+        result: dict[str, Any] = {
             "ok": True,
             "skill_id": str(card.id),
             "name": card.name,
@@ -113,6 +144,9 @@ class SkillToolHost:
                 for resource in skill.resources.values()
             ],
         }
+        if self._workspace is not None:
+            result["installed_paths"] = list(installed_paths)
+        return result
 
     def read_skill_resource(
         self, skill_id: str, resource_path: str, expected_version: str | None = None

--- a/tests/contracts/backend/test_host_tool_submit_binding.py
+++ b/tests/contracts/backend/test_host_tool_submit_binding.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import json
 
-from fleet_rlm.daytona.http_broker import extract_final_payload, remote_submit_setup_code
+from fleet_rlm.daytona.broker_source import extract_final_payload, remote_submit_setup_code
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 from fleet_rlm.rlm.dspy_contract import RLMOptions, build_native_rlm
 from fleet_rlm.rlm.dspy_interpreter_contract import FinalOutput
@@ -31,7 +31,7 @@ def test_remote_submit_setup_emits_marker_payload() -> None:
 
 
 def test_submit_payload_encoding_survives_marker_text_in_json() -> None:
-    from fleet_rlm.daytona.http_broker import FINAL_OUTPUT_MARKER
+    from fleet_rlm.daytona.broker_source import FINAL_OUTPUT_MARKER
 
     encoded = base64.b64encode(
         json.dumps({"answer": f"left {FINAL_OUTPUT_MARKER} right"}, ensure_ascii=False).encode("utf-8")

--- a/tests/contracts/backend/test_skills_api.py
+++ b/tests/contracts/backend/test_skills_api.py
@@ -55,6 +55,11 @@ def test_bundled_skill_cards_are_bounded_metadata_only() -> None:
         assert _PRIVATE_FIELDS.isdisjoint(card)
 
     serialized = json.dumps(cards).lower()
+    assert next(card for card in cards if card["name"] == "long-context")["affordances"] == [
+        "fetch_url",
+        "llm_query_batched",
+        "workspace.files",
+    ]
     assert "# long-context analysis" not in serialized
     assert "# workspace files" not in serialized
     assert "# dspy rlm" not in serialized

--- a/tests/unit/backend/daytona/test_interpreter_observation.py
+++ b/tests/unit/backend/daytona/test_interpreter_observation.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from fleet_rlm.daytona.broker_source import FINAL_OUTPUT_MARKER
 from fleet_rlm.daytona.errors import DaytonaAdapterError
-from fleet_rlm.daytona.http_broker import FINAL_OUTPUT_MARKER
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend, sandbox_backend
 from fleet_rlm.rlm.errors import TurnNoProgressError
 from fleet_rlm.rlm.events import RLMCode, RLMOutput, StepFinished, StepStarted, ToolCompleted, ToolStarted

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -26,8 +26,8 @@ class _RecordingTool:
 
 
 def test_co_located_worker_preserves_state_and_services_callbacks(tmp_path: Path) -> None:
+    from fleet_rlm.daytona.broker_source import BROKER_SERVER_CODE
     from fleet_rlm.daytona.http_broker import (
-        _BROKER_SERVER_CODE,
         _MAX_EXECUTE_OUTPUT_CHARS,
         _MAX_EXECUTE_REQUEST_BYTES,
         DaytonaHttpToolBroker,
@@ -38,7 +38,7 @@ def test_co_located_worker_preserves_state_and_services_callbacks(tmp_path: Path
         port = int(reservation.getsockname()[1])
     secret = "test-broker-secret"
     source = (
-        _BROKER_SERVER_CODE.replace("__BROKER_SECRET__", repr(secret))
+        BROKER_SERVER_CODE.replace("__BROKER_SECRET__", repr(secret))
         .replace("__BROKER_PORT__", str(port))
         .replace("__MAX_REQUEST_BYTES__", str(_MAX_EXECUTE_REQUEST_BYTES))
         .replace("__MAX_OUTPUT_CHARS__", str(_MAX_EXECUTE_OUTPUT_CHARS))

--- a/tests/unit/backend/test_import_safety.py
+++ b/tests/unit/backend/test_import_safety.py
@@ -60,9 +60,7 @@ def test_settings_exclude_secrets_from_serialization() -> None:
 def test_composition_common_import_does_not_configure_dspy_providers() -> None:
     """Importing composition.common alone must not configure a DSPy provider LM."""
     script = (
-        "import fleet_rlm.composition.common\n"
-        "import dspy\n"
-        "assert dspy.settings.lm is None, repr(dspy.settings.lm)\n"
+        "import fleet_rlm.composition.common\nimport dspy\nassert dspy.settings.lm is None, repr(dspy.settings.lm)\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", script],

--- a/tests/unit/backend/test_skill_catalog.py
+++ b/tests/unit/backend/test_skill_catalog.py
@@ -102,3 +102,18 @@ def test_models_are_immutable_and_validate_paths_versions_and_bodies() -> None:
         SkillDefinition(SkillCard(uuid4(), "empty", "Empty", "1", False), "")
     with pytest.raises(ValueError, match="version"):
         SkillSelectionRef(uuid4(), "")
+
+
+def test_bundled_cards_advertise_bounded_capability_affordances() -> None:
+    """Cards name the capability families each Skill expects so the model and
+    operator see them before loading; affordances stay closed and bounded."""
+
+    catalog = build_bundled_skill_catalog()
+    by_name = {card.name: card for card in catalog.cards()}
+    assert by_name["long-context"].affordances == ("fetch_url", "llm_query_batched", "workspace.files")
+    assert by_name["workspace-files"].affordances == ("workspace.files", "artifacts.publish")
+    assert by_name["data-analysis"].affordances == ("artifacts.publish", "llm_query_batched")
+    assert by_name["report-builder"].affordances == ("workspace.files", "artifacts.publish")
+    assert by_name["dspy-rlm"].affordances == ("interpreter", "llm_query")
+    assert all(isinstance(card.affordances, tuple) for card in catalog.cards())
+    assert all(len(card.affordances) <= 8 for card in catalog.cards())

--- a/tests/unit/backend/test_skill_tools.py
+++ b/tests/unit/backend/test_skill_tools.py
@@ -2,6 +2,8 @@
 
 from uuid import uuid4
 
+import pytest
+
 from fleet_rlm.skills.catalog import build_bundled_skill_catalog, stable_skill_id
 from fleet_rlm.skills.tools import SkillToolHost
 
@@ -75,3 +77,137 @@ def test_preload_restricts_catalog_and_events_are_metadata_only() -> None:
     events = host.drain_public_events()
     assert [event["kind"] for event in events] == ["skill.activated", "skill.loaded"]
     assert selected.instructions not in repr(events)
+
+
+class _RecordingWorkspace:
+    def __init__(self, *, raise_on_write: bool = False) -> None:
+        self.written: dict[str, str] = {}
+        self.calls: list[str] = []
+        self._raise = raise_on_write
+
+    def write_text(self, path: str, content: str, *, overwrite: bool) -> None:
+        del overwrite  # overwrite semantics exercised by the host, not the fake
+        self.calls.append(path)
+        if self._raise:
+            raise OSError("volume write failed")
+        self.written[path] = content
+
+
+def test_activated_event_advertises_card_affordances() -> None:
+    catalog = build_bundled_skill_catalog()
+    skill = catalog.require(stable_skill_id("long-context"))
+    host = SkillToolHost(catalog)
+    host.mark_preloaded(skill)
+    events = host.drain_public_events()
+    assert events[0]["kind"] == "skill.activated"
+    assert events[0]["affordances"] == list(skill.card.affordances)
+    assert "affordances" not in events[1]  # loaded lifecycle stays metadata-only
+
+
+def test_preload_installs_resources_to_session_workspace() -> None:
+    catalog = build_bundled_skill_catalog()
+    skill = catalog.require(stable_skill_id("long-context"))
+    workspace = _RecordingWorkspace()
+    host = SkillToolHost(catalog, workspace=workspace)
+
+    host.mark_preloaded(skill)
+
+    assert set(workspace.written) == {
+        "skills/long-context/scripts/semantic_chunk.py",
+        "skills/long-context/scripts/rank_chunks.py",
+        "skills/long-context/references/chunking-strategies.md",
+    }
+    assert workspace.written["skills/long-context/references/chunking-strategies.md"] == (
+        skill.resources["references/chunking-strategies.md"].content
+    )
+
+
+def test_progressive_load_reports_installed_paths_and_is_idempotent() -> None:
+    catalog = build_bundled_skill_catalog()
+    skill = catalog.require(stable_skill_id("long-context"))
+    workspace = _RecordingWorkspace()
+    host = SkillToolHost(catalog, workspace=workspace)
+
+    first = host.load_skill(str(skill.card.id), skill.card.version)
+    second = host.load_skill(str(skill.card.id), skill.card.version)
+
+    assert first == second
+    assert first["installed_paths"] == [
+        "skills/long-context/scripts/semantic_chunk.py",
+        "skills/long-context/scripts/rank_chunks.py",
+        "skills/long-context/references/chunking-strategies.md",
+    ]
+    # One write pass for mark + one for the first load (dedupe), none on repeat.
+    assert workspace.calls == workspace.calls[: len(workspace.written) * 2]
+
+
+def test_install_failure_degrades_to_resource_tool_reads_only() -> None:
+    catalog = build_bundled_skill_catalog()
+    skill = catalog.require(stable_skill_id("long-context"))
+    workspace = _RecordingWorkspace(raise_on_write=True)
+    host = SkillToolHost(catalog, workspace=workspace)
+
+    result = host.load_skill(str(skill.card.id), skill.card.version)
+
+    assert result["ok"] is True
+    assert result["installed_paths"] == []
+    assert workspace.written == {}
+    # Resources stay reachable through the read tool after a failed install.
+    path = next(iter(skill.resources))
+    assert host.read_skill_resource(str(skill.card.id), path)["ok"] is True
+
+
+def test_no_workspace_means_no_install_surface() -> None:
+    catalog = build_bundled_skill_catalog()
+    skill = catalog.require(stable_skill_id("long-context"))
+    host = SkillToolHost(catalog)
+
+    first = host.load_skill(str(skill.card.id), skill.card.version)
+    second = host.load_skill(str(skill.card.id), skill.card.version)
+
+    assert "installed_paths" not in first
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_prepare_host_capabilities_installs_preloaded_skill_resources() -> None:
+    from uuid import uuid4 as _uuid4
+
+    from fleet_rlm.chat.capability_preparation import prepare_host_capabilities
+    from fleet_rlm.chat.turn_lifecycle import ExecuteTurn, _TurnClaimToken
+    from fleet_rlm.files.workspace_models import UNAVAILABLE_WORKSPACE_CAPABILITY
+    from fleet_rlm.sessions.models import HistoryMessage, SessionHistory, TurnAccess, TurnInput
+    from fleet_rlm.skills.models import SkillSelectionRef
+
+    async def not_cancelled() -> bool:
+        return False
+
+    catalog = build_bundled_skill_catalog()
+    skill = catalog.require(stable_skill_id("long-context"))
+    workspace = _RecordingWorkspace()
+    turn = ExecuteTurn(
+        _uuid4(),
+        _uuid4(),
+        TurnAccess(_uuid4(), _uuid4()),
+        TurnInput(
+            "analyze the corpus",
+            skill_selections=(SkillSelectionRef(id=skill.card.id, expected_version=skill.card.version),),
+        ),
+        SessionHistory((HistoryMessage("user", "prior"),)),
+        not_cancelled,
+        _TurnClaimToken(_uuid4()),
+    )
+
+    spec, _skill_host, notices = await prepare_host_capabilities(
+        turn=turn,
+        skill_catalog=catalog,
+        base_tools=(),
+        base_event_views={},
+        workspace=UNAVAILABLE_WORKSPACE_CAPABILITY,
+        workspace_fs=workspace,
+        deadline=float("inf"),
+    )
+
+    assert notices == ()
+    assert spec.output_schema_id == "fleet.default"  # long-context has no custom signature
+    assert "skills/long-context/references/chunking-strategies.md" in workspace.written

--- a/tools/fleet-tui/AGENTS.md
+++ b/tools/fleet-tui/AGENTS.md
@@ -27,6 +27,9 @@ Individual lanes: `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check
 ## Constraints
 
 - Monochrome operator timeline; no mouse capture, no transcript viewport.
+- Single client protocol: the AI SDK UI v1 stream projected by
+  `src/fleet_rlm/api/sse.py`, with HTTP types owned by `make api-sync`. Do not
+  design a second client protocol unless a second client exists.
 - State mutations exclusively through `store.dispatch`; no direct mutation.
 - SSE ordering invariants are enforced in `streamFleetTurn` — one start, one terminal, [DONE] last.
 - API errors use `FleetApiError` with `status`, `correlationId`, `code`.

--- a/tools/fleet-tui/src/tui/message-renderer.ts
+++ b/tools/fleet-tui/src/tui/message-renderer.ts
@@ -130,7 +130,13 @@ export function renderMessage(
     case "skill":
       return wrappedLine(
         `  ${theme.fg("accent", theme.bold(`· SKILL ${message.phase.toUpperCase()}`))}  ${theme.bold(terminalSafeText(message.name))}  ${muted(
-          [`v${message.version}`, message.trust ? terminalSafeText(message.trust) : null]
+          [
+            `v${message.version}`,
+            message.trust ? terminalSafeText(message.trust) : null,
+            message.affordances?.length
+              ? `can use ${message.affordances.map(terminalSafeText).join(", ")}`
+              : null,
+          ]
             .filter((value): value is string => value !== null)
             .join(" · "),
         )}`,

--- a/tools/fleet-tui/src/tui/projection.ts
+++ b/tools/fleet-tui/src/tui/projection.ts
@@ -546,6 +546,9 @@ function skill(
         ? "activated"
         : "loaded";
   const trust = optionalString(value.trust);
+  const affordances = Array.isArray(value.affordances)
+    ? value.affordances.filter((item): item is string => typeof item === "string")
+    : undefined;
   return {
     id,
     kind: "skill",
@@ -555,6 +558,7 @@ function skill(
     phase,
     version: string(value.version, "1.0.0"),
     ...(trust ? { trust } : {}),
+    ...(affordances?.length ? { affordances } : {}),
     ts: clock(),
   };
 }

--- a/tools/fleet-tui/src/tui/store.ts
+++ b/tools/fleet-tui/src/tui/store.ts
@@ -76,6 +76,7 @@ export type Message =
       phase: "activated" | "loaded";
       version: string;
       trust?: string;
+      affordances?: string[];
       ts: number;
     }
   | {

--- a/tools/fleet-tui/src/tui/tests/message-renderer.test.ts
+++ b/tools/fleet-tui/src/tui/tests/message-renderer.test.ts
@@ -348,6 +348,21 @@ describe("renderMessage", () => {
     };
 
     expect(renderMessage(activated, 60).join("\n")).toContain("SKILL ACTIVATED");
+    const withAffordances: Message = {
+      id: "affordance-skill",
+      kind: "skill",
+      runId: "run",
+      skillId: "skill",
+      name: "inspect",
+      phase: "activated",
+      version: "2",
+      trust: "workspace",
+      affordances: ["workspace.files", "artifacts.publish"],
+      ts: 3,
+    };
+    expect(renderMessage(withAffordances, 120).join("\n")).toContain(
+      "can use workspace.files, artifacts.publish",
+    );
     const loadedOutput = renderMessage(loaded, 60).join("\n");
     expect(loadedOutput).toContain("SKILL LOADED");
     expect(loadedOutput).not.toContain("system");


### PR DESCRIPTION
# Description

Aligns `dev-0.7` with the ratified product identity and lands the skills capability work in four logical commits.

## Commits

- **`fix(lint)`** — repair B904 chaining in `daytona/session_manager.py` and an unformatted `test_import_safety.py` (regressions inherited from the #414 merge race; `dev-0.7` tip was lint-red before this)
- **`docs(harness)`** — codify the Product identity filter (one durable conversational RLM Session; sessions start cold, continuity is intra-session only; Skills steer guidance, never trust), document the two delegation lanes (default DSPy-native `llm_query`/`llm_query_batched` vs opt-in `daytona-recursive` child Sandbox), the single-process Workspace Memory append contract, and the single AI SDK UI v1 client protocol
- **`ref(daytona,chat)`** — flatten `http_broker.py` compat residue (2 re-exports + marker/template aliases removed; imports point at `broker_source` directly) and drop the vestigial `files` parameter (del-ed on entry) from `prepare_host_capabilities` — net −14 LOC, zero behavior change
- **`feat(skills)`** — Skill Cards and activation events now carry bounded `affordances` (surfaced on `/api/skills` and TUI skill rows;**zero wire-drift** — the API field pre-existed); while a Turn has Session Workspace capability, preloading or progressively loading a Skill **installs its resources at `skills/<name>/<path>`** in the Session Workspace so generated code can read or execute them (`semantic_chunk.py`, `rank_chunks.py` become runnable files, not copy-paste text). Installs are idempotent per Turn, all-or-nothing on write failure, with `read_skill_resource` as fallback. **No new RuntimeEvent kinds, no SSE contract change** — the load result reuses the closed tool-output channel (`installed_paths`).

## Validation

- `make check` green on the final commit (coverage 82.06% ≥ 75%; Ruff lint/format, `ty`, `api-check`, `stream-check`, TUI 187 tests, codebase-tree boundaries, docs + harness checks)
- New tests: catalog affordance population, activated-payload affordances, preload + progressive install, install dedupe/idempotency, install-failure degradation, no-workspace surface, `prepare_host_capabilities` wiring, API affordances, TUI renderer affordances

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] Relevant local validation passed (`make check` on the final commit)
- [x] Commit messages follow conventions
- [x] PR description clearly explains the change
- [x] Documentation updated (identity filter, delegation lanes, memory contract, client protocol, bundled Skills README)
