### PR TITLE
refactor+feat(tui): dead-code sweep, inventory seam note, schema-generated chunk validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,12 @@ jobs:
           name: Security checks
           command: make check-security
       - run:
+          name: Install TUI dependencies
+          command: |
+            corepack enable
+            corepack prepare pnpm@10.33.2 --activate
+            pnpm --dir tools/fleet-tui install --frozen-lockfile
+      - run:
           name: API and stream contract checks
           command: |
             make api-check

--- a/Makefile
+++ b/Makefile
@@ -175,9 +175,11 @@ check-codebase-tree:
 
 api-check:
 	uv run python scripts/openapi_tools.py check
+	uv run python scripts/generate_tui_chunk_validation.py check
 
 api-sync:
 	uv run python scripts/openapi_tools.py generate
+	uv run python scripts/generate_tui_chunk_validation.py generate
 
 stream-check:
 	uv run python scripts/generate_stream_fixture.py check

--- a/docs/reference/codebase-map.md
+++ b/docs/reference/codebase-map.md
@@ -75,14 +75,14 @@ The authoritative route inventory and shapes are in
 | `src/cli-core.ts` | CLI options and verified atomic Artifact download |
 | `src/fleet-api-client.ts` | HTTP requests and response handling |
 | `src/fleet-turn-stream.ts` | request opening, bounded same-key retry, strict stream and part lifecycle |
-| `src/sse.ts` | SSE framing and closed generated chunk validation |
+| `src/sse.ts` | SSE framing and closed validation against generated chunk tables |
 | `src/tui/runner.ts` | active Run state, submission, cancellation |
 | `src/tui/projection.ts` | shared live/durable display projection and stream accumulation |
 | `src/tui/store.ts` | conversation state, atomic Session hydration, and terminal stream settlement |
 | `src/tui/application.ts`, `screen.ts`, `transcript.ts` | pi-tui main-screen lifecycle, editor/input, cached native-scrollback layout, terminal-safe status, and mutable Run activity |
 | `src/tui/message-renderer.ts`, `terminal-text.ts` | complete event, cached Markdown, result, Artifact, code/output presentation, and terminal-safe text |
 | `src/tui/commands.ts`, `command-presenter.ts`, `autocomplete.ts` | slash commands, overlays, status, and completion |
-| `src/generated/openapi.ts` | generated HTTP types owned by `make api-sync` |
+| `src/generated/openapi.ts`, `src/generated/fleet-ui-chunk-validation.ts` | generated HTTP types and chunk-validation tables owned by `make api-sync` |
 
 Live and reload use the same display semantics. Evidence is fully expanded and
 uses native terminal scrollback; there is no classic renderer, mouse capture,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,7 @@
 | `db_init.py` | Upgrade a fresh `FLEET_DATABASE_URL` database to Alembic head |
 | `openapi_tools.py` | Generate or check backend-only `openapi.yaml` |
 | `generate_stream_fixture.py` | Generate or check the deterministic TUI turn-stream golden fixture |
+| `generate_tui_chunk_validation.py` | Generate or check the TUI runtime chunk-validation tables from `openapi.yaml` |
 | `check_codebase_tree.py` | Enforce canonical import and route boundaries |
 | `check_harness_engineering.py` | Validate repository agent-harness contracts |
 | `check_docs_quality.py` | Validate documentation structure and links |

