### PR TITLE
ref(rlm): bundle Turn context vocabulary into deep members

### DIFF
--- a/src/fleet_rlm/chat/turn_preparation.py
+++ b/src/fleet_rlm/chat/turn_preparation.py
@@ -25,9 +25,13 @@ from fleet_rlm.persistence.database import DatabaseConnectionError
 from fleet_rlm.result_snapshot import ResultSnapshotSink
 from fleet_rlm.rlm.child_runtime import ChildRuntimeFactory
 from fleet_rlm.rlm.context import (
+    DelegationPolicy,
+    ExecutionRuntime,
     PreparedCapabilities,
     RLMExecutionContext,
     RLMInterpreter,
+    SessionView,
+    TurnIdentity,
 )
 from fleet_rlm.rlm.dspy_contract import RLMOptions
 from fleet_rlm.rlm.inputs import AttachmentContextCapsule, AttachmentContextEntry
@@ -261,37 +265,45 @@ class DefaultTurnPreparer:
 
         resources = _PreparedTurnResources((environment.release, capabilities.aclose, remove_staged))
         execution = RLMExecutionContext(
-            run_id=turn.run_id,
-            session_id=turn.session_id,
-            access=turn.access,
-            request=turn.input.text,
-            session_context=build_session_context_manifest(
-                turn.session_id,
-                turn.checkpoint_version,
-                turn.history,
+            identity=TurnIdentity(
+                run_id=turn.run_id,
+                session_id=turn.session_id,
+                access=turn.access,
+                authority=turn.authority,
             ),
-            models=self._models,
-            options=self._options,
-            deadline=deadline,
-            interpreter=environment.interpreter,
-            attachments=tuple(
-                PreparedAttachment(
-                    ref.id,
-                    ref.filename,
-                    ref.content_type,
-                    ref.byte_size,
-                    ref.checksum_sha256,
-                )
-                for ref in staged.refs
+            session=SessionView(
+                request=turn.input.text,
+                session_context=build_session_context_manifest(
+                    turn.session_id,
+                    turn.checkpoint_version,
+                    turn.history,
+                ),
+                attachments=tuple(
+                    PreparedAttachment(
+                        ref.id,
+                        ref.filename,
+                        ref.content_type,
+                        ref.byte_size,
+                        ref.checksum_sha256,
+                    )
+                    for ref in staged.refs
+                ),
+                attachment_context=attachment_context,
+                preparation_notices=tuple(getattr(capabilities, "preparation_notices", ())),
+            ),
+            execution=ExecutionRuntime(
+                models=self._models,
+                options=self._options,
+                interpreter=environment.interpreter,
+                cancellation_requested=turn.cancellation_requested,
+                deadline=deadline,
             ),
             capabilities=capabilities,
-            cancellation_requested=turn.cancellation_requested,
-            preparation_notices=tuple(getattr(capabilities, "preparation_notices", ())),
-            attachment_context=attachment_context,
-            authority=turn.authority,
+            delegation=DelegationPolicy(
+                child_runtime_factory=environment.child_runtime_factory,
+                recursive_options=self._recursive_options,
+            ),
             selected_skill_count=len(turn.input.skill_selections),
-            child_runtime_factory=environment.child_runtime_factory,
-            recursive_options=self._recursive_options,
         )
         return PreparedTurn(
             execution,

--- a/src/fleet_rlm/rlm/context.py
+++ b/src/fleet_rlm/rlm/context.py
@@ -78,24 +78,52 @@ class RLMExecutionSpec:
 
 
 @dataclass(frozen=True, slots=True)
-class RLMExecutionContext:
-    """Complete immutable input accepted by `RLMRunner`."""
+class TurnIdentity:
+    """Who/which: the Run's durable identity and authority."""
 
     run_id: UUID
     session_id: UUID
     access: TurnAccess
+    authority: RunAuthority = field(default_factory=RunAuthority)
+
+
+@dataclass(frozen=True, slots=True)
+class SessionView:
+    """What the Turn is about, bounded by Session scope."""
+
     request: str
     session_context: SessionContextManifest
+    attachments: tuple[PreparedAttachment, ...]
+    attachment_context: AttachmentContextCapsule | None = None
+    preparation_notices: tuple[PreparationNotice, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionRuntime:
+    """Live execution control: models, limits, interpreter, cancellation."""
+
     models: RLMModelBundle
     options: RLMOptions
-    deadline: float
     interpreter: RLMInterpreter | None
-    attachments: tuple[PreparedAttachment, ...]
-    capabilities: PreparedCapabilities
     cancellation_requested: AsyncCancellationProbe
-    preparation_notices: tuple[PreparationNotice, ...]
-    attachment_context: AttachmentContextCapsule | None = None
-    authority: RunAuthority = field(default_factory=RunAuthority)
-    selected_skill_count: int = 0
+    deadline: float
+
+
+@dataclass(frozen=True, slots=True)
+class DelegationPolicy:
+    """Cross-sandbox recursive-RLM policy (empty when recursion is disabled)."""
+
     child_runtime_factory: ChildRuntimeFactory | None = None
     recursive_options: RecursiveRLMOptions = field(default_factory=RecursiveRLMOptions)
+
+
+@dataclass(frozen=True, slots=True)
+class RLMExecutionContext:
+    """Complete immutable input accepted by `RLMRunner`, in five deep members."""
+
+    identity: TurnIdentity
+    session: SessionView
+    execution: ExecutionRuntime
+    capabilities: PreparedCapabilities
+    delegation: DelegationPolicy = field(default_factory=DelegationPolicy)
+    selected_skill_count: int = 0

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -615,10 +615,10 @@ class _WorkerMonitor:
         pending: asyncio.Task[RuntimeEventDetail] | None = None
         try:
             while not self.task.done():
-                if await self.context.cancellation_requested():
+                if await self.context.execution.cancellation_requested():
                     self.intended_stop = TurnCancelledError()
                     break
-                remaining = self.context.deadline - asyncio.get_running_loop().time()
+                remaining = self.context.execution.deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
                     self.intended_stop = TimeoutError()
                     break
@@ -749,7 +749,7 @@ class RLMRunner:
         prediction: list[Any],
         started: float,
     ) -> AsyncIterator[RuntimeEvent]:
-        observations = _ObservationBuffer(EventRecorder(context.run_id, context.session_id))
+        observations = _ObservationBuffer(EventRecorder(context.identity.run_id, context.identity.session_id))
         async for event in self._initial_events(context, observations):
             yield event
         spec = context.capabilities.spec
@@ -769,7 +769,7 @@ class RLMRunner:
             spec.signature,
             schema_id=spec.output_schema_id,
             schema_version=spec.output_schema_version,
-            max_output_chars=context.options.max_output_chars,
+            max_output_chars=context.execution.options.max_output_chars,
         )
         outcome.append(
             RLMOutcome(
@@ -789,11 +789,11 @@ class RLMRunner:
     ) -> AsyncIterator[RuntimeEvent]:
         yield observations.recorder.record(RunStarted(delivery="live"))
         yield observations.recorder.record(Status("execution", "running"))
-        for notice in context.preparation_notices:
+        for notice in context.session.preparation_notices:
             yield observations.recorder.record(WarningEvent(notice.message, notice.code))
         for item in self._drain_capability_details(context):
             yield observations.record(item)
-        if await context.cancellation_requested():
+        if await context.execution.cancellation_requested():
             raise TurnCancelledError
 
     def _start_worker(
@@ -814,26 +814,26 @@ class RLMRunner:
         """
         spec = context.capabilities.spec
         relay = _DetailRelay(maxsize=_MAX_DETAIL_EVENTS)
-        guards = TurnToolGuards(required_targets=workspace_obligations(context.request))
-        self._bind_observer(context.interpreter, relay, context.options.max_output_chars)
+        guards = TurnToolGuards(required_targets=workspace_obligations(context.session.request))
+        self._bind_observer(context.execution.interpreter, relay, context.execution.options.max_output_chars)
         self._bind_context_capsule(context)
         recursive_executor = None
-        if context.recursive_options.enabled:
-            if context.child_runtime_factory is None and context.recursive_options.max_depth > 1:
+        if context.delegation.recursive_options.enabled:
+            if context.delegation.child_runtime_factory is None and context.delegation.recursive_options.max_depth > 1:
                 raise RLMConfigError("recursive child runtime is unavailable")
             recursive_executor = RecursiveRLMExecutor(
-                models=context.models,
-                options=context.recursive_options,
-                child_runtime_factory=context.child_runtime_factory,
-                deadline=context.deadline,
+                models=context.execution.models,
+                options=context.delegation.recursive_options,
+                child_runtime_factory=context.delegation.child_runtime_factory,
+                deadline=context.execution.deadline,
                 observer=relay.publish,
-                is_authorized=lambda: not context.authority.revoked,
+                is_authorized=lambda: not context.identity.authority.revoked,
             )
         spec = replace(
             spec,
             signature=root_signature_for_recursion(
                 spec.signature,
-                recursion_enabled=context.recursive_options.enabled,
+                recursion_enabled=context.delegation.recursive_options.enabled,
             ),
         )
 
@@ -848,22 +848,22 @@ class RLMRunner:
                 relay.publish,
                 spec.tool_event_views.get(str(tool.name), ToolEventView.metadata_only()),
                 after_result=(relay_capability_details if str(tool.name) == "load_skill" else None),
-                is_authorized=lambda: not context.authority.revoked,
+                is_authorized=lambda: not context.identity.authority.revoked,
                 guards=guards,
             )
             for tool in spec.tools
         )
         all_tools = (*observed_tools, *((recursive_executor.tool,) if recursive_executor is not None else ()))
         rlm = self._factory.create(
-            models=context.models,
-            options=context.options,
+            models=context.execution.models,
+            options=context.execution.options,
             tools=all_tools or None,
             signature=spec.signature,
         )
         self._bind_observer(
             rlm,
             relay,
-            context.options.max_output_chars,
+            context.execution.options.max_output_chars,
             emit_reasoning=type(rlm) is not dspy.RLM,
         )
         return (
@@ -896,12 +896,16 @@ class RLMRunner:
         prediction: Any,
     ) -> AsyncIterator[RuntimeEvent]:
         trajectory = normalize_prediction_trajectory(prediction)
-        for item in _reconcile_trajectory(observations.details, trajectory, max_chars=context.options.max_output_chars):
+        for item in _reconcile_trajectory(
+            observations.details, trajectory, max_chars=context.execution.options.max_output_chars
+        ):
             yield observations.recorder.record(item)
         final_reasoning = getattr(prediction, "final_reasoning", None)
         if isinstance(final_reasoning, str) and final_reasoning.strip():
-            public_reasoning = truncate_public_text(final_reasoning, max_len=context.options.max_output_chars)
-            if not self._has_reasoning(observations.details, public_reasoning, context.options.max_output_chars):
+            public_reasoning = truncate_public_text(final_reasoning, max_len=context.execution.options.max_output_chars)
+            if not self._has_reasoning(
+                observations.details, public_reasoning, context.execution.options.max_output_chars
+            ):
                 item = RLMReasoning(public_reasoning)
                 yield observations.record(item)
         for item in self._drain_capability_details(context):
@@ -910,11 +914,11 @@ class RLMRunner:
     @staticmethod
     def _bind_context_capsule(context: RLMExecutionContext) -> None:
         """Bind the prepared Volume context to the interpreter before the RLM starts."""
-        if context.attachment_context is None:
+        if context.session.attachment_context is None:
             return
-        bind = getattr(context.interpreter, "bind_context_capsule", None)
+        bind = getattr(context.execution.interpreter, "bind_context_capsule", None)
         if callable(bind):
-            bind(context.attachment_context)
+            bind(context.session.attachment_context)
 
     @staticmethod
     def _bind_observer(
@@ -946,9 +950,9 @@ class RLMRunner:
     def _native_call_args(rlm: Any, context: RLMExecutionContext) -> tuple[Any, ...]:
         if type(rlm) is not dspy.RLM:
             return ()
-        if context.interpreter is None:
+        if context.execution.interpreter is None:
             raise RLMConfigError("native RLM execution requires a caller-owned interpreter")
-        return (context.interpreter,)
+        return (context.execution.interpreter,)
 
     async def _stream_native_rlm(
         self,
@@ -975,8 +979,8 @@ class RLMRunner:
             for field in ("reasoning", "code")
         ]
         stream_projector = _NativeRLMStreamProjector(
-            run_id=context.run_id,
-            max_chars=context.options.max_output_chars,
+            run_id=context.identity.run_id,
+            max_chars=context.execution.options.max_output_chars,
             publish=relay.publish,
         )
         stream_program = cast(
@@ -1024,7 +1028,7 @@ class RLMRunner:
 
     @staticmethod
     def _record_attachment_accesses(context: RLMExecutionContext) -> None:
-        drain_accesses = getattr(context.interpreter, "drain_context_accesses", None)
+        drain_accesses = getattr(context.execution.interpreter, "drain_context_accesses", None)
         record_accesses = getattr(context.capabilities, "record_attachment_accesses", None)
         if callable(drain_accesses) and callable(record_accesses):
             record_accesses(tuple(drain_accesses()))
@@ -1093,11 +1097,11 @@ class RLMRunner:
         are surfaced as execution failures.
         """
         kwargs = build_rlm_input_kwargs(
-            request=context.request,
-            session_context=context.session_context,
+            request=context.session.request,
+            session_context=context.session.session_context,
             skill_cards=spec.skill_cards,
-            attachments=context.attachments,
-            attachment_context=context.attachment_context,
+            attachments=context.session.attachments,
+            attachment_context=context.session.attachment_context,
             workspace=spec.workspace,
         )
         started = time.perf_counter()
@@ -1105,16 +1109,18 @@ class RLMRunner:
             turn_phase_span(
                 "RLM.execute",
                 inputs={
-                    "max_iterations": context.options.max_iterations,
-                    "max_llm_calls": context.options.max_llm_calls,
-                    "max_output_chars": context.options.max_output_chars,
+                    "max_iterations": context.execution.options.max_iterations,
+                    "max_llm_calls": context.execution.options.max_llm_calls,
+                    "max_output_chars": context.execution.options.max_output_chars,
                 },
             ) as phase,
             dspy.context(
-                lm=context.models.root_lm,
+                lm=context.execution.models.root_lm,
                 # DSPy 3.3.x combines context callbacks with instance
                 # callbacks around LM requests (dspy/utils/callback.py:258-288).
-                callbacks=[_RLMTraceCallback(root_lm=context.models.root_lm, sub_lm=context.models.sub_lm)],
+                callbacks=[
+                    _RLMTraceCallback(root_lm=context.execution.models.root_lm, sub_lm=context.execution.models.sub_lm)
+                ],
                 # Keep the pinned DSPy JSON action protocol authoritative. A
                 # provider-native token stream is an adapter failure, not a
                 # second grammar that Fleet should reinterpret.

--- a/tests/contracts/backend/test_coordinator_runner_failures.py
+++ b/tests/contracts/backend/test_coordinator_runner_failures.py
@@ -16,7 +16,13 @@ from fleet_rlm.chat.turn_coordinator import TurnCoordinator
 from fleet_rlm.chat.turn_lifecycle import ExecuteTurn, TurnLifecycleService
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 from fleet_rlm.persistence.repositories import InMemoryTurnStateStore
-from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+from fleet_rlm.rlm.context import (
+    ExecutionRuntime,
+    RLMExecutionContext,
+    RLMExecutionSpec,
+    SessionView,
+    TurnIdentity,
+)
 from fleet_rlm.rlm.dspy_contract import RLMOptions
 from fleet_rlm.rlm.events import (
     TERMINAL_DETAIL_TYPES,
@@ -112,25 +118,27 @@ class _Harness:
         now = asyncio.get_running_loop().time()
         deadline = now if self.mode == "timeout" else now + 10
         execution = RLMExecutionContext(
-            run_id=turn.run_id,
-            session_id=turn.session_id,
-            access=turn.access,
-            request=turn.input.text,
-            session_context=build_session_context_manifest(
-                turn.session_id,
-                turn.checkpoint_version,
-                turn.history,
+            identity=TurnIdentity(run_id=turn.run_id, session_id=turn.session_id, access=turn.access),
+            session=SessionView(
+                request=turn.input.text,
+                session_context=build_session_context_manifest(
+                    turn.session_id,
+                    turn.checkpoint_version,
+                    turn.history,
+                ),
+                attachments=(),
+                preparation_notices=(),
             ),
-            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
-            options=RLMOptions(),
-            deadline=deadline,
-            interpreter=(
-                DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()) if self.mode == "native_success" else None
+            execution=ExecutionRuntime(
+                models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+                options=RLMOptions(),
+                deadline=deadline,
+                interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
+                if self.mode == "native_success"
+                else None,
+                cancellation_requested=turn.cancellation_requested,
             ),
-            attachments=(),
             capabilities=_Capabilities(),
-            cancellation_requested=turn.cancellation_requested,
-            preparation_notices=(),
         )
         harness = self
 

--- a/tests/contracts/backend/test_dspy_streaming.py
+++ b/tests/contracts/backend/test_dspy_streaming.py
@@ -92,7 +92,13 @@ async def test_stock_rlm_streamify_yields_field_chunks_before_prediction() -> No
 @pytest.mark.asyncio
 async def test_runner_projects_native_stream_chunks_before_typed_completion() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.events import RLMCode, RLMReasoning
     from fleet_rlm.rlm.model_bundle import RLMModelBundle
@@ -114,19 +120,21 @@ async def test_runner_projects_native_stream_chunks_before_typed_completion() ->
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "stream this",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        RLMModelBundle(root_lm=lm, sub_lm=lm),
-        RLMOptions(max_iterations=2),
-        asyncio.get_running_loop().time() + 10,
-        DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="stream this",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root_lm=lm, sub_lm=lm),
+            options=RLMOptions(max_iterations=2),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
 
     with patch("dspy.clients.lm._get_litellm", return_value=_StreamingLiteLLM()):
@@ -154,7 +162,13 @@ async def test_native_stream_path_completes_when_streamify_only_returns_predicti
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.model_bundle import RLMModelBundle
     from fleet_rlm.rlm.runner import RLMRunner
@@ -188,19 +202,21 @@ async def test_native_stream_path_completes_when_streamify_only_returns_predicti
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "complete without provider chunks",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        RLMModelBundle(root_lm=lm, sub_lm=lm),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="complete without provider chunks",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root_lm=lm, sub_lm=lm),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
 
     stream = RLMRunner().stream(context)

--- a/tests/contracts/backend/test_native_rlm_tracer.py
+++ b/tests/contracts/backend/test_native_rlm_tracer.py
@@ -11,7 +11,12 @@ import dspy
 import pytest
 
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
-from fleet_rlm.rlm.context import RLMExecutionSpec
+from fleet_rlm.rlm.context import (
+    ExecutionRuntime,
+    RLMExecutionSpec,
+    SessionView,
+    TurnIdentity,
+)
 from fleet_rlm.rlm.dspy_contract import RLMOptions, bind_native_rlm_observer
 from fleet_rlm.rlm.events import (
     RLMCode,
@@ -349,7 +354,9 @@ async def test_native_rlm_rejects_invalid_host_tool_type_before_host_logic() -> 
 @pytest.mark.parametrize("fallback", [False, True], ids=["invalid-submit-repair", "typed-extract"])
 async def test_runner_completes_native_repair_and_extract_as_prediction_result(fallback: bool) -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext
+    from fleet_rlm.rlm.context import (
+        RLMExecutionContext,
+    )
 
     class Capabilities:
         spec = RLMExecutionSpec()
@@ -375,19 +382,21 @@ async def test_runner_completes_native_repair_and_extract_as_prediction_result(f
 
     options = RLMOptions(max_iterations=1 if fallback else 2)
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "complete natively",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        options,
-        asyncio.get_running_loop().time() + 10,
-        DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="complete natively",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=options,
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=NativeFactory()).stream(context)
     events = [event async for event in stream]

--- a/tests/contracts/backend/test_rlm_history_retrieval.py
+++ b/tests/contracts/backend/test_rlm_history_retrieval.py
@@ -16,7 +16,13 @@ from fleet_rlm.sessions.history_tools import SESSION_HISTORY_RESULT_BYTE_BUDGET
 async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -> None:
     from fleet_rlm.chat.session_context import build_session_context_manifest
     from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.factory import RLMFactory
     from fleet_rlm.rlm.runner import RLMRunner
@@ -72,19 +78,18 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
         return False
 
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=session_id,
-        access=TurnAccess(uuid4(), uuid4()),
-        request="What was the project codename?",
-        session_context=manifest,
-        models=SimpleNamespace(root_lm=object(), sub_lm=object()),
-        options=RLMOptions(max_iterations=1),
-        deadline=asyncio.get_running_loop().time() + 10,
-        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        attachments=(),
+        identity=TurnIdentity(run_id=uuid4(), session_id=session_id, access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="What was the project codename?", session_context=manifest, attachments=(), preparation_notices=()
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(max_iterations=1),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
         capabilities=Capabilities(),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
     )
     factory = Factory()
     stream = RLMRunner(factory=factory).stream(context)
@@ -101,7 +106,13 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
 async def test_native_rlm_continues_history_across_truncated_pages() -> None:
     from fleet_rlm.chat.session_context import build_session_context_manifest
     from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.factory import RLMFactory
     from fleet_rlm.rlm.runner import RLMRunner
@@ -163,19 +174,18 @@ async def test_native_rlm_continues_history_across_truncated_pages() -> None:
         return False
 
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=session_id,
-        access=TurnAccess(uuid4(), uuid4()),
-        request="What is the final detail?",
-        session_context=manifest,
-        models=SimpleNamespace(root_lm=object(), sub_lm=object()),
-        options=RLMOptions(max_iterations=1),
-        deadline=asyncio.get_running_loop().time() + 10,
-        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        attachments=(),
+        identity=TurnIdentity(run_id=uuid4(), session_id=session_id, access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="What is the final detail?", session_context=manifest, attachments=(), preparation_notices=()
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(max_iterations=1),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
         capabilities=Capabilities(),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
     )
     factory = Factory()
     stream = RLMRunner(factory=factory).stream(context)

--- a/tests/contracts/backend/test_workspace_turn_flow.py
+++ b/tests/contracts/backend/test_workspace_turn_flow.py
@@ -23,7 +23,13 @@ from fleet_rlm.files.workspace_models import (
     WorkspaceTextPage,
 )
 from fleet_rlm.files.workspace_tools import WorkspaceToolError, WorkspaceToolHost
-from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+from fleet_rlm.rlm.context import (
+    ExecutionRuntime,
+    RLMExecutionContext,
+    RLMExecutionSpec,
+    SessionView,
+    TurnIdentity,
+)
 from fleet_rlm.rlm.dspy_contract import RLMOptions
 from fleet_rlm.rlm.errors import TurnCancelledError
 from fleet_rlm.rlm.events import RuntimeEvent
@@ -245,19 +251,21 @@ async def _run(
     else:
         task_request = request
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=workspace.session_id,
-        access=workspace.access,
-        request=task_request,
-        session_context=SessionContextManifest(workspace.session_id, 0, 0, ()),
-        models=SimpleNamespace(root_lm=object(), sub_lm=object()),
-        options=RLMOptions(),
-        deadline=asyncio.get_running_loop().time() + 10,
-        interpreter=Interpreter(),
-        attachments=(),
+        identity=TurnIdentity(run_id=uuid4(), session_id=workspace.session_id, access=workspace.access),
+        session=SessionView(
+            request=task_request,
+            session_context=SessionContextManifest(workspace.session_id, 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=Interpreter(),
+            cancellation_requested=not_cancelled,
+        ),
         capabilities=Capabilities(workspace),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
     )
     stream = RLMRunner(factory=factory).stream(context)
     observed = [event async for event in stream]

--- a/tests/unit/backend/chat/test_session_context.py
+++ b/tests/unit/backend/chat/test_session_context.py
@@ -154,7 +154,7 @@ async def test_prepared_rlm_kwargs_bound_a_large_session_to_recent_previews() ->
     encoded = json.dumps(factory.kwargs)
     assert messages[0].content not in encoded
     assert messages[-1].content not in encoded
-    assert prepared.execution.session_context.message_count == 100
+    assert prepared.execution.session.session_context.message_count == 100
     assert not hasattr(prepared.execution, "history")
 
     await prepared.aclose()

--- a/tests/unit/backend/rlm/test_recursive_runner_flow.py
+++ b/tests/unit/backend/rlm/test_recursive_runner_flow.py
@@ -10,7 +10,14 @@ from fleet_rlm.chat.run_authority import RunAuthority
 from fleet_rlm.chat.session_context import SessionContextManifest
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 from fleet_rlm.daytona.recursive_child_runtime import ChildRuntimeLease
-from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+from fleet_rlm.rlm.context import (
+    DelegationPolicy,
+    ExecutionRuntime,
+    RLMExecutionContext,
+    RLMExecutionSpec,
+    SessionView,
+    TurnIdentity,
+)
 from fleet_rlm.rlm.dspy_contract import RLMOptions
 from fleet_rlm.rlm.events import Status, ToolCompleted, ToolStarted
 from fleet_rlm.rlm.factory import RLMFactory
@@ -57,21 +64,25 @@ async def test_root_child_root_flow_preserves_parent_repl_and_typed_submit() -> 
         return False
 
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=uuid4(),
-        access=TurnAccess(uuid4(), uuid4()),
-        request="classify the selected row",
-        session_context=SessionContextManifest(uuid4(), 0, 0, ()),
-        models=RLMModelBundle(root, sub),
-        options=RLMOptions(max_iterations=4, max_llm_calls=4),
-        deadline=time.monotonic() + 30,
-        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        attachments=(),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="classify the selected row",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root, sub),
+            options=RLMOptions(max_iterations=4, max_llm_calls=4),
+            deadline=time.monotonic() + 30,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        delegation=DelegationPolicy(
+            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2),
+            child_runtime_factory=lambda call_index: _child_lease(call_index),
+        ),
         capabilities=Capabilities(),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
-        recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2),
-        child_runtime_factory=lambda call_index: _child_lease(call_index),
     )
 
     stream = RLMRunner().stream(context)
@@ -170,22 +181,26 @@ async def test_runner_rejects_recursive_tool_after_authority_revocation() -> Non
         return _child_lease(call_index)
 
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=uuid4(),
-        access=TurnAccess(uuid4(), uuid4()),
-        request="delegate after claim loss",
-        session_context=SessionContextManifest(uuid4(), 0, 0, ()),
-        models=RLMModelBundle(root, sub),
-        options=RLMOptions(max_iterations=2, max_llm_calls=2),
-        deadline=time.monotonic() + 30,
-        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        attachments=(),
+        identity=TurnIdentity(
+            run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4()), authority=authority
+        ),
+        session=SessionView(
+            request="delegate after claim loss",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root, sub),
+            options=RLMOptions(max_iterations=2, max_llm_calls=2),
+            deadline=time.monotonic() + 30,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        delegation=DelegationPolicy(
+            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=1), child_runtime_factory=child_factory
+        ),
         capabilities=Capabilities(),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
-        authority=authority,
-        recursive_options=RecursiveRLMOptions(enabled=True, max_calls=1),
-        child_runtime_factory=child_factory,
     )
 
     stream = RLMRunner().stream(context)
