### PR TITLE
fix: resolve remaining code-quality scanner findings

### DIFF
--- a/scripts/generate_profile_matrix.py
+++ b/scripts/generate_profile_matrix.py
@@ -40,10 +40,10 @@ def render() -> str:
         f"The active default is `{active}`.",
         "",
         "Provider environment names are the only values required by the credentialed live verifier. "
-        "Managed-policy names are additionally required when `daytona-managed` is selected.",
+        + "Managed-policy names are additionally required when `daytona-managed` is selected.",
         "",
         "| Profile | Default | Provider | Root/Sub model | Root/Sub max tokens | Recursion | MLflow | "
-        "Provider environment names | Managed-policy environment names |",
+        + "Provider environment names | Managed-policy environment names |",
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for contract in load_profile_environment_contracts():
@@ -59,8 +59,8 @@ def render() -> str:
         [
             "",
             "The verifier uses the selected row's provider environment names and never checks a hard-coded provider "
-            "credential. `FLEET_DATABASE_URL` is replaced by a temporary SQLite URL in the live proof; it is a "
-            "required selected-policy value only for the managed profile.",
+            + "credential. `FLEET_DATABASE_URL` is replaced by a temporary SQLite URL in the live proof; it is a "
+            + "required selected-policy value only for the managed profile.",
             "",
         ]
     )

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -463,7 +463,6 @@ class RLMRunner:
         observations = _ObservationBuffer(EventRecorder(context.identity.run_id, context.identity.session_id))
         async for event in self._initial_events(context, observations):
             yield event
-        spec = context.capabilities.spec
         spec, relay, guards, task, recursive_executor = self._start_worker(context)
         ownership.task = task
         if recursive_executor is not None:

--- a/tests/contracts/backend/test_stream_contract_parity.py
+++ b/tests/contracts/backend/test_stream_contract_parity.py
@@ -9,11 +9,7 @@ from fleet_rlm.composition.testing import create_testing_app
 from fleet_rlm.sessions.assistant_parts import AssistantPartModelUnion
 from fleet_rlm.sessions.committed_turn import CommittedTurn
 
-_ASSISTANT_TYPES = {
-    model.model_fields["type"].default
-    for model in AssistantPartModelUnion
-    for default in (model.model_fields["type"].default,)
-}
+_ASSISTANT_TYPES = {model.model_fields["type"].default for model in AssistantPartModelUnion}
 _TRANSPORT_SEMANTICS = set(FLEET_UI_CHUNK_TYPES)
 
 


### PR DESCRIPTION
Fixes the last three code-quality scanner findings raised on #432, which merged before they could land on that branch.

In `RLMRunner._run_success`, the `spec` local was assigned and immediately overwritten by the worker startup tuple; the dead assignment is gone:

```py
spec, relay, guards, task, recursive_executor = self._start_worker(context)
```

The stream-parity contract test's assistant-type set comprehension carried a redundant inner `for default in (...)` clause and now reads `{model.model_fields["type"].default for model in AssistantPartModelUnion}`, and `scripts/generate_profile_matrix.py` joins its multi-line row strings with explicit `+` so the implicit-concatenation alerts clear. Rendered matrix output is byte-identical, so the generated doc stays in sync.