--- a/scripts/generate_tui_chunk_validation.py
+++ b/scripts/generate_tui_chunk_validation.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Generate the TUI runtime chunk-validation tables from openapi.yaml.
+
+The AI SDK UI chunk contract stays hand-owned in exactly two places:
+``src/fleet_rlm/api/sse.py`` (runtime projector) and
+``src/fleet_rlm/api/openapi.py`` (chunk schemas). This script derives the
+third surface — the TUI's strictest runtime validator — from the OpenAPI
+``FleetUIMessageChunk`` variants, so the strict consumer can no longer drift
+silently from the documented schema. The dual snake_case/camelCase id
+tolerances stay explicit as `_FIELD_ALTERNATIVES` below (they are a
+deliberate wire compatibility surface, not schema facts).
+
+Run ``make api-sync`` after changing the OpenAPI hook; ``make api-check`` fails
+when ``tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts`` is stale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+OPENAPI = ROOT / "openapi.yaml"
+TARGET = ROOT / "tools" / "fleet-tui" / "src" / "generated" / "fleet-ui-chunk-validation.ts"
+
+# Dual snake_case/camelCase id tolerances (hand-maintained contract; at least
+# one form per group must be present for the payload to validate).
+_FIELD_ALTERNATIVES: dict[str, tuple[tuple[str, ...], ...]] = {
+    "data-status": (("status",), ("detail",), ("message",)),
+    "data-skill": (("skill_id",), ("skillId",)),
+    "data-attachment": (("attachment_id",), ("attachmentId",)),
+    "data-artifact": (("artifact_id",), ("artifactId",)),
+    "data-structured-result": (("schema_id", "schema_version"), ("schemaId", "schemaVersion")),
+}
+
+
+def _check_name(schema: dict) -> str | None:
+    """Map one OpenAPI property schema to a FieldCheck expression (or None to omit)."""
+    if "anyOf" in schema:
+        parts = schema["anyOf"]
+        if len(parts) == 2 and parts[1] == {"type": "null"}:
+            base = parts[0]
+            if base.get("type") == "string":
+                return "isNullableString"
+            if base.get("type") == "integer":
+                return "isNullableInteger"
+        raise SystemExit(f"unsupported anyOf schema: {json.dumps(schema)}")
+    stype = schema.get("type")
+    enum = schema.get("enum")
+    if enum and stype == "string":
+        quoted = " || ".join(f"value === {json.dumps(item)}" for item in enum)
+        return f"(value) => {quoted}"
+    match stype:
+        case "string":
+            return "isString"
+        case "integer":
+            return "isInteger"
+        case "boolean":
+            return "isBoolean"
+        case "array" if schema.get("items", {}).get("type") == "string":
+            return "isStringArray"
+        case "object":
+            return "isRecord"
+        case None if schema.get("type") is None and not schema:
+            return None  # untyped `{}` payloads (e.g. structured-result value) skip the check
+    raise SystemExit(f"unsupported schema: {json.dumps(schema)}")
+
+
+def _tables() -> dict[str, list]:
+    doc = yaml.safe_load(OPENAPI.read_text(encoding="utf-8"))
+    variants = doc["components"]["schemas"]["FleetUIMessageChunk"]["oneOf"]
+    chunk_types: list[str] = []
+    field_checks: dict[str, dict[str, str]] = {}
+    required: dict[str, list[str]] = {}
+    for variant in variants:
+        props = variant.get("properties", {})
+        ctype = props["type"]["const"]
+        chunk_types.append(ctype)
+        data = props.get("data") or {}
+        data_props = data.get("properties") or {}
+        if not data_props:
+            continue
+        checks: dict[str, str] = {}
+        for name, schema in data_props.items():
+            check = _check_name(schema)
+            if check is not None:
+                checks[name] = check
+        field_checks[ctype] = checks
+        required[ctype] = list(data.get("required") or ())
+    return {"chunk_types": chunk_types, "field_checks": field_checks, "required": required}
+
+
+def _render(tables: dict) -> str:
+    out: list[str] = [
+        "/**",
+        " * REGENERATED from openapi.yaml by scripts/generate_tui_chunk_validation.py.",
+        " * Do not hand-edit — run `make api-sync`. The dataAlternatives dual",
+        " * snake_case/camelCase id tolerances are the generator's declared input.",
+        " */",
+        "",
+        "export type FieldCheck = (value: unknown) => boolean;",
+        "",
+        f"export const chunkTypes = {json.dumps(tables['chunk_types'], indent=2)} as const;",
+        "",
+        "export const dataFieldChecks: Record<string, Record<string, FieldCheck>> = {",
+    ]
+    for ctype, checks in tables["field_checks"].items():
+        out.append(f"  {json.dumps(ctype)}: {{")
+        for name, check in checks.items():
+            out.append(f"    {name}: {check},")
+        out.append("  },")
+    out.append("};")
+    out.append("")
+    out.append("export const dataRequiredFields: Record<string, readonly string[]> = {")
+    for ctype, fields in tables["required"].items():
+        out.append(f"  {json.dumps(ctype)}: {json.dumps(fields)},")
+    out.append("};")
+    out.append("")
+    out.append("export const dataAlternatives: Record<string, readonly (readonly string[])[]> = {")
+    for ctype, groups in _FIELD_ALTERNATIVES.items():
+        rendered = "[" + ", ".join("[" + ", ".join(json.dumps(g) for g in group) + "]" for group in groups) + "]"
+        out.append(f"  {json.dumps(ctype)}: {rendered},")
+    out.append("};")
+    out.append("")
+    out.append(
+        """function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNullableString(value: unknown): boolean {
+  return value === null || isString(value);
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+function isInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
+}
+
+function isNullableInteger(value: unknown): boolean {
+  return value === null || isInteger(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isString);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+""",
+    )
+    return "\n".join(out) + "\n"
+
+
+def generate(_args: argparse.Namespace) -> int:
+    TARGET.parent.mkdir(parents=True, exist_ok=True)
+    TARGET.write_text(_render(_tables()), encoding="utf-8")
+    print(f"Wrote {TARGET.relative_to(ROOT)} from {OPENAPI.name}")
+    return 0
+
+
+def check(_args: argparse.Namespace) -> int:
+    if not TARGET.exists():
+        print(f"Missing generated chunk validation tables: {TARGET}", file=sys.stderr)
+        return 1
+    expected = _render(_tables())
+    actual = TARGET.read_text(encoding="utf-8")
+    if actual != expected:
+        print("TUI chunk-validation tables are stale; run `make api-sync`", file=sys.stderr)
+        return 1
+    print("TUI chunk-validation tables are current")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("generate").set_defaults(func=generate)
+    commands.add_parser("check").set_defaults(func=check)
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/fleet_rlm/api/openapi.py
+++ b/src/fleet_rlm/api/openapi.py
@@ -10,13 +10,15 @@ from fastapi.openapi.utils import get_openapi
 from fleet_rlm.api.errors import ErrorResponse
 from fleet_rlm.api.sse import FLEET_UI_CHUNK_TYPES
 