@@ -238,20 +253,22 @@ async def test_normal_daytona_policy_omits_recursive_tool_and_guidance() -> None
         return False
 
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=uuid4(),
-        access=TurnAccess(uuid4(), uuid4()),
-        request="answer directly",
-        session_context=SessionContextManifest(uuid4(), 0, 0, ()),
-        models=RLMModelBundle(root, sub),
-        options=RLMOptions(max_iterations=2, max_llm_calls=2),
-        deadline=time.monotonic() + 30,
-        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        attachments=(),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer directly",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root, sub),
+            options=RLMOptions(max_iterations=2, max_llm_calls=2),
+            deadline=time.monotonic() + 30,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        delegation=DelegationPolicy(recursive_options=RecursiveRLMOptions(enabled=False)),
         capabilities=Capabilities(),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
-        recursive_options=RecursiveRLMOptions(enabled=False),
     )
 
     stream = RLMRunner(factory=Factory()).stream(context)
@@ -319,21 +336,24 @@ async def test_failed_child_cleanup_prevents_successful_root_outcome() -> None:
         )
 
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=uuid4(),
-        access=TurnAccess(uuid4(), uuid4()),
-        request="delegate one task",
-        session_context=SessionContextManifest(uuid4(), 0, 0, ()),
-        models=RLMModelBundle(root, sub),
-        options=RLMOptions(max_iterations=4, max_llm_calls=4),
-        deadline=time.monotonic() + 30,
-        interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        attachments=(),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="delegate one task",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root, sub),
+            options=RLMOptions(max_iterations=4, max_llm_calls=4),
+            deadline=time.monotonic() + 30,
+            interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+            cancellation_requested=not_cancelled,
+        ),
+        delegation=DelegationPolicy(
+            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2), child_runtime_factory=failed_lease
+        ),
         capabilities=Capabilities(),
