### PR TITLE
fix(rlm): guard tool namespace is authoritative over path prefixes

### DIFF
--- a/src/fleet_rlm/rlm/tool_guards.py
+++ b/src/fleet_rlm/rlm/tool_guards.py
@@ -45,7 +45,17 @@ _WORKSPACE_TOOL_NAMESPACES = {
 _PREFIX_NAMESPACES = (("projects/", "project_workspace"), ("workspace/", "session_workspace"))
 
 
-def _canonical_target(path: object, *, default_namespace: str = "session_workspace") -> str | None:
+def _canonical_target(path: object, *, namespace: str | None = None) -> str | None:
+    """Canonicalize one guard target; an explicit tool namespace is authoritative.
+
+    Without ``namespace`` (request-text obligations) the guard-target language
+    infers the namespace from a ``projects/`` or ``workspace/`` path prefix.
+    With ``namespace`` (tool-derived targets) prefixes never cross namespaces:
+    project tools tolerate only a redundant leading ``projects/`` segment
+    (mirroring ``_normalize_project_path``), and session-workspace tools use
+    their paths verbatim, so a ``projects/...`` path passed to a session tool
+    stays a ``session_workspace:`` target.
+    """
     if not isinstance(path, str):
         return None
     try:
@@ -54,12 +64,15 @@ def _canonical_target(path: object, *, default_namespace: str = "session_workspa
         normalized = normalize_workspace_path(path)
     except (TypeError, WorkspacePathError):
         return None
-    namespace = default_namespace
-    for prefix, prefix_namespace in _PREFIX_NAMESPACES:
-        if normalized.startswith(prefix):
-            namespace = prefix_namespace
-            normalized = normalized.removeprefix(prefix)
-            break
+    if namespace is None:
+        namespace = "session_workspace"
+        for prefix, prefix_namespace in _PREFIX_NAMESPACES:
+            if normalized.startswith(prefix):
+                namespace = prefix_namespace
+                normalized = normalized.removeprefix(prefix)
+                break
+    elif namespace == "project_workspace":
+        normalized = normalized.removeprefix("projects/")
     return f"{namespace}:{normalized}"
 
 
@@ -67,7 +80,7 @@ def _workspace_target(tool_name: str, arguments: Mapping[str, Any]) -> str | Non
     namespace = _WORKSPACE_TOOL_NAMESPACES.get(tool_name)
     if namespace is None:
         return None
-    return _canonical_target(arguments.get("path"), default_namespace=namespace)
+    return _canonical_target(arguments.get("path"), namespace=namespace)
 
 
 def workspace_obligations(request: str) -> frozenset[str] | None:

--- a/tests/unit/backend/rlm/test_tool_guards.py
+++ b/tests/unit/backend/rlm/test_tool_guards.py
@@ -175,6 +175,33 @@ def test_project_target_strips_a_redundant_projects_prefix() -> None:
     assert guards.integrity.unresolved == ("project_workspace:fleet-rlm/review.md",)
 
 
+def test_tool_namespace_is_authoritative_over_path_prefixes() -> None:
+    # A session-workspace tool executes its path verbatim inside the session
+    # workspace, so a ``projects/...`` path must never satisfy (or even join)
+    # a ``project_workspace:`` obligation.
+    guards = TurnToolGuards(required_targets=frozenset({"project_workspace:fleet-rlm/review.md"}))
+    guards.failed("write_project_text", {"path": "fleet-rlm/review.md"})
+    assert guards.integrity.unresolved == ("project_workspace:fleet-rlm/review.md",)
+
+    guards.completed(
+        "write_workspace_text",
+        {"path": "projects/fleet-rlm/review.md", "content": "final", "overwrite": True},
+        {"ok": True},
+    )
+    guards.completed(
+        "read_workspace_text",
+        {"path": "projects/fleet-rlm/review.md"},
+        {"content": "final", "eof": True},
+    )
+    assert guards.integrity.unresolved == ("project_workspace:fleet-rlm/review.md",)
+
+    # The mirrored crossing (a project tool writing under a ``workspace``
+    # slug) stays in the project namespace instead of flipping to session.
+    session_guards = TurnToolGuards(required_targets=frozenset({"session_workspace:notes/report.md"}))
+    session_guards.failed("edit_project_text", {"path": "workspace/notes/report.md"})
+    assert session_guards.integrity.unresolved == ()
+
+
 def test_delete_and_edit_tools_join_guard_targets_in_both_namespaces() -> None:
     guards = TurnToolGuards()
 


### PR DESCRIPTION
Fixes a guard-target namespace crossing flagged by the security review on #425 (which merged before the fix could land there). `_canonical_target` let a `projects/...` path prefix override the calling tool's namespace, so `write_workspace_text(path="projects/<slug>/<file>")` was recorded as a `project_workspace:` target even though session-workspace tools execute their paths verbatim inside the session workspace. That could falsely satisfy a required project-path obligation without any mutation in the projects root (and mirrored: a project tool writing under a `workspace/` slug flipped to `session_workspace:`).

Tool-derived targets now treat the tool's namespace as authoritative; prefix inference remains only for request-text obligations, where the guard-target language defines it:

```python
if namespace is None:  # request-text obligation
    namespace = "session_workspace"
    for prefix, prefix_namespace in _PREFIX_NAMESPACES:
        if normalized.startswith(prefix):
            namespace = prefix_namespace
            normalized = normalized.removeprefix(prefix)
            break
elif namespace == "project_workspace":
    # Project tools tolerate only a redundant leading ``projects/`` segment.
    normalized = normalized.removeprefix("projects/")
```

Project tools keep tolerating the redundant `projects/` prefix (mirroring `_normalize_project_path`), so existing fingerprints and obligation matching for correctly-scoped calls are unchanged. Adds a regression test proving a session-tool write plus read-back with a `projects/...` path leaves the project obligation unresolved.