### PR TITLE
Harden Daytona startup and snapshot lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ NATIVE_LONG_CONTEXT_OUTPUT ?= .scratch/benchmark-reports/native-long-context-$(s
 benchmark-native-long-context:
 	uv run python scripts/benchmarks/run_native_long_context.py --output $(NATIVE_LONG_CONTEXT_OUTPUT)
 
-DAYTONA_SNAPSHOT_NAME ?= fleet-rlm-python313-v4
+DAYTONA_SNAPSHOT_NAME ?= fleet-rlm-python313-v5
 
 daytona-snapshot-create:
 	uv run python scripts/daytona_snapshot.py create --name $(DAYTONA_SNAPSHOT_NAME)
@@ -139,10 +139,13 @@ daytona-snapshot-check:
 tui-check:
 	$(MAKE) api-check
 	$(MAKE) stream-check
-	pnpm --dir tools/fleet-tui run format:check
-	pnpm --dir tools/fleet-tui run lint
-	pnpm --dir tools/fleet-tui run typecheck
-	pnpm --dir tools/fleet-tui run test
+	# Run pnpm from inside the workspace so corepack resolves the pinned
+	# packageManager version (pnpm --dir resolves from the invocation CWD and
+	# misses it when make runs from the repo root).
+	cd tools/fleet-tui && pnpm run format:check
+	cd tools/fleet-tui && pnpm run lint
+	cd tools/fleet-tui && pnpm run typecheck
+	cd tools/fleet-tui && pnpm run test
 
 check: lint format-check typecheck test-daytona-cov api-check tui-check check-codebase-tree check-docs
 

--- a/config/fleet.toml
+++ b/config/fleet.toml
@@ -50,7 +50,7 @@ database_url_env = "FLEET_DATABASE_URL"
 
 [defaults.daytona]
 api_key_env = "FLEET_DAYTONA_API_KEY"
-snapshot = "fleet-rlm-python313-v4"
+snapshot = "fleet-rlm-python313-v5"
 volume_name = "fleet-volume"
 volume_mount_path = "/home/daytona/fleet"
 
@@ -73,7 +73,7 @@ environment = "daytona"
 model = "deepseek-v4-flash"
 api_key_env = "FLEET_OPENCODE_GO_API_KEY"
 base_url_env = "FLEET_OPENCODE_GO_BASE_URL"
-max_tokens = 8000
+max_tokens = 16000
 # Streaming turns re-enter identical action prompts on retries/repeated steps;
 # a cache hit yields zero streamify deltas and reads as a frozen stream.
 cache = false
@@ -83,7 +83,7 @@ reasoning_effort = "low"
 model = "deepseek-v4-flash"
 api_key_env = "FLEET_OPENCODE_GO_API_KEY"
 base_url_env = "FLEET_OPENCODE_GO_BASE_URL"
-max_tokens = 8000
+max_tokens = 16000
 temperature = 0
 cache = false
 reasoning_effort = "low"
@@ -100,7 +100,7 @@ environment = "daytona"
 model = "deepseek-v4-flash"
 api_key_env = "FLEET_OPENCODE_GO_API_KEY"
 base_url_env = "FLEET_OPENCODE_GO_BASE_URL"
-max_tokens = 8000
+max_tokens = 16000
 cache = false
 reasoning_effort = "low"
 
@@ -108,7 +108,7 @@ reasoning_effort = "low"
 model = "deepseek-v4-flash"
 api_key_env = "FLEET_OPENCODE_GO_API_KEY"
 base_url_env = "FLEET_OPENCODE_GO_BASE_URL"
-max_tokens = 8000
+max_tokens = 16000
 temperature = 0
 cache = false
 reasoning_effort = "low"

--- a/docs/how-to-guides/daytona-snapshot.md
+++ b/docs/how-to-guides/daytona-snapshot.md
@@ -1,12 +1,14 @@
 # Daytona Snapshot
 
 Fleet Daytona Sandboxes use an explicit immutable Snapshot rather than the
-provider default. The current contract is `fleet-rlm-python313-v4`: Python
+provider default. The current contract is `fleet-rlm-python313-v5`: Python
 3.13.13 from a linux/amd64 digest-pinned `python:3.13.13-slim-bookworm` image,
-a `daytona` non-root user, `/home/daytona` working directory, and 2 vCPU, 4 GiB
+a `git`/`ca-certificates` toolchain layer for Daytona git operations, a
+`daytona` non-root user, `/home/daytona` working directory, and 2 vCPU, 4 GiB
 memory, and 8 GiB disk. Its repository-owned dependency manifest currently
-bakes `mpmath==1.4.1` into system site-packages and records the manifest digest
-in the image contract. It contains no Fleet source, provider credentials, DSPy,
+bakes `mpmath==1.4.1`, `numpy==2.5.1`, `pandas==3.0.5`, and
+`beautifulsoup4==4.15.0` into system site-packages and records the manifest
+digest in the image contract. It contains no Fleet source, provider credentials, DSPy,
 or uv.
 
 Snapshot provisioning is an operator action, never an application-startup side
@@ -34,9 +36,9 @@ disposable Sandbox without user-site repair.
 ## Upgrade and rollback
 
 For a future upgrade, create a new immutable name such as
-`fleet-rlm-python313-v5`, verify it, and change only `daytona.snapshot` in the
+`fleet-rlm-python313-v6`, verify it, and change only `daytona.snapshot` in the
 committed TOML policy. Existing Session Sandboxes with the old
 identity are replaced lazily while retaining their Workspace Volume ID and
-`workspaces/<workspace_id>` scope. During the v4 rollout, roll back by restoring
-`fleet-rlm-python313-v3`; for later upgrades, restore the preceding immutable
+`workspaces/<workspace_id>` scope. During the v5 rollout, roll back by restoring
+`fleet-rlm-python313-v4`; for later upgrades, restore the preceding immutable
 Snapshot. Do not mutate or overwrite an existing Snapshot.

--- a/scripts/daytona_snapshot.py
+++ b/scripts/daytona_snapshot.py
@@ -24,7 +24,7 @@ def _parser() -> argparse.ArgumentParser:
     subcommands = parser.add_subparsers(dest="command", required=True)
     for command in ("create", "check"):
         sub = subcommands.add_parser(command)
-        sub.add_argument("--name", required=True, help="Immutable snapshot name, for example fleet-rlm-python313-v4")
+        sub.add_argument("--name", required=True, help="Immutable snapshot name, for example fleet-rlm-python313-v5")
     return parser
 
 

--- a/scripts/daytona_snapshot.py
+++ b/scripts/daytona_snapshot.py
@@ -20,6 +20,12 @@ from fleet_rlm.daytona.provisioning import DaytonaSandboxSpec, build_snapshot_im
 
 
 def _parser() -> argparse.ArgumentParser:
+    """
+    Create the command-line parser for snapshot creation and inspection commands.
+    
+    Returns:
+    	argparse.ArgumentParser: Parser with required `create` and `check` subcommands and snapshot name arguments.
+    """
     parser = argparse.ArgumentParser(description="Manage the immutable Fleet Daytona Snapshot.")
     subcommands = parser.add_subparsers(dest="command", required=True)
     for command in ("create", "check"):

--- a/src/fleet_rlm/cli/supervisor.py
+++ b/src/fleet_rlm/cli/supervisor.py
@@ -33,12 +33,18 @@ class SupervisorError(RuntimeError):
     """A user-actionable local process supervision failure."""
 
 
-# Daytona lifespan creates ephemeral Volume I/O sandboxes during orphan cleanup;
-# cold provider create/delete routinely exceeds a 30s local readiness budget.
+# Daytona startup runs settling recovery after a cold Lakebase connect; the
+# bounded worst-case path (~90s) sits at the old 90s budget, so allow headroom.
+# Every startup await is now bounded (DB connect, deferred cleanup, shielded
+# delete), so this never masks an infinite hang -- it only lets bounded-but-slow
+# startup finish instead of being killed mid-recovery.
 _READY_TIMEOUT_SECONDS = {
-    "daytona": 90.0,
+    "daytona": 150.0,
 }
 _MLFLOW_READY_TIMEOUT_SECONDS = 30.0
+# Lakebase scale-to-zero connects take ~10s when cold; bound the preflight so a
+# hung endpoint fails fast with a clear message instead of blocking the launcher.
+_DATABASE_PREFLIGHT_TIMEOUT_SECONDS = 30.0
 _LOCAL_MLFLOW_URI = "http://127.0.0.1:5001"
 _LOCAL_MLFLOW_HOST = "127.0.0.1"
 _LOCAL_MLFLOW_PORT = 5001
@@ -137,7 +143,14 @@ def _validate_daytona_database(repo_root: Path, *, settings: Settings | None = N
     if not database_url:
         raise SupervisorError("Fleet database preflight failed; verify FLEET_DATABASE_URL")
     try:
-        asyncio.run(ensure_database_compatible(database_url, repo_root=repo_root))
+        asyncio.run(
+            asyncio.wait_for(
+                ensure_database_compatible(database_url, repo_root=repo_root),
+                timeout=_DATABASE_PREFLIGHT_TIMEOUT_SECONDS,
+            )
+        )
+    except TimeoutError as exc:
+        raise SupervisorError("Fleet database preflight timed out; verify FLEET_DATABASE_URL reachability") from exc
     except Exception as exc:
         raise SupervisorError(str(exc)) from exc
 

--- a/src/fleet_rlm/cli/supervisor.py
+++ b/src/fleet_rlm/cli/supervisor.py
@@ -134,6 +134,15 @@ def _api_url(host: str, port: int) -> str:
 
 
 def _validate_daytona_database(repo_root: Path, *, settings: Settings | None = None) -> None:
+    """Validate Fleet database compatibility before launching supervised processes.
+    
+    Parameters:
+    	repo_root (Path): Root directory used for database compatibility checks.
+    	settings (Settings | None): Runtime settings containing the database URL; loaded when omitted.
+    
+    Raises:
+    	SupervisorError: If the database URL is unavailable, the compatibility check times out, or the check fails.
+    """
     if settings is None:
         try:
             settings = load_runtime_settings()

--- a/src/fleet_rlm/composition/daytona.py
+++ b/src/fleet_rlm/composition/daytona.py
@@ -68,6 +68,15 @@ async def _dispose_components(
     database: RuntimeDatabaseLifecycle | None = None,
     suppress_errors: bool,
 ) -> None:
+    """
+    Asynchronously disposes the available runtime components.
+    
+    Parameters:
+    	resources (RuntimeProcessResources | None): Runtime process resources to dispose.
+    	gateway (object | None): Gateway to close.
+    	database (RuntimeDatabaseLifecycle | None): Database lifecycle to close.
+    	suppress_errors (bool): Whether to suppress disposal errors.
+    """
     first_error: Exception | None = None
     for target, method_name in ((resources, "adispose"), (gateway, "close"), (database, "aclose")):
         method = getattr(target, method_name, None)
@@ -103,7 +112,16 @@ async def _reconcile_daytona_settling(
     fence_timeout: float = _STARTUP_RECOVERY_FENCE_TIMEOUT_SECONDS,
     deadline: float | None = None,
 ) -> ReconciliationSummary:
-    """Recover stale Turns without letting one provider fence block startup."""
+    """
+    Reconcile stale settling turns using bounded session fencing.
+    
+    Parameters:
+        fence_timeout (float): Maximum time allowed to fence each session, in seconds.
+        deadline (float | None): Optional monotonic-time deadline for the overall reconciliation.
+    
+    Returns:
+        ReconciliationSummary: Summary of the reconciliation results.
+    """
 
     async def bounded_fence(session_id: UUID) -> None:
         remaining = fence_timeout
@@ -164,7 +182,16 @@ async def run_deferred_orphan_cleanup(
 
 
 async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillCatalog) -> RuntimeInventory:
-    """Construct the Daytona lifespan inventory and clean partial failures."""
+    """
+    Construct the Daytona runtime inventory and clean up partially initialized resources on failure.
+    
+    Parameters:
+    	settings (Settings): Application settings used to configure the Daytona runtime.
+    	skill_catalog (SkillCatalog): Application skill catalog used to build turn preparation.
+    
+    Returns:
+    	RuntimeInventory: The initialized Daytona runtime services and resources.
+    """
     from fleet_rlm.rlm.dspy_contract import assert_dspy_version
 
     assert_dspy_version()
@@ -356,7 +383,15 @@ async def install_daytona_composition(
     app: FastAPI,
     settings: Settings,
 ) -> RuntimeInventory:
-    """Attach an already-migrated Daytona inventory to app state."""
+    """Install the Daytona runtime inventory on the application.
+    
+    Parameters:
+    	app (FastAPI): Application that provides the skill catalog and receives the runtime inventory.
+    	settings (Settings): Configuration used to build the Daytona composition.
+    
+    Returns:
+    	RuntimeInventory: The installed Daytona runtime inventory.
+    """
     from fleet_rlm.daytona.interpreter import set_bridge_service_loop
 
     skill_catalog = getattr(app.state, "skill_catalog", None)
@@ -410,7 +445,10 @@ async def install_daytona_composition(
 
 
 async def dispose_daytona_composition(app: FastAPI) -> None:
-    """Best-effort shutdown of Daytona resources."""
+    """Dispose the Daytona runtime composition and release its associated resources.
+    
+    The shutdown drains pending turn cleanup before disposing runtime, gateway, and database resources, then unregisters the Daytona bridge service loop.
+    """
     from fleet_rlm.daytona.interpreter import set_bridge_service_loop
 
     inventory = clear_runtime_inventory(app)

--- a/src/fleet_rlm/composition/daytona.py
+++ b/src/fleet_rlm/composition/daytona.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from datetime import timedelta
 from pathlib import Path
+from typing import Any
 from uuid import UUID
 
 from fastapi import FastAPI
@@ -81,6 +82,20 @@ async def _dispose_components(
         raise first_error
 
 
+async def _cancel_orphan_cleanup(task: asyncio.Task[None] | None) -> None:
+    """Cancel and settle the owned orphan sweep before disposing its resources."""
+    if task is None:
+        return
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.warning("Daytona orphan cleanup failed while settling shutdown", exc_info=True)
+
+
 async def _reconcile_daytona_settling(
     turn_state: SettlingTurnStore,
     session_manager: RuntimeSessionManager,
@@ -101,6 +116,53 @@ async def _reconcile_daytona_settling(
     return await turn_state.reconcile_settling(bounded_fence, deadline=deadline)
 
 
+async def run_deferred_orphan_cleanup(
+    gateway: Any,
+    *,
+    workspace_id: UUID,
+    paths: Any,
+    artifact_catalog: Any,
+    grace_period: timedelta = timedelta(hours=1),
+) -> None:
+    """Best-effort orphan sweep that must never block startup readiness.
+
+    Runs as a tracked background task after the composition is installed; its
+    sandbox creation (cold provisioning) and deletions are deliberately kept off
+    the readiness-critical path. Failures and timeouts are logged and left for a
+    later startup.
+    """
+    from fleet_rlm.daytona.workspace_gateway import cleanup_orphan_bytes
+
+    try:
+        async with asyncio.timeout(_ORPHAN_CLEANUP_TIMEOUT_SECONDS):
+            cleanup_report = await cleanup_orphan_bytes(
+                gateway,
+                workspace_id=workspace_id,
+                paths=paths,
+                committed_storage_refs=await artifact_catalog.list_storage_refs(workspace_id=workspace_id),
+                completed_runs=await artifact_catalog.list_completed_runs(workspace_id=workspace_id),
+                active_runs=await artifact_catalog.list_active_runs(workspace_id=workspace_id),
+                grace_period=grace_period,
+            )
+    except TimeoutError:
+        logger.warning(
+            "Daytona orphan cleanup timed out phase=orphan_cleanup timeout_seconds=%.3f; left for a later startup",
+            _ORPHAN_CLEANUP_TIMEOUT_SECONDS,
+        )
+        return
+    except Exception:
+        logger.warning("Daytona orphan cleanup failed phase=orphan_cleanup", exc_info=True)
+        return
+    logger.info(
+        "Daytona orphan cleanup complete phase=orphan_cleanup scanned=%d removed=%d retained=%d "
+        "skipped_fresh=%d deferred=true",
+        cleanup_report.scanned,
+        cleanup_report.removed,
+        cleanup_report.retained,
+        cleanup_report.skipped_fresh,
+    )
+
+
 async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillCatalog) -> RuntimeInventory:
     """Construct the Daytona lifespan inventory and clean partial failures."""
     from fleet_rlm.rlm.dspy_contract import assert_dspy_version
@@ -119,7 +181,6 @@ async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillC
     from fleet_rlm.daytona.workspace_gateway import (
         DaytonaWorkspaceGateway,
         DaytonaWorkspaceVolumeGateway,
-        cleanup_orphan_bytes,
     )
     from fleet_rlm.files.lifecycle import AttachmentLifecycleService
     from fleet_rlm.files.local_catalog import WorkspaceAttachmentBlobGateway
@@ -145,6 +206,7 @@ async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillC
     database_lifecycle: RuntimeDatabaseLifecycle | None = None
     resources: DaytonaRuntimeResources | None = None
     gateway: object | None = None
+    orphan_cleanup_task: asyncio.Task[None] | None = None
     try:
         # Fail closed on an unreachable or non-head database, inside the
         # cleanup scope so the engine above is always disposed on failure.
@@ -193,40 +255,6 @@ async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillC
         local_scope = LocalScope()
         startup_started = asyncio.get_running_loop().time()
         startup_deadline = startup_started + _STARTUP_CLEANUP_RECOVERY_BUDGET_SECONDS
-        cleanup_remaining = startup_deadline - asyncio.get_running_loop().time()
-        if cleanup_remaining <= 0:
-            logger.warning("Daytona orphan cleanup skipped phase=orphan_cleanup budget_exhausted=true")
-        else:
-            cleanup_timeout = min(_ORPHAN_CLEANUP_TIMEOUT_SECONDS, cleanup_remaining)
-            try:
-                async with asyncio.timeout(cleanup_timeout):
-                    cleanup_report = await cleanup_orphan_bytes(
-                        gateway,
-                        workspace_id=local_scope.workspace_id,
-                        paths=volume_paths,
-                        committed_storage_refs=await artifact_catalog.list_storage_refs(
-                            workspace_id=local_scope.workspace_id
-                        ),
-                        completed_runs=await artifact_catalog.list_completed_runs(
-                            workspace_id=local_scope.workspace_id
-                        ),
-                        active_runs=await artifact_catalog.list_active_runs(workspace_id=local_scope.workspace_id),
-                        grace_period=timedelta(hours=1),
-                    )
-                logger.info(
-                    "Daytona orphan cleanup complete phase=orphan_cleanup scanned=%d removed=%d retained=%d "
-                    "skipped_fresh=%d timeout_seconds=%.3f",
-                    cleanup_report.scanned,
-                    cleanup_report.removed,
-                    cleanup_report.retained,
-                    cleanup_report.skipped_fresh,
-                    cleanup_timeout,
-                )
-            except TimeoutError:
-                logger.warning(
-                    "Daytona orphan cleanup timed out phase=orphan_cleanup timeout_seconds=%.3f; continuing startup",
-                    cleanup_timeout,
-                )
         turn_preparation = build_turn_preparation(
             resources,
             attachment_lifecycle=attachment_lifecycle,
@@ -270,6 +298,20 @@ async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillC
                 recovery.skipped,
                 recovery.budget_exhausted,
             )
+
+        # Defer the non-critical orphan sweep until after readiness; it creates
+        # ephemeral Daytona sandboxes whose cold provisioning routinely exceeds
+        # the startup budget (see supervisor._READY_TIMEOUT_SECONDS).
+        orphan_cleanup_task = asyncio.get_running_loop().create_task(
+            run_deferred_orphan_cleanup(
+                gateway,
+                workspace_id=local_scope.workspace_id,
+                paths=volume_paths,
+                artifact_catalog=artifact_catalog,
+            ),
+            name="fleet-daytona-orphan-cleanup",
+        )
+
         coordinator = TurnCoordinator(
             lifecycle=lifecycle,
             preparation=turn_preparation,
@@ -294,8 +336,10 @@ async def build_daytona_composition(settings: Settings, *, skill_catalog: SkillC
             turn_state_store=turn_state,
             database=database_lifecycle,
             model_bundle=model_bundle,
+            orphan_cleanup_task=orphan_cleanup_task,
         )
     except Exception:
+        await _cancel_orphan_cleanup(orphan_cleanup_task)
         if resources is None and database_lifecycle is None:
             await engine.dispose()
         else:
@@ -349,10 +393,12 @@ async def install_daytona_composition(
             workspace_volume_gateway=inventory.workspace_volume_gateway,
             workspace_file_service=inventory.workspace_file_service,
             workspace_volume_mirror=inventory.workspace_volume_mirror,
+            orphan_cleanup_task=inventory.orphan_cleanup_task,
         )
         return install_runtime_inventory(app, inventory)
     except Exception:
         clear_runtime_inventory(app)
+        await _cancel_orphan_cleanup(inventory.orphan_cleanup_task)
         await _dispose_components(
             resources=inventory.run_environment_resources,
             gateway=inventory.workspace_volume_gateway,
@@ -368,6 +414,8 @@ async def dispose_daytona_composition(app: FastAPI) -> None:
     from fleet_rlm.daytona.interpreter import set_bridge_service_loop
 
     inventory = clear_runtime_inventory(app)
+    orphan_task = getattr(inventory, "orphan_cleanup_task", None)
+    await _cancel_orphan_cleanup(orphan_task)
     cleanup = getattr(inventory, "turn_cleanup_supervisor", None)
     if cleanup is not None:
         await cleanup.shutdown(drain_seconds=30)

--- a/src/fleet_rlm/composition/inventory.py
+++ b/src/fleet_rlm/composition/inventory.py
@@ -12,6 +12,7 @@ import provider modules and re-couple the test suite to Daytona.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import ClassVar, Protocol
@@ -100,6 +101,9 @@ class RuntimeInventory:
     workspace_volume_gateway: WorkspaceVolumeGateway | None = None
     workspace_file_service: WorkspaceFileService | None = None
     workspace_volume_mirror: VolumeTreeFs | None = None
+    # Best-effort post-readiness orphan sweep; cancelled at dispose. It must
+    # never gate startup readiness, so it is tracked (not awaited) here.
+    orphan_cleanup_task: asyncio.Task[None] | None = None
 
     _REQUIRED_ROUTE_FIELDS: ClassVar[tuple[str, ...]] = (
         "turn_coordinator",

--- a/src/fleet_rlm/daytona/diagnostics.py
+++ b/src/fleet_rlm/daytona/diagnostics.py
@@ -20,7 +20,7 @@ from fleet_rlm.daytona.platform import (
 from fleet_rlm.daytona.provisioning import (
     ExpectedWorkspaceMount,
     sandbox_spec_from_settings,
-    snapshot_execution_dependencies,
+    snapshot_dependency_import_names,
     verify_sandbox_spec,
     verify_sandbox_workspace_mount,
     volume_config_from_settings,
@@ -150,16 +150,16 @@ class _ProductionDaytonaDoctorDependencies:
         context = await sandbox.code_interpreter.create_context()
         run_error: BaseException | None = None
         try:
-            dependencies = snapshot_execution_dependencies()
+            dependencies = snapshot_dependency_import_names()
             result = await sandbox.code_interpreter.run_code(
-                "import importlib, importlib.metadata, os, sys\n"
+                "import importlib, importlib.metadata, os, shutil, sys\n"
                 "assert sys.version_info[:3] == (3, 13, 13)\n"
                 "assert os.geteuid() != 0\n"
                 "assert os.getcwd() == '/home/daytona'\n"
+                "assert shutil.which('git'), 'git toolchain missing from snapshot'\n"
                 f"dependencies = {dependencies!r}\n"
-                "for requirement in dependencies:\n"
-                "    package, expected = requirement.split('==', 1)\n"
-                "    importlib.import_module(package.replace('-', '_'))\n"
+                "for package, module, expected in dependencies:\n"
+                "    importlib.import_module(module)\n"
                 "    assert importlib.metadata.version(package) == expected\n"
                 "print('fleet-doctor-ok')",
                 context=context,

--- a/src/fleet_rlm/daytona/diagnostics.py
+++ b/src/fleet_rlm/daytona/diagnostics.py
@@ -147,6 +147,18 @@ class _ProductionDaytonaDoctorDependencies:
         verify_sandbox_spec(sandbox, self._sandbox_spec)
 
     async def execute(self, sandbox: Any) -> str:
+        """
+        Run the Daytona interpreter diagnostic in a temporary sandbox context.
+        
+        Parameters:
+            sandbox (Any): Sandbox whose code interpreter runs the diagnostic.
+        
+        Returns:
+            str: Diagnostic process output.
+        
+        Raises:
+            RuntimeError: If the interpreter reports an execution error.
+        """
         context = await sandbox.code_interpreter.create_context()
         run_error: BaseException | None = None
         try:

--- a/src/fleet_rlm/daytona/platform.py
+++ b/src/fleet_rlm/daytona/platform.py
@@ -214,7 +214,12 @@ class LiveDaytonaPlatform:
         await self._client.start(sandbox)
 
     async def stop(self, sandbox_id: str, *, timeout: float = 60, force: bool = False) -> None:
-        sandbox = await self._client.get(sandbox_id)
+        try:
+            sandbox = await self._client.get(sandbox_id)
+        except Exception as exc:
+            if is_sandbox_not_found(exc):
+                return
+            raise
         try:
             await self._client.stop(sandbox, timeout=timeout)
         except Exception:

--- a/src/fleet_rlm/daytona/platform.py
+++ b/src/fleet_rlm/daytona/platform.py
@@ -210,10 +210,25 @@ class LiveDaytonaPlatform:
         await self._client.delete(target)
 
     async def start(self, sandbox_id: str) -> None:
+        """Start the specified sandbox.
+        
+        Parameters:
+        	sandbox_id (str): The identifier of the sandbox to start.
+        """
         sandbox = await self._client.get(sandbox_id)
         await self._client.start(sandbox)
 
     async def stop(self, sandbox_id: str, *, timeout: float = 60, force: bool = False) -> None:
+        """
+        Stop a sandbox, optionally deleting it if stopping fails.
+        
+        Parameters:
+            sandbox_id (str): Identifier of the sandbox to stop.
+            timeout (float): Maximum time to wait for the stop operation, in seconds.
+            force (bool): Whether to delete the sandbox if stopping fails.
+        
+        A missing sandbox is treated as already stopped.
+        """
         try:
             sandbox = await self._client.get(sandbox_id)
         except Exception as exc:

--- a/src/fleet_rlm/daytona/provisioning.py
+++ b/src/fleet_rlm/daytona/provisioning.py
@@ -15,7 +15,7 @@ from fleet_rlm.daytona.errors import DaytonaAdapterError, map_provider_error
 from fleet_rlm.files.volume_paths import DEFAULT_VOLUME_MOUNT_PATH, VolumePaths, validate_mount_path
 from fleet_rlm.snapshot_contract import validate_snapshot_name
 
-DEFAULT_SNAPSHOT_NAME = "fleet-rlm-python313-v4"
+DEFAULT_SNAPSHOT_NAME = "fleet-rlm-python313-v5"
 DEFAULT_VOLUME_NAME = "rlm-volume-dspy"
 PYTHON_VERSION = "3.13.13"
 BASE_IMAGE = "python:3.13.13-slim-bookworm@sha256:f576b530293e74140ea91d262232648d5c4f45640a95ec447757701bfcacf034"
@@ -159,6 +159,18 @@ def snapshot_execution_dependencies() -> tuple[str, ...]:
     return dependencies
 
 
+_IMPORT_NAME_OVERRIDES: dict[str, str] = {"beautifulsoup4": "bs4"}
+
+
+def snapshot_dependency_import_names() -> tuple[tuple[str, str, str], ...]:
+    """Return (distribution, import-module, version) triples baked into the Snapshot."""
+    triples = []
+    for dependency in snapshot_execution_dependencies():
+        package, version = dependency.split("==", 1)
+        triples.append((package, _IMPORT_NAME_OVERRIDES.get(package, package.replace("-", "_")), version))
+    return tuple(triples)
+
+
 def snapshot_dependency_sha256() -> str:
     """Return the stable digest of the canonical Snapshot dependency contract."""
     canonical = "".join(f"{dependency}\n" for dependency in snapshot_execution_dependencies())
@@ -171,6 +183,8 @@ def build_snapshot_image(spec: DaytonaSandboxSpec) -> Any:
     return (
         Image.base(spec.base_image)
         .run_commands(
+            "apt-get update && apt-get install -y --no-install-recommends "
+            "git ca-certificates && rm -rf /var/lib/apt/lists/*",
             "groupadd --gid 1000 daytona",
             "useradd --uid 1000 --gid daytona --create-home --home-dir /home/daytona --shell /bin/bash daytona",
             "chown -R daytona:daytona /home/daytona",

--- a/src/fleet_rlm/daytona/provisioning.py
+++ b/src/fleet_rlm/daytona/provisioning.py
@@ -163,7 +163,11 @@ _IMPORT_NAME_OVERRIDES: dict[str, str] = {"beautifulsoup4": "bs4"}
 
 
 def snapshot_dependency_import_names() -> tuple[tuple[str, str, str], ...]:
-    """Return (distribution, import-module, version) triples baked into the Snapshot."""
+    """Return dependency distributions, import module names, and pinned versions included in the snapshot.
+    
+    Returns:
+    	tuple[tuple[str, str, str], ...]: Triples containing each distribution name, its import module name, and its pinned version.
+    """
     triples = []
     for dependency in snapshot_execution_dependencies():
         package, version = dependency.split("==", 1)
@@ -178,6 +182,15 @@ def snapshot_dependency_sha256() -> str:
 
 
 def build_snapshot_image(spec: DaytonaSandboxSpec) -> Any:
+    """
+    Build the Daytona image used for the configured snapshot execution environment.
+    
+    Parameters:
+    	spec (DaytonaSandboxSpec): Snapshot specification containing the base image.
+    
+    Returns:
+    	Any: Configured Daytona image with required system and Python dependencies, environment variables, working directory, and user.
+    """
     from daytona import Image
 
     return (

--- a/src/fleet_rlm/daytona/snapshot-requirements.txt
+++ b/src/fleet_rlm/daytona/snapshot-requirements.txt
@@ -1,1 +1,4 @@
 mpmath==1.4.1
+numpy==2.5.1
+pandas==3.0.5
+beautifulsoup4==4.15.0

--- a/src/fleet_rlm/daytona/workspace_gateway.py
+++ b/src/fleet_rlm/daytona/workspace_gateway.py
@@ -37,6 +37,10 @@ from fleet_rlm.files.workspace_models import WorkspaceEntry, WorkspaceTextPage
 
 logger = logging.getLogger(__name__)
 
+# Bound provider deletion and cancel it on timeout so no untracked task can
+# outlive the gateway operation or race process-scoped Daytona disposal.
+_SANDBOX_DELETE_GRACE_SECONDS = 15.0
+
 
 def _public_entry(entry: WorkspaceEntry, checksum: str | None = None) -> WorkspaceFileEntry:
     return WorkspaceFileEntry(
@@ -298,7 +302,18 @@ class DaytonaWorkspaceGateway:
             finally:
                 if sandbox is not None:
                     try:
-                        await asyncio.shield(self._platform.delete(sandbox))
+                        await asyncio.wait_for(
+                            self._platform.delete(sandbox),
+                            timeout=_SANDBOX_DELETE_GRACE_SECONDS,
+                        )
+                    except TimeoutError:
+                        logger.warning(
+                            "Workspace I/O Sandbox deletion did not finish within grace period",
+                            extra={
+                                "workspace_id": str(workspace_id),
+                                "grace_seconds": _SANDBOX_DELETE_GRACE_SECONDS,
+                            },
+                        )
                     except Exception as exc:
                         logger.warning(
                             "Workspace I/O Sandbox deletion failed",

--- a/src/fleet_rlm/daytona/workspace_gateway.py
+++ b/src/fleet_rlm/daytona/workspace_gateway.py
@@ -43,6 +43,16 @@ _SANDBOX_DELETE_GRACE_SECONDS = 15.0
 
 
 def _public_entry(entry: WorkspaceEntry, checksum: str | None = None) -> WorkspaceFileEntry:
+    """
+    Convert an internal workspace entry into a public file-entry model.
+    
+    Parameters:
+    	entry (WorkspaceEntry): Internal workspace entry to convert.
+    	checksum (str | None): Optional SHA-256 checksum for the entry.
+    
+    Returns:
+    	WorkspaceFileEntry: Public representation of the workspace entry.
+    """
     return WorkspaceFileEntry(
         path=entry.path,
         kind=entry.kind,

--- a/src/fleet_rlm/persistence/database.py
+++ b/src/fleet_rlm/persistence/database.py
@@ -87,6 +87,11 @@ def normalize_database_url(url: str) -> str:
 # bound so long-lived processes never reuse a server-closed connection.
 _POSTGRES_POOL_PRE_PING = True
 _POSTGRES_POOL_RECYCLE_SECONDS = 1800
+# Lakebase scale-to-zero cold starts routinely take ~10s to connect; bound the
+# connect so a hung endpoint fails fast with a clear error instead of blocking
+# startup (readiness checks, the supervisor preflight, and the daytona
+# composition all build engines through this helper) indefinitely.
+_POSTGRES_CONNECT_TIMEOUT_SECONDS = 30.0
 
 
 def _pool_kwargs_for_url(normalized_url: str) -> dict[str, object]:
@@ -95,6 +100,7 @@ def _pool_kwargs_for_url(normalized_url: str) -> dict[str, object]:
         return {
             "pool_pre_ping": _POSTGRES_POOL_PRE_PING,
             "pool_recycle": _POSTGRES_POOL_RECYCLE_SECONDS,
+            "connect_args": {"timeout": _POSTGRES_CONNECT_TIMEOUT_SECONDS},
         }
     return {}
 

--- a/src/fleet_rlm/persistence/database.py
+++ b/src/fleet_rlm/persistence/database.py
@@ -95,7 +95,15 @@ _POSTGRES_CONNECT_TIMEOUT_SECONDS = 30.0
 
 
 def _pool_kwargs_for_url(normalized_url: str) -> dict[str, object]:
-    """Pool kwargs for a normalized URL; Postgres only, SQLite keeps defaults."""
+    """
+    Return PostgreSQL connection pool settings for a normalized database URL.
+    
+    Parameters:
+    	normalized_url (str): A normalized database connection URL.
+    
+    Returns:
+    	dict[str, object]: PostgreSQL pooling and connection timeout settings, or an empty dictionary for other database URLs.
+    """
     if normalized_url.startswith("postgresql+asyncpg://"):
         return {
             "pool_pre_ping": _POSTGRES_POOL_PRE_PING,

--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -107,6 +107,18 @@ class ReconciliationSummary:
     budget_exhausted: bool = False
 
 
+async def _await_recovery_step(awaitable: Awaitable[Any], *, deadline: float | None) -> Any:
+    """Await one recovery operation without exceeding the shared startup deadline."""
+    if deadline is None:
+        return await awaitable
+    async with asyncio.timeout_at(deadline):
+        return await awaitable
+
+
+def _recovery_deadline_exhausted(deadline: float | None) -> bool:
+    return deadline is not None and asyncio.get_running_loop().time() >= deadline
+
+
 def _decode_failure_status(value: str) -> Literal["failed", "cancelled", "timeout"]:
     if value in {"failed", "cancelled", "timeout"}:
         return value
@@ -819,11 +831,23 @@ class SqlAlchemyTurnStateStore:
                     await fence(pending_run.session_id)
             except Exception:
                 fence_failures += 1
-                await self._restore_after_fence_failure(
-                    pending_run,
-                    recovery_owner,
-                    original_owner=pending_run.claim_owner,
-                )
+                if _recovery_deadline_exhausted(deadline):
+                    skipped += len(pending) - index - 1
+                    budget_exhausted = True
+                    break
+                try:
+                    await _await_recovery_step(
+                        self._restore_after_fence_failure(
+                            pending_run,
+                            recovery_owner,
+                            original_owner=pending_run.claim_owner,
+                        ),
+                        deadline=deadline,
+                    )
+                except TimeoutError:
+                    skipped += len(pending) - index - 1
+                    budget_exhausted = True
+                    break
                 continue
             if await self._complete_recovery(pending_run, recovery_owner):
                 recovered += 1

--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -116,10 +116,29 @@ async def _await_recovery_step(awaitable: Awaitable[Any], *, deadline: float | N
 
 
 def _recovery_deadline_exhausted(deadline: float | None) -> bool:
+    """Determine whether the recovery deadline has been reached.
+    
+    Parameters:
+    	deadline (float | None): Monotonic time at which recovery must stop, or `None` for no deadline.
+    
+    Returns:
+    	`true` if the deadline has been reached, `false` otherwise.
+    """
     return deadline is not None and asyncio.get_running_loop().time() >= deadline
 
 
 def _decode_failure_status(value: str) -> Literal["failed", "cancelled", "timeout"]:
+    """Validate and return a persisted run failure status.
+    
+    Parameters:
+    	value (str): The persisted failure status.
+    
+    Returns:
+    	The validated failure status.
+    
+    Raises:
+    	TurnStateError: If the value is not a supported failure status.
+    """
     if value in {"failed", "cancelled", "timeout"}:
         return value
     raise TurnStateError("persisted Run has an invalid failure status")
@@ -806,11 +825,14 @@ class SqlAlchemyTurnStateStore:
         *,
         deadline: float | None = None,
     ) -> ReconciliationSummary:
-        """Recover stale provider claims left by a prior process.
-
-        Recovery first claims each stale row with a conditional update, then
-        fences provider state outside the database transaction. A failed fence
-        leaves the row non-terminal and eligible for a later retry.
+        """Recover stale provider claims and report reconciliation outcomes.
+        
+        Parameters:
+            fence (Callable[[UUID], Awaitable[None]] | None): Optional callback used to verify provider state before completing recovery.
+            deadline (float | None): Optional monotonic deadline for the recovery operation.
+        
+        Returns:
+            ReconciliationSummary: Counts of candidates, recovered runs, provider fence failures, skipped runs, and whether the deadline was exhausted.
         """
         pending = await self._load_recovery_candidates()
         recovered = 0

--- a/tests/unit/backend/daytona/test_sandbox_spec.py
+++ b/tests/unit/backend/daytona/test_sandbox_spec.py
@@ -13,6 +13,7 @@ from fleet_rlm.daytona.provisioning import (
     DaytonaSandboxSpec,
     build_snapshot_image,
     sandbox_spec_from_settings,
+    snapshot_dependency_import_names,
     snapshot_dependency_sha256,
     snapshot_execution_dependencies,
     verify_sandbox_spec,
@@ -25,7 +26,7 @@ def test_spec_requires_an_immutable_versioned_name() -> None:
             DaytonaSandboxSpec(name)
 
 
-def test_spec_builds_minimal_non_root_pinned_image_with_declared_dependencies() -> None:
+def test_spec_builds_non_root_pinned_image_with_toolchain_and_declared_dependencies() -> None:
     spec = DaytonaSandboxSpec("fleet-rlm-python313-v1")
     dockerfile = build_snapshot_image(spec).dockerfile()
     digest = snapshot_dependency_sha256()
@@ -36,19 +37,35 @@ def test_spec_builds_minimal_non_root_pinned_image_with_declared_dependencies() 
     assert "PYTHONUNBUFFERED=1" in dockerfile
     assert f"FLEET_SNAPSHOT_DEPENDENCIES_SHA256={digest}" in dockerfile
     assert "WORKDIR /home/daytona" in dockerfile
-    assert snapshot_execution_dependencies() == ("mpmath==1.4.1",)
-    assert "pip install mpmath==1.4.1" in dockerfile
-    assert dockerfile.index("pip install mpmath==1.4.1") < dockerfile.index("USER daytona")
+    assert snapshot_execution_dependencies() == (
+        "mpmath==1.4.1",
+        "numpy==2.5.1",
+        "pandas==3.0.5",
+        "beautifulsoup4==4.15.0",
+    )
+    install_line = "pip install beautifulsoup4==4.15.0 mpmath==1.4.1 numpy==2.5.1 pandas==3.0.5"
+    assert install_line in dockerfile
+    assert dockerfile.index(install_line) < dockerfile.index("USER daytona")
+    assert "apt-get install -y --no-install-recommends git ca-certificates" in dockerfile
+    assert dockerfile.index("apt-get install") < dockerfile.index("USER daytona")
     assert "dspy" not in dockerfile.lower()
-    assert "apt-get" not in dockerfile
 
 
-def test_default_snapshot_envelope_stays_minimal_and_fixed() -> None:
+def test_default_snapshot_envelope_stays_fixed() -> None:
     spec = DaytonaSandboxSpec(DEFAULT_SNAPSHOT_NAME)
 
-    assert spec.snapshot == "fleet-rlm-python313-v4"
+    assert spec.snapshot == "fleet-rlm-python313-v5"
     assert spec.python_version == PYTHON_VERSION == "3.13.13"
     assert (spec.cpu, spec.memory_gib, spec.disk_gib) == (2, 4, 8)
+
+
+def test_dependency_import_names_map_distribution_to_module() -> None:
+    assert snapshot_dependency_import_names() == (
+        ("mpmath", "mpmath", "1.4.1"),
+        ("numpy", "numpy", "2.5.1"),
+        ("pandas", "pandas", "3.0.5"),
+        ("beautifulsoup4", "bs4", "4.15.0"),
+    )
 
 
 def test_settings_require_snapshot_only_when_converted_to_daytona_spec() -> None:

--- a/tests/unit/backend/daytona/test_workspace_gateway.py
+++ b/tests/unit/backend/daytona/test_workspace_gateway.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from contextlib import redirect_stdout, suppress
 from io import StringIO
@@ -119,6 +120,33 @@ async def test_mounted_gateway_creates_and_deletes_exactly_one_ephemeral_sandbox
         }
     ]
     assert platform.deleted == ["sandbox-1"]
+
+
+@pytest.mark.asyncio
+async def test_mounted_gateway_cancels_delete_that_exceeds_grace_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import fleet_rlm.daytona.workspace_gateway as workspace_gateway
+
+    platform = _Platform()
+    delete_started = asyncio.Event()
+    delete_cancelled = asyncio.Event()
+
+    async def slow_delete(_sandbox: object) -> None:
+        delete_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            delete_cancelled.set()
+
+    monkeypatch.setattr(platform, "delete", slow_delete)
+    monkeypatch.setattr(workspace_gateway, "_SANDBOX_DELETE_GRACE_SECONDS", 0.01)
+
+    async with _core(platform).open_sandbox(uuid4(), purpose="workspace-files-read"):
+        pass
+
+    assert delete_started.is_set()
+    assert delete_cancelled.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/backend/test_cli_supervisor.py
+++ b/tests/unit/backend/test_cli_supervisor.py
@@ -825,13 +825,13 @@ def test_supervisor_uses_longer_daytona_readiness_timeout(
     )
     backend = _Process(pid=9)
     monkeypatch.setattr(supervisor.subprocess, "Popen", lambda *_args, **_kwargs: backend)
-    # deadline = 100 + 90; second monotonic sample exceeds it without a ready probe.
-    clock = iter((100.0, 191.0))
+    # deadline = 100 + 150; second monotonic sample exceeds it without a ready probe.
+    clock = iter((100.0, 251.0))
     monkeypatch.setattr(supervisor.time, "monotonic", lambda: next(clock))
     monkeypatch.setattr(supervisor.os, "killpg", lambda *_args: None)
     monkeypatch.setattr(supervisor, "_validate_daytona_database", lambda *_args, **_kwargs: None)
 
-    with pytest.raises(supervisor.SupervisorError, match="not ready within 90s") as error:
+    with pytest.raises(supervisor.SupervisorError, match="not ready within 150s") as error:
         supervisor.supervise(
             host="127.0.0.1",
             port=8126,

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -24,13 +24,13 @@ def test_daytona_profile_uses_specialized_bounded_model_roles() -> None:
         "daytona-bench",
         "daytona-bench-40",
     }
-    assert document["defaults"]["daytona"]["snapshot"] == "fleet-rlm-python313-v4"
+    assert document["defaults"]["daytona"]["snapshot"] == "fleet-rlm-python313-v5"
     llm = document["profiles"]["daytona"]["llm"]
     assert llm["root"] == {
         "model": "deepseek-v4-flash",
         "api_key_env": "FLEET_OPENCODE_GO_API_KEY",
         "base_url_env": "FLEET_OPENCODE_GO_BASE_URL",
-        "max_tokens": 8000,
+        "max_tokens": 16000,
         # Cache hits emit zero streamify deltas and read as a frozen stream.
         "cache": False,
         "reasoning_effort": "low",
@@ -39,7 +39,7 @@ def test_daytona_profile_uses_specialized_bounded_model_roles() -> None:
         "model": "deepseek-v4-flash",
         "api_key_env": "FLEET_OPENCODE_GO_API_KEY",
         "base_url_env": "FLEET_OPENCODE_GO_BASE_URL",
-        "max_tokens": 8000,
+        "max_tokens": 16000,
         "temperature": 0,
         "cache": False,
         "reasoning_effort": "low",
@@ -211,7 +211,7 @@ def test_daytona_profile_resolves_deepseek_root_and_sub_with_gateway_params(
     # deltas and read as a frozen stream.
     assert settings.root_llm_cache is False
     assert settings.sub_llm_cache is False
-    assert settings.root_llm_max_tokens == settings.sub_llm_max_tokens == 8000
+    assert settings.root_llm_max_tokens == settings.sub_llm_max_tokens == 16000
     assert settings.mlflow_tracing_enabled is True
     assert settings.mlflow_tracking_uri == "http://127.0.0.1:5001"
 
@@ -320,7 +320,7 @@ def test_daytona_benchmark_profiles_resolve_without_mlflow(
     assert settings.sub_model == settings.root_model
     assert settings.root_llm_model_provider_service == "uscentral.default.zencode-oai"
     assert settings.sub_llm_model_provider_service == "uscentral.default.zencode-oai"
-    assert settings.daytona_snapshot == "fleet-rlm-python313-v4"
+    assert settings.daytona_snapshot == "fleet-rlm-python313-v5"
     assert settings.root_llm_cache is False
     assert settings.sub_llm_cache is False
     assert settings.rlm_max_iterations == iterations

--- a/tests/unit/backend/test_engine_pool_policy.py
+++ b/tests/unit/backend/test_engine_pool_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fleet_rlm.persistence.database import (
+    _POSTGRES_CONNECT_TIMEOUT_SECONDS,
     _POSTGRES_POOL_PRE_PING,
     _POSTGRES_POOL_RECYCLE_SECONDS,
     _pool_kwargs_for_url,
@@ -8,11 +9,12 @@ from fleet_rlm.persistence.database import (
 )
 
 
-def test_pool_kwargs_postgres_enables_pre_ping_and_recycle() -> None:
+def test_pool_kwargs_postgres_enables_pre_ping_recycle_and_connect_timeout() -> None:
     kwargs = _pool_kwargs_for_url("postgresql+asyncpg://u:p@h/db")
     assert kwargs == {
         "pool_pre_ping": _POSTGRES_POOL_PRE_PING,
         "pool_recycle": _POSTGRES_POOL_RECYCLE_SECONDS,
+        "connect_args": {"timeout": _POSTGRES_CONNECT_TIMEOUT_SECONDS},
     }
 
 

--- a/tests/unit/backend/test_live_composition.py
+++ b/tests/unit/backend/test_live_composition.py
@@ -620,6 +620,7 @@ def test_offline_lifespan_disposes_engine_when_table_creation_fails(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_live_startup_preserves_original_error_and_attempts_all_cleanup(monkeypatch) -> None:
+    """Preserve the original startup failure while completing all available cleanup."""
     import fleet_rlm.composition.daytona as composition
 
     disposed: list[str] = []

--- a/tests/unit/backend/test_live_composition.py
+++ b/tests/unit/backend/test_live_composition.py
@@ -623,6 +623,16 @@ async def test_live_startup_preserves_original_error_and_attempts_all_cleanup(mo
     import fleet_rlm.composition.daytona as composition
 
     disposed: list[str] = []
+    orphan_cleanup_cancelled = asyncio.Event()
+
+    async def run_orphan_cleanup() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            orphan_cleanup_cancelled.set()
+
+    orphan_cleanup_task = asyncio.create_task(run_orphan_cleanup())
+    await asyncio.sleep(0)
 
     class Resources:
         session_manager = object()
@@ -630,6 +640,7 @@ async def test_live_startup_preserves_original_error_and_attempts_all_cleanup(mo
         engine = object()
 
         async def adispose(self) -> None:
+            assert orphan_cleanup_cancelled.is_set()
             disposed.append("resources")
 
     class Gateway:
@@ -645,6 +656,7 @@ async def test_live_startup_preserves_original_error_and_attempts_all_cleanup(mo
         attachment_lifecycle=object(),
         artifact_reader=object(),
         workspace_volume_gateway=Gateway(),
+        orphan_cleanup_task=orphan_cleanup_task,
     )
 
     async def fake_build(_settings, *, skill_catalog):
@@ -663,3 +675,4 @@ async def test_live_startup_preserves_original_error_and_attempts_all_cleanup(mo
         )
 
     assert disposed == ["resources", "gateway"]
+    assert orphan_cleanup_task.cancelled()

--- a/tests/unit/backend/test_orphan_cleanup.py
+++ b/tests/unit/backend/test_orphan_cleanup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -8,7 +9,7 @@ from uuid import uuid4
 import pytest
 
 from fleet_rlm.artifacts.models import CompletedRun
-from fleet_rlm.daytona.workspace_gateway import cleanup_orphan_bytes
+from fleet_rlm.daytona.workspace_gateway import OrphanCleanupReport, cleanup_orphan_bytes
 from fleet_rlm.files.host_volume import HostVolumeMirror, OfflineHostVolumeGateway
 from fleet_rlm.files.volume_paths import VolumePaths
 
@@ -172,3 +173,95 @@ def test_host_volume_listing_is_rooted_bounded_and_returns_file_mtimes(tmp_path:
     assert len(listed) == 1
     assert listed[0].path == blob
     assert listed[0].modified_at > 0
+
+
+class _FakeArtifactCatalog:
+    """Records the workspace-id scoped enumerations the sweep reads."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    async def list_storage_refs(self, *, workspace_id: object) -> list[str]:
+        self.calls.append(("storage", workspace_id))
+        return ["ref-1"]
+
+    async def list_completed_runs(self, *, workspace_id: object) -> list[CompletedRun]:
+        self.calls.append(("completed", workspace_id))
+        return []
+
+    async def list_active_runs(self, *, workspace_id: object) -> list[CompletedRun]:
+        self.calls.append(("active", workspace_id))
+        return []
+
+
+@pytest.mark.asyncio
+async def test_run_deferred_orphan_cleanup_enumerates_and_reports(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fleet_rlm.composition.daytona import run_deferred_orphan_cleanup
+
+    workspace_id = uuid4()
+    catalog = _FakeArtifactCatalog()
+
+    async def fake_cleanup(
+        gateway: object,
+        *,
+        workspace_id: object,
+        paths: object,  # noqa: ARG001 - fake mirrors the real cleanup_orphan_bytes signature
+        committed_storage_refs: object,
+        completed_runs: object,  # noqa: ARG001 - fake mirrors the real cleanup_orphan_bytes signature
+        active_runs: object,  # noqa: ARG001 - fake mirrors the real cleanup_orphan_bytes signature
+        grace_period: object,  # noqa: ARG001 - fake mirrors the real cleanup_orphan_bytes signature
+    ) -> OrphanCleanupReport:
+        assert committed_storage_refs == ["ref-1"]
+        assert gateway == "gateway"
+        assert workspace_id == workspace_id
+        return OrphanCleanupReport(scanned=3, removed=1, retained=1, skipped_fresh=1)
+
+    monkeypatch.setattr("fleet_rlm.daytona.workspace_gateway.cleanup_orphan_bytes", fake_cleanup)
+
+    await run_deferred_orphan_cleanup(
+        "gateway",
+        workspace_id=workspace_id,
+        paths=object(),
+        artifact_catalog=catalog,
+    )
+
+    assert [name for name, _ in catalog.calls] == ["storage", "completed", "active"]
+
+
+@pytest.mark.asyncio
+async def test_run_deferred_orphan_cleanup_swallows_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fleet_rlm.composition import daytona as composition_module
+    from fleet_rlm.composition.daytona import run_deferred_orphan_cleanup
+
+    monkeypatch.setattr(composition_module, "_ORPHAN_CLEANUP_TIMEOUT_SECONDS", 0.05)
+
+    async def hang(_gateway: object, **_kwargs: object) -> OrphanCleanupReport:
+        await asyncio.sleep(1.0)
+        raise AssertionError("cleanup timeout should have interrupted the sweep")
+
+    monkeypatch.setattr("fleet_rlm.daytona.workspace_gateway.cleanup_orphan_bytes", hang)
+
+    # Must return (not raise) when the sweep exceeds its budget.
+    await run_deferred_orphan_cleanup(
+        "gateway",
+        workspace_id=uuid4(),
+        paths=object(),
+        artifact_catalog=_FakeArtifactCatalog(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_deferred_orphan_cleanup_swallows_provider_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fleet_rlm.composition.daytona import run_deferred_orphan_cleanup
+
+    async def boom(_gateway: object, **_kwargs: object) -> OrphanCleanupReport:
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr("fleet_rlm.daytona.workspace_gateway.cleanup_orphan_bytes", boom)
+
+    await run_deferred_orphan_cleanup(
+        "gateway",
+        workspace_id=uuid4(),
+        paths=object(),
+        artifact_catalog=_FakeArtifactCatalog(),
+    )

--- a/tests/unit/backend/test_orphan_cleanup.py
+++ b/tests/unit/backend/test_orphan_cleanup.py
@@ -182,14 +182,40 @@ class _FakeArtifactCatalog:
         self.calls: list[tuple[str, object]] = []
 
     async def list_storage_refs(self, *, workspace_id: object) -> list[str]:
+        """
+        Enumerate storage references for a workspace.
+        
+        Parameters:
+            workspace_id (object): Identifier of the workspace.
+        
+        Returns:
+            list[str]: Storage references associated with the workspace.
+        """
         self.calls.append(("storage", workspace_id))
         return ["ref-1"]
 
     async def list_completed_runs(self, *, workspace_id: object) -> list[CompletedRun]:
+        """
+        List completed runs for a workspace.
+        
+        Parameters:
+        	workspace_id (object): Identifier of the workspace.
+        
+        Returns:
+        	list[CompletedRun]: The workspace's completed runs.
+        """
         self.calls.append(("completed", workspace_id))
         return []
 
     async def list_active_runs(self, *, workspace_id: object) -> list[CompletedRun]:
+        """List active runs for a workspace.
+        
+        Parameters:
+        	workspace_id (object): Identifier of the workspace.
+        
+        Returns:
+        	list[CompletedRun]: Active runs associated with the workspace.
+        """
         self.calls.append(("active", workspace_id))
         return []
 

--- a/tests/unit/backend/test_sandbox_lifecycle.py
+++ b/tests/unit/backend/test_sandbox_lifecycle.py
@@ -114,6 +114,20 @@ async def test_live_platform_get_none_only_on_not_found() -> None:
 
 
 @pytest.mark.asyncio
+async def test_live_platform_stop_treats_missing_sandbox_as_already_stopped() -> None:
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=DaytonaNotFoundError())
+    client.stop = AsyncMock()
+    client.delete = AsyncMock()
+    platform = LiveDaytonaPlatform(client, _SPEC)
+
+    await platform.stop("sb-missing", force=True)
+
+    client.stop.assert_not_awaited()
+    client.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_live_platform_get_raises_on_auth_error() -> None:
     client = MagicMock()
     client.get = AsyncMock(side_effect=_AuthError())

--- a/tests/unit/backend/test_sql_turn_state.py
+++ b/tests/unit/backend/test_sql_turn_state.py
@@ -411,6 +411,9 @@ async def test_reconcile_deadline_recovers_one_run_and_leaves_later_claim_retrya
         # in-loop deadline check, and the fence span must exceed that margin so
         # the deadline is only crossed after run 0's fence completes.
         async def fence(session_id):
+            """
+            Record a fenced session and delay completion.
+            """
             fenced.append(session_id)
             await asyncio.sleep(1.0)
 
@@ -539,6 +542,12 @@ async def test_reconcile_deadline_does_not_restore_after_fence_consumes_budget(
     restore_calls: list[object] = []
 
     async def load_candidates() -> list[object]:
+        """
+        Load the pending run as a reconciliation candidate.
+        
+        Returns:
+            list[object]: A list containing the pending run.
+        """
         return [pending_run]
 
     async def claim_owner(_pending_run: object) -> str:
@@ -586,6 +595,12 @@ async def test_reconcile_deadline_bounds_fence_failure_restore(
     store = SqlAlchemyTurnStateStore(lambda: None)  # type: ignore[arg-type]
 
     async def load_candidates() -> list[object]:
+        """
+        Load the pending run as a reconciliation candidate.
+        
+        Returns:
+            list[object]: A list containing the pending run.
+        """
         return [pending_run]
 
     async def claim_owner(_pending_run: object) -> str:

--- a/tests/unit/backend/test_sql_turn_state.py
+++ b/tests/unit/backend/test_sql_turn_state.py
@@ -406,13 +406,17 @@ async def test_reconcile_deadline_recovers_one_run_and_leaves_later_claim_retrya
 
         fenced: list[object] = []
 
+        # The deadline margin must comfortably exceed the latency of
+        # _load_recovery_candidates (a real DB query) that runs before the first
+        # in-loop deadline check, and the fence span must exceed that margin so
+        # the deadline is only crossed after run 0's fence completes.
         async def fence(session_id):
             fenced.append(session_id)
-            await asyncio.sleep(0.02)
+            await asyncio.sleep(1.0)
 
         summary = await store.reconcile_settling(
             fence,
-            deadline=asyncio.get_running_loop().time() + 0.01,
+            deadline=asyncio.get_running_loop().time() + 0.5,
         )
 
         assert summary.candidates == 2
@@ -516,6 +520,103 @@ async def test_reconcile_retries_failed_settling_fence_without_losing_intent() -
             assert row.recovery_metadata_json is None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_deadline_does_not_restore_after_fence_consumes_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from fleet_rlm.persistence.repositories.turns import SqlAlchemyTurnStateStore
+
+    pending_run = SimpleNamespace(
+        session_id=uuid4(),
+        claim_owner="original-owner",
+        status="running",
+    )
+    store = SqlAlchemyTurnStateStore(lambda: None)  # type: ignore[arg-type]
+    restore_calls: list[object] = []
+
+    async def load_candidates() -> list[object]:
+        return [pending_run]
+
+    async def claim_owner(_pending_run: object) -> str:
+        return "recovery-owner"
+
+    async def fence(_session_id: object) -> None:
+        # Sleep longer than the deadline margin so the budget is exhausted by
+        # the time the fence fails, and the restore step is skipped.
+        await asyncio.sleep(1.0)
+        raise TimeoutError("provider fence deadline")
+
+    async def restore(*_args: object, **_kwargs: object) -> None:
+        restore_calls.append(True)
+
+    monkeypatch.setattr(store, "_load_recovery_candidates", load_candidates)
+    monkeypatch.setattr(store, "_claim_recovery_owner", claim_owner)
+    monkeypatch.setattr(store, "_restore_after_fence_failure", restore)
+
+    summary = await store.reconcile_settling(
+        fence,
+        deadline=asyncio.get_running_loop().time() + 0.5,
+    )
+
+    assert summary.candidates == 1
+    assert summary.recovered == 0
+    assert summary.fence_failures == 1
+    assert summary.skipped == 0
+    assert summary.budget_exhausted is True
+    assert restore_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_deadline_bounds_fence_failure_restore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from fleet_rlm.persistence.repositories.turns import SqlAlchemyTurnStateStore
+
+    pending_run = SimpleNamespace(
+        session_id=uuid4(),
+        claim_owner="original-owner",
+        status="running",
+    )
+    store = SqlAlchemyTurnStateStore(lambda: None)  # type: ignore[arg-type]
+
+    async def load_candidates() -> list[object]:
+        return [pending_run]
+
+    async def claim_owner(_pending_run: object) -> str:
+        return "recovery-owner"
+
+    async def fence(_session_id: object) -> None:
+        raise RuntimeError("provider fence failed")
+
+    async def restore(*_args: object, **_kwargs: object) -> None:
+        await asyncio.sleep(60)
+
+    monkeypatch.setattr(store, "_load_recovery_candidates", load_candidates)
+    monkeypatch.setattr(store, "_claim_recovery_owner", claim_owner)
+    monkeypatch.setattr(store, "_restore_after_fence_failure", restore)
+
+    # The deadline margin must exceed the load_candidates latency so the first
+    # in-loop check passes, while the outer wait_for must exceed the margin so
+    # the bounded restore (sleep 60) has room to time out at the deadline.
+    summary = await asyncio.wait_for(
+        store.reconcile_settling(
+            fence,
+            deadline=asyncio.get_running_loop().time() + 0.2,
+        ),
+        timeout=1.0,
+    )
+
+    assert summary.candidates == 1
+    assert summary.recovered == 0
+    assert summary.fence_failures == 1
+    assert summary.skipped == 0
+    assert summary.budget_exhausted is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- move orphan-byte cleanup off the readiness-critical path while retaining task ownership through startup failure and shutdown
- bound database connection, stale-claim recovery, and workspace sandbox cleanup behavior
- upgrade the immutable Daytona snapshot contract to v5 with git, CA certificates, and common analysis dependencies
- raise the Daytona root/sub model output limits and make TUI checks resolve the pinned pnpm version

## Root cause

Cold Lakebase and Daytona operations could consume or exceed the launcher readiness budget. The first deferred-cleanup implementation also left cancellation gaps: a failed inventory installation could dispose resources while its cleanup task was still running, and shielded sandbox deletion could continue untracked after timeout.

## Impact

Startup recovery remains bounded and observable, deferred cleanup is settled before provider disposal, missing sandboxes are treated idempotently during stop, and the v5 snapshot includes the tools used by generated analysis code.

## Validation

- `make check` (83.4% backend coverage; 192 TUI tests)
- `make check-security`
- `make build-release`
- `make check-release`
- `git diff --check`