-        cancellation_requested=not_cancelled,
-        preparation_notices=(),
-        recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2),
-        child_runtime_factory=failed_lease,
     )
 
     stream = RLMRunner().stream(context)

--- a/tests/unit/backend/rlm/test_runner_cancellation.py
+++ b/tests/unit/backend/rlm/test_runner_cancellation.py
@@ -14,7 +14,13 @@ import pytest
 @pytest.mark.asyncio
 async def test_runner_returns_promptly_and_retains_blocking_worker_for_cleanup() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -47,19 +53,21 @@ async def test_runner_returns_promptly_and_retains_blocking_worker_for_cleanup()
         return cancel_requested
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        cancellation_probe,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=cancellation_probe,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
 
@@ -83,7 +91,13 @@ async def test_runner_returns_promptly_and_retains_blocking_worker_for_cleanup()
 @pytest.mark.asyncio
 async def test_runner_transfers_blocking_worker_after_caller_cancellation() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -115,19 +129,21 @@ async def test_runner_transfers_blocking_worker_after_caller_cancellation() -> N
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
 

--- a/tests/unit/backend/rlm/test_runner_execution.py
+++ b/tests/unit/backend/rlm/test_runner_execution.py
@@ -50,7 +50,13 @@ async def test_detail_relay_retains_step_lifecycle_when_ordinary_queue_is_full()
 @pytest.mark.asyncio
 async def test_runner_uses_native_path_for_plain_greeting() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -88,19 +94,21 @@ async def test_runner_uses_native_path_for_plain_greeting() -> None:
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "  Hi!  ",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="  Hi!  ",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
 
     factory = Factory()