-# The AI SDK UI chunk contract is hand-maintained in FOUR places; keep them in
-# sync (tests/contracts/backend/test_stream_fixture.py + the TUI golden-stream
-# test lock this copy against the runtime projector):
+# The AI SDK UI chunk contract is hand-maintained in THREE places; the TUI
+# validator tables are generated from this module's schemas
+# (tests/contracts/backend/test_stream_fixture.py + the TUI golden-stream test
+# lock the copies against the runtime projector):
 #   1. src/fleet_rlm/api/sse.py            (runtime projector)
 #   2. src/fleet_rlm/api/ui_message.py     (reload projection)
 #   3. this module                          (OpenAPI chunk schemas)
-#   4. tools/fleet-tui/src/sse.ts           (TUI runtime validator)
+#   4. tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts
+#      (TUI validator tables via scripts/generate_tui_chunk_validation.py)
 _CHUNK_FIELD_TYPES: dict[str, dict[str, Any]] = {
     "id": {"type": "string"},
     "messageId": {"type": "string", "format": "uuid"},

--- a/src/fleet_rlm/api/sse.py
+++ b/src/fleet_rlm/api/sse.py
@@ -1,12 +1,14 @@
 """Exhaustive AI SDK UI v1 projection for typed Fleet Runtime Events."""
 
-# The AI SDK UI chunk contract is hand-maintained in FOUR places; keep them in
-# sync (this projector is the runtime source of truth; the golden-stream
-# fixture in scripts/generate_stream_fixture.py locks it to the TUI):
+# The AI SDK UI chunk contract is hand-maintained in THREE places; the fourth
+# surface is GENERATED from the OpenAPI hook (the golden-stream fixture in
+# scripts/generate_stream_fixture.py locks them together):
 #   1. this module (AISDKUIProjector)
 #   2. src/fleet_rlm/api/ui_message.py       (reload projection)
 #   3. src/fleet_rlm/api/openapi.py          (OpenAPI chunk schemas)
-#   4. tools/fleet-tui/src/sse.ts            (TUI runtime validator)
+#   4. tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts
+#      (TUI validator tables, owned by scripts/generate_tui_chunk_validation.py
+#      via `make api-sync`)
 
 from __future__ import annotations
 

--- a/src/fleet_rlm/composition/inventory.py
+++ b/src/fleet_rlm/composition/inventory.py
@@ -1,4 +1,14 @@
-"""Typed runtime inventory publication for FastAPI lifespan composition."""
+"""Typed runtime inventory publication for FastAPI lifespan composition.
+
+Why these seams are Protocols rather than attributes: the inventory is
+provider-neutral. `SettlingTurnStore`, `RuntimeSessionManager`, and
+`RuntimeProcessResources` let `composition/inventory.py` name exactly the
+surfaces startup recovery needs without importing `daytona/` (which owns the
+SDK boundary), and they let the private testing composition substitute
+deterministic, credential-free implementations for every provider-backed
+participant. Folding them into concrete classes would force composition to
+import provider modules and re-couple the test suite to Daytona.
+"""
 
 from __future__ import annotations
 

--- a/tools/fleet-tui/AGENTS.md
+++ b/tools/fleet-tui/AGENTS.md
@@ -15,6 +15,7 @@ pi-tui-only terminal client. No web frontend, no React, no browser runtime.
 | `src/tui/store.ts` | Atomic hydration; all state via `dispatch` + pure `reduce` |
 | `src/tui/commands.ts` | Slash commands, including loopback-only TOML policy editing |
 | `src/generated/openapi.ts` | **Generated** — do not hand-edit; use `make api-sync` |
+| `src/generated/fleet-ui-chunk-validation.ts` | **Generated** — do not hand-edit; use `make api-sync` (`scripts/generate_tui_chunk_validation.py`) |
 
 ## Validation
 

--- a/tools/fleet-tui/src/cli-core.ts
+++ b/tools/fleet-tui/src/cli-core.ts
@@ -3,6 +3,7 @@ import { open, rename, rm } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
 import { FleetApiClient } from "./fleet-api-client.js";
+import { listCommands } from "./tui/commands.js";
 
 export type CliOptions = {
   apiUrl: string;
@@ -110,24 +111,19 @@ export async function runArtifactDownload(options: CliOptions): Promise<boolean>
 }
 
 export function tuiUsage(): string {
+  const commandLines = listCommands()
+    .map((spec) => `  ${spec.usage.padEnd(28)}  ${spec.description}`)
+    .join("\n");
   return `Usage: pnpm start -- [options]
 
 Options:
   --api-url <url>          Fleet API base URL (default: http://127.0.0.1:8000)
   --session <uuid>         Resume an existing Fleet session
   artifact <uuid> --output <path>
-                            Download, verify, and atomically save an Artifact
+                           Download, verify, and atomically save an Artifact
   --help, -h               Show this help
 
 Slash commands:
-  /help      list commands
-  /clear     clear the visible conversation
-  /sessions  list recent sessions
-  /resume    resume a session by id
-  /cancel    cancel the current run
-  /skills    select Skills for the next Turn
-  /skill     pin a Skill by name or exact UUID@version
-  /status    show session, run, and usage
-  /exit      exit
+${commandLines}
 `;
 }

--- a/tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts
+++ b/tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts
@@ -1,0 +1,150 @@
+/**
+ * REGENERATED from openapi.yaml by scripts/generate_tui_chunk_validation.py.
+ * Do not hand-edit — run `make api-sync`. The dataAlternatives dual
+ * snake_case/camelCase id tolerances are the generator's declared input.
+ */
+
+export type FieldCheck = (value: unknown) => boolean;
+
+export const chunkTypes = [
+  "start",
+  "start-step",
+  "finish-step",
+  "reasoning-start",
+  "reasoning-delta",
+  "reasoning-end",
+  "data-status",
+  "data-skill",
+  "data-rlm-code",
+  "data-rlm-output",
+  "tool-input-available",
+  "tool-output-available",
+  "tool-output-error",
+  "data-attachment",
+  "data-warning",
+  "data-artifact",
+  "data-usage",
+  "data-structured-result",
+  "text-start",
+  "text-delta",
+  "text-end",
+  "finish",
+  "abort",
+  "error"
+] as const;
+
+export const dataFieldChecks: Record<string, Record<string, FieldCheck>> = {
+  "data-status": {
+    phase: isString,
+    status: isString,
+    detail: isString,
+    message: isNullableString,
+  },
+  "data-skill": {
+    skill_id: isString,
+    skillId: isString,
+    name: isString,
+    version: isString,
+    phase: (value) => value === "activated" || value === "loaded",
+    trust: isString,
+    affordances: isStringArray,
+  },
+  "data-rlm-code": {
+    code: isString,
+    step: isNullableInteger,
+    stream_id: isNullableString,
+    is_delta: isBoolean,
+    is_final: isBoolean,
+  },
+  "data-rlm-output": {
+    output: isString,
+    step: isNullableInteger,
+    stream_id: isNullableString,
+    is_delta: isBoolean,
+    is_final: isBoolean,
+  },
+  "data-attachment": {
+    attachment_id: isString,
+    attachmentId: isString,
+    phase: isString,
+    filename: isString,
+    byte_size: isInteger,
+    byteSize: isInteger,
+  },
+  "data-warning": {
+    message: isString,
+    code: isNullableString,
+  },
+  "data-artifact": {
+    artifact_id: isString,
+    artifactId: isString,
+    artifact_kind: isString,
+    kind: isString,
+    title: isNullableString,
+    name: isString,
+    media_type: isString,
+    mediaType: isString,
+    byte_size: isInteger,
+    byteSize: isInteger,
+    checksum_sha256: isString,
+    checksumSha256: isString,
+  },
+  "data-usage": {
+    usage: isRecord,
+  },
+  "data-structured-result": {
+    schema_id: isString,
+    schemaId: isString,
+    schema_version: isString,
+    schemaVersion: isString,
+  },
+};
+
+export const dataRequiredFields: Record<string, readonly string[]> = {
+  "data-status": ["phase"],
+  "data-skill": ["name", "version", "skill_id"],
+  "data-rlm-code": ["code"],
+  "data-rlm-output": ["output"],
+  "data-attachment": ["filename", "attachment_id"],
+  "data-warning": ["message"],
+  "data-artifact": ["artifact_id"],
+  "data-usage": ["usage"],
+  "data-structured-result": ["schema_id", "schema_version", "value"],
+};
+
+export const dataAlternatives: Record<string, readonly (readonly string[])[]> = {
+  "data-status": [["status"], ["detail"], ["message"]],
+  "data-skill": [["skill_id"], ["skillId"]],
+  "data-attachment": [["attachment_id"], ["attachmentId"]],
+  "data-artifact": [["artifact_id"], ["artifactId"]],
+  "data-structured-result": [["schema_id", "schema_version"], ["schemaId", "schemaVersion"]],
+};
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNullableString(value: unknown): boolean {
+  return value === null || isString(value);
+}
+
+function isBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+function isInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
+}
+
+function isNullableInteger(value: unknown): boolean {
+  return value === null || isInteger(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isString);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+

--- a/tools/fleet-tui/src/sse.ts
+++ b/tools/fleet-tui/src/sse.ts
@@ -1,47 +1,31 @@
 import type { components } from "./generated/openapi.js";
+import {
+  chunkTypes as chunkTypeList,
+  dataAlternatives,
+  dataFieldChecks,
+  dataRequiredFields,
+  isRecord,
+} from "./generated/fleet-ui-chunk-validation.js";
 
 /**
- * The AI SDK UI chunk contract is hand-maintained in FOUR places; keep them in
- * sync or the golden stream test (`tests/stream-fixture.test.ts`) fails:
+ * The AI SDK UI chunk contract is owned in TWO hand-edited places plus one
+ * generated consumer; the golden stream test (`tests/stream-fixture.test.ts`)
+ * locks all of them:
  *
  * 1. Backend runtime projector  — src/fleet_rlm/api/sse.py (AISDKUIProjector)
  * 2. Backend reload projection  — src/fleet_rlm/api/ui_message.py
  * 3. OpenAPI hook               — src/fleet_rlm/api/openapi.py (_CHUNK_FIELD_*)
- * 4. This runtime validator     — dataFieldChecks / dataRequiredFields /
- *                                dataAlternatives below
+ * 4. This runtime validator     — tables REGENERATED from openapi.yaml by
+ *    scripts/generate_tui_chunk_validation.py (imported below)
  *
- * The validator below is the STRICTEST copy: a backend emission that violates
- * it throws mid-stream ("Fleet API returned an invalid AI SDK UI stream chunk")
- * in a terminal, so a shape change must land here and in #1/#3 together.
+ * The validator is the STRICTEST consumer: a backend emission that violates
+ * it throws mid-stream ("Fleet API returned an invalid AI SDK UI stream
+ * chunk"), so a shape change must land in #1/#3 together, after which
+ * `make api-sync` refreshes the generated tables.
  */
 export type FleetUIMessageChunk = components["schemas"]["FleetUIMessageChunk"];
 
-const chunkTypes = new Set<FleetUIMessageChunk["type"]>([
-  "start",
-  "start-step",
-  "finish-step",
-  "reasoning-start",
-  "reasoning-delta",
-  "reasoning-end",
-  "data-status",
-  "data-skill",
-  "data-rlm-code",
-  "data-rlm-output",
-  "tool-input-available",
-  "tool-output-available",
-  "tool-output-error",
-  "data-attachment",
-  "data-warning",
-  "data-artifact",
-  "data-usage",
-  "data-structured-result",
-  "text-start",
-  "text-delta",
-  "text-end",
-  "finish",
-  "abort",
-  "error",
-]);
+const chunkTypes = new Set<FleetUIMessageChunk["type"]>(chunkTypeList);
 
 export async function* parseSSE(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
   const reader = body.getReader();
@@ -142,100 +126,11 @@ function isFleetUIMessageChunk(value: unknown): value is FleetUIMessageChunk {
   }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function nonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
 type FieldCheck = (value: unknown) => boolean;
-
-const dataFieldChecks: Record<string, Record<string, FieldCheck>> = {
-  "data-status": {
-    phase: isString,
-    status: isString,
-    detail: isString,
-    message: isNullableString,
-  },
-  "data-skill": {
-    skill_id: isString,
-    skillId: isString,
-    name: isString,
-    version: isString,
-    phase: (value) => value === "activated" || value === "loaded",
-    trust: isString,
-    affordances: isStringArray,
-  },
-  "data-rlm-code": {
-    code: isString,
-    step: isNullableInteger,
-    stream_id: isNullableString,
-    is_delta: isBoolean,
-    is_final: isBoolean,
-  },
-  "data-rlm-output": {
-    output: isString,
-    step: isNullableInteger,
-    stream_id: isNullableString,
-    is_delta: isBoolean,
-    is_final: isBoolean,
-  },
-  "data-attachment": {
-    attachment_id: isString,
-    attachmentId: isString,
-    phase: isString,
-    filename: isString,
-    byte_size: isInteger,
-    byteSize: isInteger,
-  },
-  "data-warning": { message: isString, code: isNullableString },
-  "data-artifact": {
-    artifact_id: isString,
-    artifactId: isString,
-    artifact_kind: isString,
-    kind: isString,
-    title: isNullableString,
-    name: isString,
-    media_type: isString,
-    mediaType: isString,
-    byte_size: isInteger,
-    byteSize: isInteger,
-    checksum_sha256: isString,
-    checksumSha256: isString,
-  },
-  "data-usage": { usage: isRecord },
-  "data-structured-result": {
-    schema_id: isString,
-    schemaId: isString,
-    schema_version: isString,
-    schemaVersion: isString,
-  },
-};
-
-const dataRequiredFields: Record<string, readonly string[]> = {
-  "data-status": ["phase"],
-  "data-skill": ["name", "version"],
-  "data-rlm-code": ["code"],
-  "data-rlm-output": ["output"],
-  "data-attachment": ["filename"],
-  "data-warning": ["message"],
-  "data-artifact": [],
-  "data-usage": ["usage"],
-  "data-structured-result": ["value"],
-};
-
-const dataAlternatives: Record<string, readonly (readonly string[])[]> = {
-  "data-status": [["status"], ["detail"], ["message"]],
-  "data-skill": [["skill_id"], ["skillId"]],
-  "data-attachment": [["attachment_id"], ["attachmentId"]],
-  "data-artifact": [["artifact_id"], ["artifactId"]],
-  "data-structured-result": [
-    ["schema_id", "schema_version"],
-    ["schemaId", "schemaVersion"],
-  ],
-};
 
 function isTypedDataPayload(type: string, value: unknown): boolean {
   if (!isRecord(value)) return false;
@@ -260,28 +155,4 @@ function hasOwn(value: Record<string, unknown>, field: string): boolean {
 
 function hasUsableValue(value: Record<string, unknown>, field: string): boolean {
   return hasOwn(value, field) && value[field] !== null && value[field] !== undefined;
-}
-
-function isString(value: unknown): value is string {
-  return typeof value === "string";
-}
-
-function isNullableString(value: unknown): boolean {
-  return value === null || isString(value);
-}
-
-function isBoolean(value: unknown): value is boolean {
-  return typeof value === "boolean";
-}
-
-function isInteger(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value);
-}
-
-function isNullableInteger(value: unknown): boolean {
-  return value === null || isInteger(value);
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every(isString);
 }

--- a/tools/fleet-tui/src/tests/cli.test.ts
+++ b/tools/fleet-tui/src/tests/cli.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 
+import { listCommands } from "../tui/commands.js";
+import { tuiUsage } from "../cli-core.js";
+
 import { parseArgs, run } from "../cli.js";
 
 describe("CLI options", () => {
@@ -21,5 +24,16 @@ describe("CLI options", () => {
     await expect(run({ apiUrl: "http://fleet.test" })).rejects.toThrow(
       "requires interactive stdin and stdout terminals",
     );
+  });
+});
+
+describe("tuiUsage", () => {
+  it("lists every registered slash command", () => {
+    const usage = tuiUsage();
+    for (const spec of listCommands()) expect(usage).toContain(spec.usage.split(" ", 1)[0]);
+    expect(usage).toContain("/profiles");
+    expect(usage).toContain("/settings");
+    expect(usage).toContain("/volume");
+    expect(usage).toContain("/rename");
   });
 });

--- a/tools/fleet-tui/src/tui/commands.ts
+++ b/tools/fleet-tui/src/tui/commands.ts
@@ -230,6 +230,11 @@ registerCommand({
   description: "Cancel the current run",
   usage: "/cancel",
   handler: async (_args, ctx) => {
+    const phase = ctx.store.getState().run.phase;
+    if (phase !== "submitting" && phase !== "running") {
+      appendSystem(ctx.store, "No active run.");
+      return;
+    }
     await ctx.cancelActiveRun();
     appendSystem(ctx.store, "Cancellation requested.");
   },

--- a/tools/fleet-tui/src/tui/format.ts
+++ b/tools/fleet-tui/src/tui/format.ts
@@ -1,88 +1,5 @@
 /** Renderer-neutral shared formatters for the Fleet TUI. */
 
-const ESC = String.fromCharCode(27);
-const ansiPrefixPattern = new RegExp(`${ESC}\\[[0-9;]*m`);
-
-export function visibleLength(input: string): number {
-  let length = 0;
-  let index = 0;
-  while (index < input.length) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
-    if (ansiMatch && ansiMatch.index === 0) {
-      index += ansiMatch[0].length;
-      continue;
-    }
-    const codePoint = input.codePointAt(index);
-    if (codePoint === undefined) break;
-    length += 1;
-    index += codePoint > 0xffff ? 2 : 1;
-  }
-  return length;
-}
-
-export function sliceVisible(input: string, width: number): string {
-  let visible = 0;
-  let index = 0;
-  let out = "";
-  while (index < input.length && visible < width) {
-    const ansiMatch = input.slice(index).match(ansiPrefixPattern);
-    if (ansiMatch && ansiMatch.index === 0) {
-      out += ansiMatch[0];
-      index += ansiMatch[0].length;
-      continue;
-    }
-    const codePoint = input.codePointAt(index);
-    if (codePoint === undefined) break;
-    out += String.fromCodePoint(codePoint);
-    index += codePoint > 0xffff ? 2 : 1;
-    visible += 1;
-  }
-  return out;
-}
-
-export function wrapToWidth(input: string, width: number): string[] {
-  if (width <= 0) return [input];
-  const lines: string[] = [];
-  for (const line of input.split("\n")) {
-    if (line.length === 0) {
-      lines.push("");
-      continue;
-    }
-    let remaining = line;
-    while (visibleLength(remaining) > width) {
-      let breakAt = -1;
-      let visible = 0;
-      let index = 0;
-      while (index < remaining.length) {
-        const ansiMatch = remaining.slice(index).match(ansiPrefixPattern);
-        if (ansiMatch && ansiMatch.index === 0) {
-          index += ansiMatch[0].length;
-          continue;
-        }
-        const codePoint = remaining.codePointAt(index);
-        if (codePoint === undefined) break;
-        if (visible >= width) {
-          breakAt = index;
-          break;
-        }
-        if (codePoint === 0x20 || codePoint === 0x09) {
-          breakAt = index + (codePoint > 0xffff ? 2 : 1);
-        }
-        index += codePoint > 0xffff ? 2 : 1;
-        visible += 1;
-      }
-      if (breakAt <= 0) {
-        breakAt = sliceVisible(remaining, width).length;
-        if (breakAt === 0) break;
-      }
-      lines.push(remaining.slice(0, breakAt).trimEnd());
-      remaining = remaining.slice(breakAt).trimStart();
-    }
-    lines.push(remaining);
-  }
-  return lines;
-}
-
 export function formatDuration(ms: number): string {
   if (ms < 0 || !Number.isFinite(ms)) return "0:00";
   const totalSeconds = Math.floor(ms / 1000);
@@ -140,15 +57,6 @@ export function redact(value: unknown): unknown {
     );
   }
   return value;
-}
-
-export function previewJson(value: unknown, maxLen = 240): string {
-  try {
-    const text = JSON.stringify(redact(value));
-    return text.length > maxLen ? `${text.slice(0, maxLen - 1)}…` : text;
-  } catch {
-    return String(value);
-  }
 }
 
 export type StructuredResultDisplay = {

--- a/tools/fleet-tui/src/tui/store.ts
+++ b/tools/fleet-tui/src/tui/store.ts
@@ -212,7 +212,6 @@ type Event =
   | { type: "run/cancelled"; reason: string }
   | { type: "run/interrupted"; error: string }
   | { type: "message/upsert"; message: Message }
-  | { type: "message/patch"; id: string; patch: Partial<Message> }
   | { type: "skill-selection/pin"; selection: PendingSkillSelection }
   | { type: "skill-selection/clear" }
   | { type: "skill-selection/replace"; selections: PendingSkillSelection[] }
@@ -445,20 +444,6 @@ function reduce(state: State, event: Event): State {
         }
       }
       return { ...state, messages: [...state.messages, incoming], run };
-    }
-    case "message/patch": {
-      const existing = state.messages.findIndex((m) => m.id === event.id);
-      if (existing < 0) return state;
-      const target = state.messages[existing] as Message;
-      const run = state.run;
-      if (target.kind === "text") {
-        const messages = state.messages.slice();
-        messages[existing] = { ...target, ...event.patch } as Message;
-        return { ...state, messages, run };
-      }
-      const messages = state.messages.slice();
-      messages[existing] = { ...target, ...event.patch } as Message;
-      return { ...state, messages, run };
     }
     case "skill-selection/pin": {
       const existing = state.pendingSkillSelections.findIndex(

--- a/tools/fleet-tui/src/tui/tests/commands.test.ts
+++ b/tools/fleet-tui/src/tui/tests/commands.test.ts
@@ -204,13 +204,26 @@ describe("command handlers", () => {
     });
   });
 
-  it("/cancel forwards to the cancelActiveRun hook", () => {
+  it("/cancel forwards to the cancelActiveRun hook while a Run is active", () => {
+    const { ctx } = makeContext();
+    const cancelSpy = vi.fn();
+    ctx.cancelActiveRun = cancelSpy;
+    ctx.store.dispatch({ type: "user/submit", text: "hi" });
+    ctx.store.dispatch({ type: "run/start", runId: "run-1", delivery: "live" });
+    const cancel = listCommands().find((c) => c.name === "cancel");
+    if (cancel) cancel.handler([], ctx);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("/cancel is a no-op without an active Run", () => {
     const { ctx } = makeContext();
     const cancelSpy = vi.fn();
     ctx.cancelActiveRun = cancelSpy;
     const cancel = listCommands().find((c) => c.name === "cancel");
     if (cancel) cancel.handler([], ctx);
-    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).not.toHaveBeenCalled();
+    const last = ctx.store.getState().messages[ctx.store.getState().messages.length - 1];
+    expect(last?.kind === "text" && last.text).toContain("No active run.");
   });
 
   it("/skills lists only cards returned by discovery", async () => {

--- a/tools/fleet-tui/src/tui/tests/format.test.ts
+++ b/tools/fleet-tui/src/tui/tests/format.test.ts
@@ -5,30 +5,11 @@ import {
   formatDuration,
   formatTokens,
   formatStructuredResult,
-  previewJson,
   redact,
   shortId,
-  sliceVisible,
-  visibleLength,
-  wrapToWidth,
 } from "../format.js";
 
 describe("format helpers", () => {
-  it("measures visible length ignoring ANSI escapes", () => {
-    expect(visibleLength("hello")).toBe(5);
-    expect(visibleLength("\x1b[31mhello\x1b[0m")).toBe(5);
-  });
-
-  it("slices up to a visible width and preserves ANSI sequences", () => {
-    expect(sliceVisible("\x1b[31mhello world\x1b[0m", 5)).toBe("\x1b[31mhello");
-  });
-
-  it("wraps lines to the requested width", () => {
-    const lines = wrapToWidth("the quick brown fox jumps over the lazy dog", 10);
-    expect(lines.length).toBeGreaterThan(1);
-    for (const line of lines) expect(visibleLength(line)).toBeLessThanOrEqual(10);
-  });
-
   it("formats duration in mm:ss or h:mm:ss", () => {
     expect(formatDuration(0)).toBe("0:00");
     expect(formatDuration(45_000)).toBe("0:45");
@@ -56,13 +37,6 @@ describe("format helpers", () => {
       nested: { password: "[redacted]" },
       ok: 1,
     });
-  });
-
-  it("previews JSON without throwing on circular structures", () => {
-    expect(previewJson({ a: 1, token: "x" })).toBe('{"a":1,"token":"[redacted]"}');
-    const cycle: Record<string, unknown> = {};
-    cycle.self = cycle;
-    expect(previewJson(cycle)).toBe("[object Object]");
   });
 
   it.each([

--- a/tools/fleet-tui/src/tui/tests/runner.test.ts
+++ b/tools/fleet-tui/src/tui/tests/runner.test.ts
@@ -337,7 +337,7 @@ describe("RunController", () => {
             'data: {"type":"reasoning-end","id":"reasoning-run-structured-2"}\n\n',
             'data: {"type":"data-rlm-output","id":"output-run-structured-2","data":{"step":2,"output":"verified: 1"}}\n\n',
             'data: {"type":"data-usage","id":"usage-run-structured","data":{"usage":{"iterations":2,"observed_lm_usage":{},"duration_ms":20}}}\n\n',
-            'data: {"type":"data-structured-result","id":"result-run-structured","data":{"schemaId":"digit","schemaVersion":"1","value":{"digit":"1"}}}\n\n',
+            'data: {"type":"data-structured-result","id":"result-run-structured","data":{"schema_id":"digit","schema_version":"1","value":{"digit":"1"}}}\n\n',
             'data: {"type":"text-start","id":"text-run-structured"}\n\n',
             'data: {"type":"text-delta","id":"text-run-structured","delta":"The verified digit is 1."}\n\n',
             'data: {"type":"text-end","id":"text-run-structured"}\n\n',


### PR DESCRIPTION
# Description

Three independent hygiene commits against `dev-0.7` — protocol-seam documentation, TUI dead-code sweep, and the first single-sourced stream-validator table.

## Commits

1. **`docs(composition)` — runtime inventory Protocols documented**: why `SettlingTurnStore`/`RuntimeSessionManager`/`RuntimeProcessResources` stay Protocols (provider-neutral inventory, credential-free test injection) instead of being folded. Docstring-only; folding was rejected because it would couple `inventory.py` to `daytona/` imports.
2. **`refactor(tui)` — dead-code sweep** (net −105 LOC): four never-consumed `format.ts` utilities removed (`visibleLength`, `sliceVisible`, `wrapToWidth`, `previewJson`) with their sole test coverage; never-dispatched `message/patch` store event deleted (with a duplicated reducer branch); `tuiUsage()` derived from `listCommands()` so `--help` can never drift from `/help`; `/cancel` is now an honest no-op without an active run.
3. **`feat(tui)` — chunk-validation tables single-sourced**: `scripts/generate_tui_chunk_validation.py` derives `tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts` from `openapi.yaml`'s `FleetUIMessageChunk` variants. The strictest stream consumer (`sse.ts`) now reads generated tables instead of a hand-maintained fourth copy. Contract owners shrink from four hand files to three + one generator; dual snake/camel id tolerances remain the generator's declared input; generator check is wired into `make api-check`/`api-sync` and proven to fail on stale output. One test fixture (a camelCase structured result pushed through the **live** stream path) was realigned to the actual snake_case wire form — the mock was wrong per the contract the generator now enforces.

## Validation

- `make check` green (coverage 82.07% ≥ 75%; Ruff, `ty`, `api-check` (+generator check), `stream-check`, TUI 185 tests, codebase-tree, docs + harness)
- Generator drift-detection proven: stale generated file exits 1; regenerate is byte-current
- `pnpm typecheck` on the new generated module import cycle — clean (type-only ring)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — dead code / stale help damage
- [x] New feature (non-breaking change which adds functionality) — generator + drift gate
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] Relevant local validation passed (`make check` on the final commit)
- [x] Commit messages follow conventions
- [x] PR description clearly explains the change
- [x] Documentation updated (scripts inventory, AGENTS.md ownership, codebase map, generated-artifacts notes)