@@ -129,7 +137,13 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
 ) -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
     from fleet_rlm.files.workspace_models import WorkspaceCapabilityMetadata
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.events import RLMCode, RLMOutput, StepFinished, StepStarted
     from fleet_rlm.rlm.runner import RLMRunner
@@ -235,19 +249,21 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
     monkeypatch.setattr(dspy, "context", tracked_context)
     monkeypatch.setattr("fleet_rlm.rlm.runner.turn_phase_span", tracked_phase_span)
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        interpreter,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=interpreter,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=factory).stream(context)
     Capabilities.spec = RLMExecutionSpec(
@@ -281,13 +297,13 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
     assert stream.outcome.prediction.display_text == "42"
     assert stream.outcome.prediction.outputs == {"answer": "42"}
     assert stream.outcome.succeeded
-    assert factory.options is context.options
+    assert factory.options is context.execution.options
     assert isinstance(factory.tools[0], dspy.Tool)
     assert stream.outcome.usage["iterations"] == 1
     assert stream.outcome.usage["observed_lm_usage"] == {"root": {"prompt_tokens": 4, "completion_tokens": 2}}
     assert set(stream.outcome.usage) == {"iterations", "observed_lm_usage", "duration_ms"}
     assert len(contexts) == 1
-    assert contexts[0]["lm"] is context.models.root_lm
+    assert contexts[0]["lm"] is context.execution.models.root_lm
     assert contexts[0]["track_usage"] is True
     adapter = contexts[0]["adapter"]
     assert isinstance(adapter, dspy.JSONAdapter)
@@ -297,9 +313,9 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
         (
             "RLM.execute",
             {
-                "max_iterations": context.options.max_iterations,
-                "max_llm_calls": context.options.max_llm_calls,
-                "max_output_chars": context.options.max_output_chars,
+                "max_iterations": context.execution.options.max_iterations,
+                "max_llm_calls": context.execution.options.max_llm_calls,
+                "max_output_chars": context.execution.options.max_output_chars,
             },
         )
     ]
@@ -315,7 +331,13 @@ def test_runner_uses_stock_json_adapter_without_protocol_salvage() -> None:
 @pytest.mark.asyncio
 async def test_runner_passes_prepared_attachment_context_to_rlm() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.inputs import AttachmentContextCapsule, AttachmentContextEntry
     from fleet_rlm.rlm.runner import RLMRunner
@@ -356,20 +378,22 @@ async def test_runner_passes_prepared_attachment_context_to_rlm() -> None:
         mount_root="/home/daytona/run",
     )
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "use context",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
-        attachment_context=attachment_context,
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="use context",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+            attachment_context=attachment_context,
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
 
     stream = RLMRunner(factory=Factory()).stream(context)
@@ -381,7 +405,12 @@ async def test_runner_passes_prepared_attachment_context_to_rlm() -> None:
 @pytest.mark.asyncio
 async def test_runner_validates_host_metadata_before_provider_execution() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest, TurnPreview
-    from fleet_rlm.rlm.context import RLMExecutionContext
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -419,19 +448,18 @@ async def test_runner_validates_host_metadata_before_provider_execution() -> Non
         (TurnPreview(0, "system", "malformed"),),  # type: ignore[arg-type]
     )
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "validate me",
-        malformed_context,
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="validate me", session_context=malformed_context, attachments=(), preparation_notices=()
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     factory = Factory()
     stream = RLMRunner(factory=factory).stream(context)
@@ -447,7 +475,13 @@ async def test_runner_validates_host_metadata_before_provider_execution() -> Non
 async def test_runner_loads_two_skills_reads_python_resource_and_completes_submit() -> None:
     from fleet_rlm.chat.capability_preparation import PreparedHostCapabilities
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -516,19 +550,21 @@ async def test_runner_loads_two_skills_reads_python_resource_and_completes_submi
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(user_id, workspace_id),
-        "complete progressively",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        capabilities,
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(user_id, workspace_id)),
+        session=SessionView(
+            request="complete progressively",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=capabilities,
     )
     stream = RLMRunner(factory=Factory()).stream(context)
     events = [event async for event in stream]

--- a/tests/unit/backend/rlm/test_runner_outcomes.py
+++ b/tests/unit/backend/rlm/test_runner_outcomes.py
@@ -13,7 +13,13 @@ import pytest
 @pytest.mark.asyncio
 async def test_runner_retains_prediction_usage_when_typed_output_is_invalid() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -50,19 +56,21 @@ async def test_runner_retains_prediction_usage_when_typed_output_is_invalid() ->
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
     _ = [event async for event in stream]
@@ -79,7 +87,13 @@ async def test_runner_retains_prediction_usage_when_typed_output_is_invalid() ->
 @pytest.mark.asyncio
 async def test_runner_reports_turn_output_too_large_for_oversized_answer() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -119,19 +133,21 @@ async def test_runner_reports_turn_output_too_large_for_oversized_answer() -> No
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(max_output_chars=32),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(max_output_chars=32),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
     _ = [event async for event in stream]
@@ -144,7 +160,13 @@ async def test_runner_reports_turn_output_too_large_for_oversized_answer() -> No
 @pytest.mark.asyncio
 async def test_runner_emits_preloaded_skill_events_before_later_output_failure() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.events import SkillActivated, SkillLoaded
     from fleet_rlm.rlm.runner import RLMRunner
@@ -179,19 +201,21 @@ async def test_runner_emits_preloaded_skill_events_before_later_output_failure()
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
     events = [event async for event in stream]
@@ -210,7 +234,13 @@ async def test_runner_emits_preloaded_skill_events_before_later_output_failure()
 @pytest.mark.parametrize("terminal_status", ["cancelled", "timeout"])
 async def test_runner_emits_preloaded_skill_events_before_cancel_or_timeout(terminal_status: str) -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.events import SkillActivated, SkillLoaded
     from fleet_rlm.rlm.runner import RLMRunner
@@ -246,19 +276,21 @@ async def test_runner_emits_preloaded_skill_events_before_cancel_or_timeout(term
 
     loop = asyncio.get_running_loop()
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        loop.time() - 1 if terminal_status == "timeout" else loop.time() + 10,
-        None,
-        (),
-        Capabilities(),
-        cancellation_probe,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=loop.time() - 1 if terminal_status == "timeout" else loop.time() + 10,
+            interpreter=None,
+            cancellation_requested=cancellation_probe,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
     events = [event async for event in stream]
@@ -288,7 +320,13 @@ def test_public_failure_message_honors_instance_override() -> None:
 @pytest.mark.asyncio
 async def test_stream_closed_before_iteration_synthesizes_cancelled_outcome() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
@@ -314,19 +352,21 @@ async def test_stream_closed_before_iteration_synthesizes_cancelled_outcome() ->
 
     loop = asyncio.get_running_loop()
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(),
-        loop.time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=loop.time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
     stream = RLMRunner(factory=Factory()).stream(context)
     await stream.aclose()

--- a/tests/unit/backend/rlm/test_trajectory_projection.py
+++ b/tests/unit/backend/rlm/test_trajectory_projection.py
@@ -194,7 +194,13 @@ def test_trajectory_reconciliation_updates_pre_step_live_reasoning_when_canonica
 @pytest.mark.asyncio
 async def test_runner_deduplicates_final_reasoning_against_nonadjacent_normalized_trajectory() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest
-    from fleet_rlm.rlm.context import RLMExecutionContext, RLMExecutionSpec
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        RLMExecutionSpec,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.events import RLMReasoning
     from fleet_rlm.rlm.runner import RLMRunner
@@ -231,19 +237,21 @@ async def test_runner_deduplicates_final_reasoning_against_nonadjacent_normalize
         return False
 
     context = RLMExecutionContext(
-        uuid4(),
-        uuid4(),
-        TurnAccess(uuid4(), uuid4()),
-        "answer",
-        SessionContextManifest(uuid4(), 0, 0, ()),
-        SimpleNamespace(root_lm=object(), sub_lm=object()),
-        RLMOptions(max_output_chars=16),
-        asyncio.get_running_loop().time() + 10,
-        None,
-        (),
-        Capabilities(),
-        not_cancelled,
-        (),
+        identity=TurnIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="answer",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(max_output_chars=16),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=None,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=Capabilities(),
     )
 
     events = [event async for event in RLMRunner(factory=Factory()).stream(context)]

--- a/tests/unit/backend/test_execution_context.py
+++ b/tests/unit/backend/test_execution_context.py
@@ -12,38 +12,47 @@ import pytest
 
 def test_execution_context_is_immutable_and_contains_prepared_runner_inputs() -> None:
     from fleet_rlm.chat.session_context import SessionContextManifest, TurnPreview
-    from fleet_rlm.rlm.context import RLMExecutionContext
+    from fleet_rlm.rlm.context import (
+        ExecutionRuntime,
+        RLMExecutionContext,
+        SessionView,
+        TurnIdentity,
+    )
     from fleet_rlm.rlm.dspy_contract import RLMOptions
     from fleet_rlm.rlm.model_bundle import RLMModelBundle
     from fleet_rlm.sessions.models import TurnAccess
 
     session_id = uuid4()
     context = RLMExecutionContext(
-        run_id=uuid4(),
-        session_id=session_id,
-        access=TurnAccess(user_id=uuid4(), workspace_id=uuid4()),
-        request="inspect",
-        session_context=SessionContextManifest(
-            session_id,
-            3,
-            1,
-            (TurnPreview(1, "user", "prior"),),
+        identity=TurnIdentity(
+            run_id=uuid4(), session_id=session_id, access=TurnAccess(user_id=uuid4(), workspace_id=uuid4())
         ),
-        models=RLMModelBundle(root_lm=MagicMock(), sub_lm=MagicMock()),
-        options=RLMOptions(),
-        deadline=123.0,
-        interpreter=SimpleNamespace(execute=lambda code: code),
-        attachments=(),
+        session=SessionView(
+            request="inspect",
+            session_context=SessionContextManifest(
+                session_id,
+                3,
+                1,
+                (TurnPreview(1, "user", "prior"),),
+            ),
+            attachments=(),
+            preparation_notices=(),
+        ),
+        execution=ExecutionRuntime(
+            models=RLMModelBundle(root_lm=MagicMock(), sub_lm=MagicMock()),
+            options=RLMOptions(),
+            deadline=123.0,
+            interpreter=SimpleNamespace(execute=lambda code: code),
+            cancellation_requested=lambda: False,
+        ),
         capabilities=SimpleNamespace(),
-        cancellation_requested=lambda: False,
-        preparation_notices=(),
     )
 
-    assert context.session_id == session_id
-    assert context.request == "inspect"
-    assert context.deadline == 123.0
-    assert context.attachments == ()
+    assert context.identity.session_id == session_id
+    assert context.session.request == "inspect"
+    assert context.execution.deadline == 123.0
+    assert context.session.attachments == ()
     assert not hasattr(context, "settings")
     assert not hasattr(context, "turn_store")
     with pytest.raises(FrozenInstanceError):
-        context.request = "changed"  # type: ignore[misc]
+        context.session.request = "changed"  # type: ignore[misc]

--- a/tests/unit/backend/test_live_turn_preparation.py
+++ b/tests/unit/backend/test_live_turn_preparation.py
@@ -134,7 +134,7 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
         models=RLMModelBundle(object(), object()),
     ).prepare(turn, deadline=float("inf"))
 
-    assert prepared.execution.attachments[0].attachment_id == attachment_id
+    assert prepared.execution.session.attachments[0].attachment_id == attachment_id
     assert data in volume.values()
     expected_tools = {
         "create_artifact",

--- a/tests/unit/backend/test_turn_preparation.py
+++ b/tests/unit/backend/test_turn_preparation.py
@@ -100,7 +100,7 @@ async def test_preparation_bounds_history_and_closes_in_dependency_order() -> No
         capabilities=CapabilityFactory(),
     ).prepare(turn, deadline=float("inf"))
 
-    assert prepared.execution.session_context.to_input() == {
+    assert prepared.execution.session.session_context.to_input() == {
         "session_id": str(turn.session_id),
         "checkpoint_version": 0,
         "message_count": 1,

--- a/tests/unit/backend/test_turn_preparation_tracing.py
+++ b/tests/unit/backend/test_turn_preparation_tracing.py
@@ -175,5 +175,5 @@ async def test_prepare_without_active_trace_is_noop() -> None:
     """No fake mlflow and no trace gate: preparation succeeds without MLflow."""
     prepared = await _make_preparer().prepare(_make_turn(), deadline=float("inf"))
 
-    assert prepared.execution.request == "next"
+    assert prepared.execution.session.request == "next"
     await prepared.aclose()


### PR DESCRIPTION
# Description

Composes the Turn context vocabulary (`plans/WIP3.md` Phase 2): `RLMExecutionContext`'s 18 flat fields become **five deep frozen members**, shrinking the most-touched boundary in the Backend (`preparation → execution driver → runner → recursive calls`) to a prepared world in named buckets.

```python
RLMExecutionContext:
    identity:     TurnIdentity         # run_id, session_id, access, authority
    session:      SessionView          # request, session_context, attachments, attachment_context, preparation_notices
    execution:    ExecutionRuntime     # models, options, interpreter, cancellation_requested, deadline
    capabilities: PreparedCapabilities # already deep — untouched
    delegation:   DelegationPolicy     # child_runtime_factory, recursive_options
    selected_skill_count: int          # flat scalar kept
```

- Every consumer moves in the same PR: `rlm/context.py`, `chat/turn_preparation.py`, `rlm/runner.py`, `chat/turn_execution.py`, `composition/testing.py`, plus all 15 touching test files.
- No back-compat façade — private type, all call sites updated (`ty` + the 82.09% coverage gate are the exhaustiveness proof).
- **Zero behavior change, zero wire change**: no API/SSE/contract edits; this is comprehension/maintenance value only.

## Validation

- `make check` green on `a697fa8ae`: coverage 82.09% ≥ 75%, ruff lint/format, `ty`, `api-check`, `stream-check`, TUI 187 tests, codebase-tree boundaries, docs + harness checks

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  — conceptual debt fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Relevant local validation passed (`make check` on the final commit)
- [x] Commit messages follow conventions
- [x] PR description clearly explains the change
