### PR TITLE
fix(rlm): Tighten runtime protocol seams

### DIFF
--- a/src/fleet_rlm/chat/capability_preparation.py
+++ b/src/fleet_rlm/chat/capability_preparation.py
@@ -62,6 +62,7 @@ class PreparedHostCapabilities:
         self._artifact_candidates = artifact_candidates
         self._memory_candidates = memory_candidates
         self.preparation_notices = preparation_notices
+        self.workspace_memory_digest = ""
 
     def drain_public_details(self) -> tuple[AttachmentRead | SkillActivated | SkillLoaded, ...]:
         values: list[AttachmentRead | SkillActivated | SkillLoaded] = []

--- a/src/fleet_rlm/chat/run_preparation.py
+++ b/src/fleet_rlm/chat/run_preparation.py
@@ -100,9 +100,8 @@ class PreparedRun:
         await self._resources.aclose()
 
 
-def _workspace_memory_digest(capabilities: PreparedCapabilities) -> str:
-    """Bounded defensive projection of the capability digest; never fails a Run."""
-    digest = getattr(capabilities, "workspace_memory_digest", "")
+def _bounded_workspace_memory_digest(digest: str) -> str:
+    """Clamp a Protocol digest to the injection tail; never fails a Run."""
     if not isinstance(digest, str) or len(digest.encode("utf-8")) > WORKSPACE_MEMORY_INJECTION_TAIL_BYTES:
         return ""
     return digest
@@ -244,7 +243,7 @@ class DefaultRunPreparer:
                     raise RunPreparationTimeoutError("Turn preparation timed out") from None
                 except (DatabaseConnectionError, OSError, SQLAlchemyError) as exc:
                     raise RunPreparationUnavailableError("Turn capabilities are unavailable") from exc
-                capabilities_phase.set_outputs({"notice_count": len(getattr(capabilities, "preparation_notices", ()))})
+                capabilities_phase.set_outputs({"notice_count": len(capabilities.preparation_notices)})
             try:
                 if await run.cancellation_requested():
                     raise RunPreparationCancelledError("Turn cancelled")
@@ -305,8 +304,8 @@ class DefaultRunPreparer:
                     for ref in staged.refs
                 ),
                 attachment_context=attachment_context,
-                preparation_notices=tuple(getattr(capabilities, "preparation_notices", ())),
-                workspace_memory_digest=_workspace_memory_digest(capabilities),
+                preparation_notices=tuple(capabilities.preparation_notices),
+                workspace_memory_digest=_bounded_workspace_memory_digest(capabilities.workspace_memory_digest),
             ),
             execution=ExecutionRuntime(
                 models=self._models,

--- a/src/fleet_rlm/composition/testing.py
+++ b/src/fleet_rlm/composition/testing.py
@@ -38,6 +38,7 @@ from fleet_rlm.files.lifecycle import AttachmentLifecycle
 from fleet_rlm.files.models import PreparedAttachments
 from fleet_rlm.files.workspace_models import UNAVAILABLE_WORKSPACE_CAPABILITY
 from fleet_rlm.rlm.dspy_contract import RLMOptions
+from fleet_rlm.rlm.inputs import AttachmentContextCapsule
 from fleet_rlm.rlm.model_bundle import RLMModelBundle
 from fleet_rlm.rlm.recursive_calls import RecursiveRLMOptions
 from fleet_rlm.rlm.signature import FleetRLMSignature
@@ -66,6 +67,9 @@ class TestingInterpreter:
 
     def shutdown(self) -> None:
         return None
+
+    def bind_context_capsule(self, capsule: AttachmentContextCapsule) -> None:
+        del capsule
 
     def drain_context_accesses(self) -> tuple[str, ...]:
         return ()

--- a/src/fleet_rlm/daytona/diagnostics.py
+++ b/src/fleet_rlm/daytona/diagnostics.py
@@ -208,7 +208,7 @@ class _ProductionDaytonaDoctorDependencies:
         await probe_configured_root_lm(
             settings,
             interpreter_factory=_provider_probe_interpreter,
-            child_runtime_factory=_provider_probe_child_runtime,
+            child_runtime_factory=_ProviderProbeChildRuntimeFactory(),
         )
 
 
@@ -230,6 +230,19 @@ def _provider_probe_child_runtime(call_index: int) -> Any:
         volume_subpath=f"recursive/provider-probe/run/{call_index}",
         _close=interpreter.shutdown,
     )
+
+
+class _ProviderProbeChildRuntimeFactory:
+    """In-process probe factory with no late-acquisition ownership."""
+
+    def __call__(self, call_index: int) -> Any:
+        return _provider_probe_child_runtime(call_index)
+
+    def wait_owned(self) -> None:
+        return None
+
+    def raise_if_cleanup_failed(self) -> None:
+        return None
 
 
 _SUCCESS_MESSAGES: dict[DoctorStepName, str] = {

--- a/src/fleet_rlm/rlm/child_runtime.py
+++ b/src/fleet_rlm/rlm/child_runtime.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
@@ -34,7 +33,25 @@ class ChildRuntimeLease(Protocol):
         ...
 
 
-ChildRuntimeFactory = Callable[[int], ChildRuntimeLease]
+class ChildRuntimeFactory(Protocol):
+    """Acquire child leases and own late acquisitions that never produced a lease.
+
+    ``wait_owned`` and ``raise_if_cleanup_failed`` sit on the factory, not the
+    lease: a timed-out Daytona acquisition may still complete with a Sandbox
+    that must be closed even though no ``ChildRuntimeLease`` was returned.
+    """
+
+    def __call__(self, call_index: int) -> ChildRuntimeLease:
+        """Return a dedicated child runtime lease for ``call_index``."""
+        ...
+
+    def wait_owned(self) -> None:
+        """Block until late factory-owned acquisitions have closed."""
+        ...
+
+    def raise_if_cleanup_failed(self) -> None:
+        """Raise when factory-owned late cleanup failed or is still pending."""
+        ...
 
 
 __all__ = [

--- a/src/fleet_rlm/rlm/context.py
+++ b/src/fleet_rlm/rlm/context.py
@@ -40,7 +40,16 @@ class PreparationNotice:
 
 
 class RLMInterpreter(CodeInterpreter, Protocol):
-    """Narrow interpreter surface consumed by DSPy's RLM adapter."""
+    """Fleet interpreter surface used before ``dspy.RLM.acall``.
+
+    DSPy ``CodeInterpreter`` remains ``tools`` / ``start`` / ``execute`` /
+    ``shutdown``. ``bind_context_capsule`` and ``drain_context_accesses`` are
+    Fleet pre-``acall`` hooks; DSPy never calls them.
+    """
+
+    def bind_context_capsule(self, capsule: AttachmentContextCapsule) -> None:
+        """Bind one host-created Volume context capsule before the RLM starts."""
+        ...
 
     def drain_context_accesses(self) -> tuple[str, ...]: ...
 
@@ -61,6 +70,11 @@ class PreparedCapabilities(Protocol):
     def drain_memory_candidates(self) -> tuple[MemoryCandidate, ...]: ...
 
     def record_attachment_accesses(self, attachment_ids: tuple[str, ...]) -> None: ...
+
+    @property
+    def workspace_memory_digest(self) -> str:
+        """Bounded Workspace Memory tail for Signature injection; empty when absent."""
+        ...
 
     async def aclose(self) -> None: ...
 

--- a/src/fleet_rlm/rlm/recursive_calls.py
+++ b/src/fleet_rlm/rlm/recursive_calls.py
@@ -319,9 +319,9 @@ class RecursiveRLMExecutor:
             raise ChildRuntimeCleanupError("recursive child cleanup failed") from fatal_cleanup_error
         if cleanup_pending:
             raise ChildRuntimeCleanupError("recursive child cleanup is still pending")
-        factory_check = getattr(self._child_runtime_factory, "raise_if_cleanup_failed", None)
-        if callable(factory_check):
-            factory_check()
+        factory = self._child_runtime_factory
+        if factory is not None:
+            factory.raise_if_cleanup_failed()
 
     def wait_owned(self) -> None:
         """Wait for every detached child worker retained after batch settlement.
@@ -348,11 +348,11 @@ class RecursiveRLMExecutor:
             raise ChildRuntimeCleanupError("recursive child cleanup failed") from self._state.fatal_cleanup_error
 
         # A Daytona factory adopts timed-out provider acquisitions so a late
-        # Sandbox/permit cannot be orphaned.  Keep that ownership under the
-        # same cleanup boundary when the optional hook is available.
-        factory_wait_owned = getattr(self._child_runtime_factory, "wait_owned", None)
-        if callable(factory_wait_owned):
-            factory_wait_owned()
+        # Sandbox/permit cannot be orphaned. Keep that ownership under the
+        # same cleanup boundary as retained child workers.
+        factory = self._child_runtime_factory
+        if factory is not None:
+            factory.wait_owned()
 
     def _retain_pending_batch_futures(self, futures: set[Future[str]]) -> None:
         pending = [future for future in futures if not future.done()]

--- a/src/fleet_rlm/rlm/routing_eval.py
+++ b/src/fleet_rlm/rlm/routing_eval.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, cast
 
 import dspy
 
+from fleet_rlm.rlm.child_runtime import ChildRuntimeFactory
 from fleet_rlm.rlm.dspy_contract import RLMOptions, _RLMTraceCallback, build_native_rlm
 from fleet_rlm.rlm.events import ObservationDetail, ToolCompleted, ToolFailed, ToolStarted
 from fleet_rlm.rlm.model_bundle import RLMModelBundle
@@ -312,6 +313,24 @@ class _RoutingScenarioSignature(dspy.Signature):
     answer: str = dspy.OutputField()
 
 
+class _TrackingChildRuntimeFactory:
+    """Count child acquisitions while forwarding factory-owned cleanup."""
+
+    def __init__(self, inner: ChildRuntimeFactory) -> None:
+        self._inner = inner
+        self.created = 0
+
+    def __call__(self, call_index: int) -> Any:
+        self.created += 1
+        return self._inner(call_index)
+
+    def wait_owned(self) -> None:
+        self._inner.wait_owned()
+
+    def raise_if_cleanup_failed(self) -> None:
+        self._inner.raise_if_cleanup_failed()
+
+
 async def _maybe_await(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await value
@@ -324,7 +343,7 @@ async def run_routing_scenario(
     root_lm: Any,
     sub_lm: Any,
     root_interpreter_factory: Callable[[], Any] | Callable[[], Awaitable[Any]],
-    child_runtime_factory: Callable[[int], Any],
+    child_runtime_factory: ChildRuntimeFactory,
     recursion_enabled: bool = True,
     repeats: int = 1,
     deadline_seconds: float = 120.0,
@@ -344,13 +363,7 @@ async def run_routing_scenario(
         captured = []
         started = time.perf_counter()
         deadline = time.monotonic() + deadline_seconds
-        created_children = 0
-
-        def tracked_child_factory(call_index: int) -> Any:
-            nonlocal created_children
-            created_children += 1
-            return child_runtime_factory(call_index)
-
+        tracked_child_factory = _TrackingChildRuntimeFactory(child_runtime_factory)
         recursive = RecursiveRLMExecutor(
             models=RLMModelBundle(root_lm=root_lm, sub_lm=sub_lm),
             options=RecursiveRLMOptions(enabled=recursion_enabled),
@@ -399,7 +412,7 @@ async def run_routing_scenario(
             child_iterations=summary.child_iterations,
             recursive_prompt_chars=summary.maximum_prompt_chars,
             latency_ms=details_facts.latency_ms,
-            sandbox_count=created_children,
+            sandbox_count=tracked_child_factory.created,
             recursive_batch_calls=summary.recursive_batch_calls,
             peak_child_concurrency=summary.peak_child_concurrency,
         )

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -634,9 +634,10 @@ class RLMRunner:
         """Bind the prepared Volume context to the interpreter before the RLM starts."""
         if context.session.attachment_context is None:
             return
-        bind = getattr(context.execution.interpreter, "bind_context_capsule", None)
-        if callable(bind):
-            bind(context.session.attachment_context)
+        interpreter = context.execution.interpreter
+        if interpreter is None:
+            return
+        interpreter.bind_context_capsule(context.session.attachment_context)
 
     @staticmethod
     def _bind_observer(
@@ -683,10 +684,10 @@ class RLMRunner:
 
     @staticmethod
     def _record_attachment_accesses(context: RLMExecutionContext) -> None:
-        drain_accesses = getattr(context.execution.interpreter, "drain_context_accesses", None)
-        record_accesses = getattr(context.capabilities, "record_attachment_accesses", None)
-        if callable(drain_accesses) and callable(record_accesses):
-            record_accesses(tuple(drain_accesses()))
+        interpreter = context.execution.interpreter
+        if interpreter is None:
+            return
+        context.capabilities.record_attachment_accesses(tuple(interpreter.drain_context_accesses()))
 
     @staticmethod
     def _record_phase_failure(

--- a/tests/contracts/backend/test_coordinator_runner_failures.py
+++ b/tests/contracts/backend/test_coordinator_runner_failures.py
@@ -36,12 +36,13 @@ from fleet_rlm.rlm.events import (
 from fleet_rlm.rlm.factory import RLMFactory
 from fleet_rlm.rlm.runner import RLMRunner
 from fleet_rlm.sessions.models import AssistantTurnRecord, TurnAccess, TurnInput
+from tests.unit.backend.rlm.fakes import HostCapabilityDefaults
 
 FailureMode = Literal["invalid_output", "malformed_trajectory", "internal_cancel", "timeout"]
 HarnessMode = FailureMode | Literal["caller_cancel", "native_success"]
 
 
-class _Capabilities:
+class _Capabilities(HostCapabilityDefaults):
     spec = RLMExecutionSpec()
 
     def drain_public_details(self):

--- a/tests/contracts/backend/test_native_rlm_tracer.py
+++ b/tests/contracts/backend/test_native_rlm_tracer.py
@@ -33,6 +33,7 @@ from fleet_rlm.rlm.model_bundle import RLMModelBundle
 from fleet_rlm.rlm.runner import RLMRunner
 from fleet_rlm.rlm.tool_observer import ToolEventView, observe_tool
 from fleet_rlm.sessions.models import TurnAccess
+from tests.unit.backend.rlm.fakes import HostCapabilityDefaults
 
 
 class _ActionPredictor(dspy.Predict):
@@ -358,7 +359,7 @@ async def test_runner_completes_native_repair_and_extract_as_prediction_result(f
         RLMExecutionContext,
     )
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec()
 
         def drain_public_details(self):

--- a/tests/contracts/backend/test_rlm_history_retrieval.py
+++ b/tests/contracts/backend/test_rlm_history_retrieval.py
@@ -10,6 +10,7 @@ import dspy
 import pytest
 
 from fleet_rlm.sessions.history_tools import SESSION_HISTORY_RESULT_BYTE_BUDGET
+from tests.unit.backend.rlm.fakes import HostCapabilityDefaults
 
 
 @pytest.mark.asyncio
@@ -41,7 +42,7 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
     assert older_detail not in str(manifest.to_input())
     (history_tool,) = SessionHistoryToolHost(history).as_tools()
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec(tools=(history_tool,))
 
         def drain_public_details(self):
@@ -139,7 +140,7 @@ async def test_native_rlm_continues_history_across_truncated_pages() -> None:
     second_page = history_tool(offset=first_page["next_offset"], limit=20)
     assert second_page["messages"][-1]["content"] == "final-detail"
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec(tools=(history_tool,))
 
         def drain_public_details(self):

--- a/tests/contracts/backend/test_workspace_turn_flow.py
+++ b/tests/contracts/backend/test_workspace_turn_flow.py
@@ -39,6 +39,7 @@ from fleet_rlm.rlm.errors import RunCancelledError
 from fleet_rlm.rlm.events import RuntimeEvent
 from fleet_rlm.rlm.runner import RLMRunner
 from fleet_rlm.sessions.models import TurnAccess
+from tests.unit.backend.rlm.fakes import FakeRLMInterpreter, HostCapabilityDefaults
 
 
 class MemoryStore:
@@ -180,7 +181,7 @@ class MemoryWorkspace:
         return WorkspaceEntry(path, "file", len(self.files[path].encode()), None)
 
 
-class Capabilities:
+class Capabilities(HostCapabilityDefaults):
     def __init__(self, workspace: MemoryWorkspace) -> None:
         workspace_host = WorkspaceToolHost(workspace, max_file_bytes=1024)
         memory_host = WorkspaceMemoryToolHost(workspace.memory_registry.resolve(workspace.access.workspace_id))
@@ -203,7 +204,7 @@ class Capabilities:
         return ()
 
 
-class Interpreter:
+class Interpreter(FakeRLMInterpreter):
     def __init__(self) -> None:
         self.variables: dict[str, object] = {}
 

--- a/tests/unit/backend/chat/test_session_context.py
+++ b/tests/unit/backend/chat/test_session_context.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
-from types import SimpleNamespace
 from uuid import uuid4
 
 import dspy
 import pytest
+
+from tests.unit.backend.rlm.fakes import FakeRLMInterpreter, HostCapabilityDefaults
 
 
 @pytest.mark.asyncio
@@ -56,7 +57,7 @@ async def test_prepared_rlm_kwargs_bound_a_large_session_to_recent_previews() ->
             del access, ids, run, sink
             return PreparedAttachments((), ())
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec()
 
         def drain_public_details(self):
@@ -86,7 +87,7 @@ async def test_prepared_rlm_kwargs_bound_a_large_session_to_recent_previews() ->
             async def release():
                 return None
 
-            return RunEnvironment(SimpleNamespace(), sink, sink, release)
+            return RunEnvironment(FakeRLMInterpreter(), sink, sink, release)
 
     async def not_cancelled() -> bool:
         return False

--- a/tests/unit/backend/rlm/fakes.py
+++ b/tests/unit/backend/rlm/fakes.py
@@ -2,14 +2,27 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from fleet_rlm.artifacts.models import ArtifactCandidate
 from fleet_rlm.files.memory_candidates import MemoryCandidate
+from fleet_rlm.rlm.child_runtime import ChildRuntimeLease
 from fleet_rlm.rlm.context import RLMExecutionSpec
+from fleet_rlm.rlm.inputs import AttachmentContextCapsule
 
 
-class EmptyCapabilities:
+class HostCapabilityDefaults:
+    """Named PreparedCapabilities fields for test doubles that are not EmptyCapabilities."""
+
+    workspace_memory_digest = ""
+    preparation_notices: tuple[Any, ...] = ()
+
+    def record_attachment_accesses(self, attachment_ids: tuple[str, ...]) -> None:
+        del attachment_ids
+
+
+class EmptyCapabilities(HostCapabilityDefaults):
     """Minimal PreparedCapabilities stand-in with empty drains."""
 
     def __init__(self, *, spec: Any | None = None) -> None:
@@ -28,4 +41,35 @@ class EmptyCapabilities:
         return None
 
 
-__all__ = ["EmptyCapabilities"]
+class FakeChildRuntimeFactory:
+    """Test adapter: wrap a create callable with no-op late-acquisition ownership."""
+
+    def __init__(self, create: Callable[[int], Any]) -> None:
+        self._create = create
+
+    def __call__(self, call_index: int) -> ChildRuntimeLease:
+        return self._create(call_index)
+
+    def wait_owned(self) -> None:
+        return None
+
+    def raise_if_cleanup_failed(self) -> None:
+        return None
+
+
+class FakeRLMInterpreter:
+    """No-op Fleet pre-acall hooks for runner tests that are not Daytona interpreters."""
+
+    def bind_context_capsule(self, capsule: AttachmentContextCapsule) -> None:
+        del capsule
+
+    def drain_context_accesses(self) -> tuple[str, ...]:
+        return ()
+
+
+__all__ = [
+    "EmptyCapabilities",
+    "FakeChildRuntimeFactory",
+    "FakeRLMInterpreter",
+    "HostCapabilityDefaults",
+]

--- a/tests/unit/backend/rlm/test_protocol_seams.py
+++ b/tests/unit/backend/rlm/test_protocol_seams.py
@@ -1,0 +1,271 @@
+"""Named Fleet Protocol fields: no getattr probes at the recursive, prepare, or bind seams."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import dspy
+import pytest
+
+from fleet_rlm.chat.run_lifecycle import ClaimedRun, _RunClaimToken
+from fleet_rlm.chat.run_preparation import DefaultRunPreparer, PreparedRun, RunEnvironment
+from fleet_rlm.chat.session_context import SessionContextManifest
+from fleet_rlm.files.memory_models import WORKSPACE_MEMORY_INJECTION_TAIL_BYTES
+from fleet_rlm.files.models import PreparedAttachments
+from fleet_rlm.rlm.context import ExecutionRuntime, RLMExecutionContext, RunIdentity, SessionView
+from fleet_rlm.rlm.dspy_contract import RLMOptions
+from fleet_rlm.rlm.inputs import AttachmentContextCapsule, AttachmentContextEntry
+from fleet_rlm.rlm.model_bundle import RLMModelBundle
+from fleet_rlm.rlm.recursive_calls import RecursiveRLMExecutor, RecursiveRLMOptions
+from fleet_rlm.rlm.runner import RLMRunner
+from fleet_rlm.sessions.models import SessionHistory, TurnAccess, TurnInput
+from tests.unit.backend.rlm.fakes import (
+    EmptyCapabilities,
+    FakeChildRuntimeFactory,
+    FakeRLMInterpreter,
+)
+
+
+class _RecordingChildRuntimeFactory:
+    def __init__(self) -> None:
+        self.wait_calls = 0
+        self.raise_calls = 0
+
+    def __call__(self, call_index: int) -> Any:
+        del call_index
+        raise AssertionError("wait_owned must not acquire a child lease")
+
+    def wait_owned(self) -> None:
+        self.wait_calls += 1
+
+    def raise_if_cleanup_failed(self) -> None:
+        self.raise_calls += 1
+
+
+class _RecordingInterpreter(FakeRLMInterpreter):
+    def __init__(self) -> None:
+        self.bind_calls = 0
+        self.bound: AttachmentContextCapsule | None = None
+
+    def bind_context_capsule(self, capsule: AttachmentContextCapsule) -> None:
+        self.bind_calls += 1
+        self.bound = capsule
+
+    def drain_context_accesses(self) -> tuple[str, ...]:
+        return ("notes.txt",)
+
+
+class _RecordingCapabilities(EmptyCapabilities):
+    def __init__(self) -> None:
+        super().__init__()
+        self.recorded: tuple[str, ...] | None = None
+
+    def record_attachment_accesses(self, attachment_ids: tuple[str, ...]) -> None:
+        self.recorded = attachment_ids
+
+
+class _ImmediateAnswerFactory:
+    def create(self, **_kwargs: Any) -> Any:
+        class Program:
+            async def acall(self, **_call_kwargs: Any) -> dspy.Prediction:
+                return dspy.Prediction(answer="ok", trajectory=[])
+
+        return Program()
+
+
+async def _prepare(capabilities: EmptyCapabilities) -> PreparedRun:
+    class Sink:
+        async def remove_private(self, location: str) -> None:
+            del location
+
+    class Attachments:
+        async def prepare_run(self, access: Any, ids: Any, run: Any, sink: Any) -> PreparedAttachments:
+            del access, ids, run, sink
+            return PreparedAttachments((), ())
+
+    class Environments:
+        async def acquire(self, turn: Any, *, deadline: float) -> RunEnvironment:
+            del turn, deadline
+
+            async def release() -> None:
+                return None
+
+            return RunEnvironment(None, Sink(), Sink(), release)
+
+    class CapabilityFactory:
+        async def prepare(self, turn: Any, environment: Any, attachments: Any, *, deadline: float) -> EmptyCapabilities:
+            del turn, environment, attachments, deadline
+            return capabilities
+
+    async def not_cancelled() -> bool:
+        return False
+
+    turn = ClaimedRun(
+        uuid4(),
+        uuid4(),
+        TurnAccess(uuid4(), uuid4()),
+        TurnInput("next"),
+        SessionHistory(()),
+        not_cancelled,
+        _RunClaimToken(uuid4()),
+    )
+    return await DefaultRunPreparer(
+        models=RLMModelBundle(object(), object()),
+        options=RLMOptions(),
+        attachments=Attachments(),
+        environments=Environments(),
+        capabilities=CapabilityFactory(),
+    ).prepare(turn, deadline=float("inf"))
+
+
+def _executor(factory: Any) -> RecursiveRLMExecutor:
+    return RecursiveRLMExecutor(
+        models=RLMModelBundle(object(), object()),
+        options=RecursiveRLMOptions(),
+        child_runtime_factory=factory,
+        deadline=time.monotonic() + 30,
+    )
+
+
+def _attachment_capsule() -> AttachmentContextCapsule:
+    return AttachmentContextCapsule(
+        (
+            AttachmentContextEntry(
+                attachment_id=uuid4(),
+                filename="notes.txt",
+                content_type="text/plain",
+                byte_size=3,
+                checksum_sha256="a" * 64,
+                sandbox_path="/home/daytona/run/notes.txt",
+            ),
+        ),
+        mount_root="/home/daytona/run",
+    )
+
+
+async def _stream_runner(
+    *, interpreter: Any, attachment_context: AttachmentContextCapsule | None
+) -> _RecordingCapabilities:
+    async def not_cancelled() -> bool:
+        return False
+
+    capabilities = _RecordingCapabilities()
+    context = RLMExecutionContext(
+        identity=RunIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
+        session=SessionView(
+            request="use context",
+            session_context=SessionContextManifest(uuid4(), 0, 0, ()),
+            attachments=(),
+            preparation_notices=(),
+            attachment_context=attachment_context,
+        ),
+        execution=ExecutionRuntime(
+            models=SimpleNamespace(root_lm=object(), sub_lm=object()),
+            options=RLMOptions(),
+            deadline=asyncio.get_running_loop().time() + 10,
+            interpreter=interpreter,
+            cancellation_requested=not_cancelled,
+        ),
+        capabilities=capabilities,
+    )
+    stream = RLMRunner(factory=_ImmediateAnswerFactory()).stream(context)
+    _events = [event async for event in stream]
+    assert stream.outcome is not None and stream.outcome.succeeded
+    return capabilities
+
+
+def test_fake_child_runtime_factory_owns_noop_wait_and_raise() -> None:
+    created: list[int] = []
+
+    def create(call_index: int) -> object:
+        created.append(call_index)
+        return object()
+
+    factory = FakeChildRuntimeFactory(create)
+    factory.wait_owned()
+    factory.raise_if_cleanup_failed()
+    assert factory(4) is not None
+    assert created == [4]
+
+
+def test_executor_wait_owned_calls_factory_wait_owned() -> None:
+    factory = _RecordingChildRuntimeFactory()
+    executor = _executor(factory)
+    executor.wait_owned()
+    executor.raise_if_cleanup_failed()
+    assert factory.wait_calls == 1
+    assert factory.raise_calls == 1
+
+
+def test_bare_create_callable_is_not_a_child_runtime_factory() -> None:
+    def create(call_index: int) -> object:
+        del call_index
+        return object()
+
+    with pytest.raises(AttributeError):
+        _executor(create).wait_owned()  # type: ignore[arg-type]
+
+
+def test_executor_wait_owned_accepts_fake_factory_wrapping_a_create_callable() -> None:
+    def create(call_index: int) -> object:
+        del call_index
+        return object()
+
+    executor = _executor(FakeChildRuntimeFactory(create))
+    executor.wait_owned()
+    executor.raise_if_cleanup_failed()
+
+
+@pytest.mark.asyncio
+async def test_preparation_copies_protocol_workspace_memory_digest() -> None:
+    capabilities = EmptyCapabilities()
+    capabilities.workspace_memory_digest = "remember the cobalt-orchid code"
+    prepared = await _prepare(capabilities)
+    try:
+        assert prepared.execution.session.workspace_memory_digest == "remember the cobalt-orchid code"
+    finally:
+        await prepared.aclose()
+
+
+@pytest.mark.asyncio
+async def test_preparation_keeps_digest_at_injection_byte_bound() -> None:
+    capabilities = EmptyCapabilities()
+    capabilities.workspace_memory_digest = "x" * WORKSPACE_MEMORY_INJECTION_TAIL_BYTES
+    prepared = await _prepare(capabilities)
+    try:
+        assert prepared.execution.session.workspace_memory_digest == capabilities.workspace_memory_digest
+    finally:
+        await prepared.aclose()
+
+
+@pytest.mark.asyncio
+async def test_preparation_clamps_oversized_workspace_memory_digest() -> None:
+    capabilities = EmptyCapabilities()
+    capabilities.workspace_memory_digest = "x" * (WORKSPACE_MEMORY_INJECTION_TAIL_BYTES + 1)
+    prepared = await _prepare(capabilities)
+    try:
+        assert prepared.execution.session.workspace_memory_digest == ""
+    finally:
+        await prepared.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runner_binds_context_capsule_when_present() -> None:
+    interpreter = _RecordingInterpreter()
+    capsule = _attachment_capsule()
+    capabilities = await _stream_runner(interpreter=interpreter, attachment_context=capsule)
+    assert interpreter.bind_calls == 1
+    assert interpreter.bound is capsule
+    assert capabilities.recorded == ("notes.txt",)
+
+
+@pytest.mark.asyncio
+async def test_runner_skips_bind_context_capsule_when_attachment_context_is_none() -> None:
+    interpreter = _RecordingInterpreter()
+    await _stream_runner(interpreter=interpreter, attachment_context=None)
+    assert interpreter.bind_calls == 0
+    assert interpreter.bound is None

--- a/tests/unit/backend/rlm/test_provider_probe.py
+++ b/tests/unit/backend/rlm/test_provider_probe.py
@@ -6,6 +6,7 @@ import dspy
 import pytest
 
 from fleet_rlm.rlm.provider_probe import RLMProviderContractError, probe_root_lm
+from tests.unit.backend.rlm.fakes import FakeChildRuntimeFactory
 
 
 def _interpreter():
@@ -40,7 +41,11 @@ async def test_provider_probe_requires_multiple_native_actions_and_typed_submit(
         adapter=dspy.JSONAdapter(),
     )
 
-    result = await probe_root_lm(lm, interpreter_factory=_interpreter, child_runtime_factory=_child_runtime)
+    result = await probe_root_lm(
+        lm,
+        interpreter_factory=_interpreter,
+        child_runtime_factory=FakeChildRuntimeFactory(_child_runtime),
+    )
 
     assert result.iterations == 3
     assert result.termination_mode == "typed_submit"
@@ -54,7 +59,11 @@ async def test_provider_probe_rejects_unparseable_native_provider_output() -> No
     )
 
     with pytest.raises(RLMProviderContractError, match="unparseable"):
-        await probe_root_lm(lm, interpreter_factory=_interpreter, child_runtime_factory=_child_runtime)
+        await probe_root_lm(
+            lm,
+            interpreter_factory=_interpreter,
+            child_runtime_factory=FakeChildRuntimeFactory(_child_runtime),
+        )
 
 
 @pytest.mark.asyncio
@@ -90,7 +99,7 @@ async def test_provider_probe_reports_native_extraction_fallback_for_forced_fina
     result = await provider_probe.probe_root_lm(
         dspy.utils.DummyLM([], adapter=dspy.JSONAdapter()),
         interpreter_factory=_interpreter,
-        child_runtime_factory=_child_runtime,
+        child_runtime_factory=FakeChildRuntimeFactory(_child_runtime),
     )
 
     assert result.iterations == 3

--- a/tests/unit/backend/rlm/test_recursive_calls.py
+++ b/tests/unit/backend/rlm/test_recursive_calls.py
@@ -24,6 +24,7 @@ from fleet_rlm.rlm.recursive_calls import (
     RecursiveRLMExecutor,
     RecursiveRLMOptions,
 )
+from tests.unit.backend.rlm.fakes import FakeChildRuntimeFactory
 
 
 def _executor(
@@ -76,7 +77,7 @@ def _executor(
     return RecursiveRLMExecutor(
         models=RLMModelBundle(root, sub),
         options=options or RecursiveRLMOptions(),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 30,
         observer=observer,
         is_authorized=is_authorized,
@@ -204,7 +205,7 @@ def test_recursive_batched_tool_preserves_order_and_bounds_child_concurrency() -
     executor = RecursiveRLMExecutor(
         models=RLMModelBundle(root, sub),
         options=RecursiveRLMOptions(max_calls=3, max_parallel_children=2),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 30,
         observer=events.append,
     )
@@ -295,7 +296,7 @@ def test_recursive_batch_join_stops_at_turn_deadline_and_worker_retains_lease(
             dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(max_calls=1, max_parallel_children=1),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 0.05,
     )
 
@@ -551,7 +552,7 @@ def test_recursive_batch_preserves_order_when_workers_finish_out_of_order(
     executor = RecursiveRLMExecutor(
         models=RLMModelBundle(root, sub),
         options=RecursiveRLMOptions(max_calls=3, max_parallel_children=3),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 5,
     )
 
@@ -601,7 +602,7 @@ def test_recursive_batch_wraps_failure_when_all_children_are_done(
     executor = RecursiveRLMExecutor(
         models=RLMModelBundle(root, sub),
         options=RecursiveRLMOptions(max_calls=2, max_parallel_children=2),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 5,
     )
 
@@ -653,7 +654,7 @@ def test_recursive_batch_failure_returns_before_running_sibling_and_cleanup_wait
     executor = RecursiveRLMExecutor(
         models=RLMModelBundle(root, sub),
         options=RecursiveRLMOptions(max_calls=2, max_parallel_children=2),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 5,
     )
     result: dict[str, BaseException] = {}
@@ -739,7 +740,7 @@ def test_recursive_batch_submit_failure_retains_already_submitted_worker(
             dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(max_calls=2, max_parallel_children=1),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 10,
     )
 
@@ -767,12 +768,14 @@ def test_executor_wait_owned_times_out_when_child_worker_never_completes(
             dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(max_calls=1, max_parallel_children=1),
-        child_runtime_factory=lambda call_index: ChildRuntimeLease(
-            DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-            f"child-{call_index}",
-            "test-volume",
-            f"recursive/test-workspace/test-run/{call_index}",
-            lambda: None,
+        child_runtime_factory=FakeChildRuntimeFactory(
+            lambda call_index: ChildRuntimeLease(
+                DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
+                f"child-{call_index}",
+                "test-volume",
+                f"recursive/test-workspace/test-run/{call_index}",
+                lambda: None,
+            )
         ),
         deadline=time.monotonic() + 10,
     )
@@ -834,7 +837,7 @@ def test_recursive_batch_cancels_queued_children_before_they_acquire_a_lease(
     executor = RecursiveRLMExecutor(
         models=RLMModelBundle(root, sub),
         options=RecursiveRLMOptions(max_calls=3, max_parallel_children=1),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 1,
     )
 

--- a/tests/unit/backend/rlm/test_recursive_runner_flow.py
+++ b/tests/unit/backend/rlm/test_recursive_runner_flow.py
@@ -26,7 +26,7 @@ from fleet_rlm.rlm.model_bundle import RLMModelBundle
 from fleet_rlm.rlm.recursive_calls import RecursiveRLMOptions
 from fleet_rlm.rlm.runner import RLMRunner
 from fleet_rlm.sessions.models import TurnAccess
-from tests.unit.backend.rlm.fakes import EmptyCapabilities
+from tests.unit.backend.rlm.fakes import EmptyCapabilities, FakeChildRuntimeFactory
 
 
 @pytest.mark.asyncio
@@ -73,7 +73,7 @@ async def test_root_child_root_flow_preserves_parent_repl_and_typed_submit() -> 
         ),
         delegation=DelegationPolicy(
             recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2),
-            child_runtime_factory=lambda call_index: _child_lease(call_index),
+            child_runtime_factory=FakeChildRuntimeFactory(lambda call_index: _child_lease(call_index)),
         ),
         capabilities=EmptyCapabilities(),
     )
@@ -176,7 +176,8 @@ async def test_runner_rejects_recursive_tool_after_authority_revocation() -> Non
             cancellation_requested=not_cancelled,
         ),
         delegation=DelegationPolicy(
-            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=1), child_runtime_factory=child_factory
+            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=1),
+            child_runtime_factory=FakeChildRuntimeFactory(child_factory),
         ),
         capabilities=EmptyCapabilities(),
     )
@@ -299,7 +300,8 @@ async def test_failed_child_cleanup_prevents_successful_root_outcome() -> None:
             cancellation_requested=not_cancelled,
         ),
         delegation=DelegationPolicy(
-            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2), child_runtime_factory=failed_lease
+            recursive_options=RecursiveRLMOptions(enabled=True, max_calls=2),
+            child_runtime_factory=FakeChildRuntimeFactory(failed_lease),
         ),
         capabilities=EmptyCapabilities(),
     )
@@ -374,7 +376,7 @@ async def test_runner_wait_owned_retains_pending_recursive_workers_until_child_l
         ),
         delegation=DelegationPolicy(
             recursive_options=RecursiveRLMOptions(enabled=True, max_calls=1),
-            child_runtime_factory=child_factory,
+            child_runtime_factory=FakeChildRuntimeFactory(child_factory),
         ),
         capabilities=EmptyCapabilities(),
     )

--- a/tests/unit/backend/rlm/test_routing_eval.py
+++ b/tests/unit/backend/rlm/test_routing_eval.py
@@ -24,6 +24,7 @@ from fleet_rlm.rlm.routing_eval import (
     score_routing_execution,
     summarize_scores,
 )
+from tests.unit.backend.rlm.fakes import FakeChildRuntimeFactory
 
 
 def test_curated_scenarios_cover_the_six_owned_routes() -> None:
@@ -152,7 +153,7 @@ def test_native_child_to_sub_lm_fallback_has_no_second_sandbox() -> None:
             dspy.utils.DummyLM([{"answer": "fallback element"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(),
-        child_runtime_factory=factory,
+        child_runtime_factory=FakeChildRuntimeFactory(factory),
         deadline=time.monotonic() + 30,
     )
 
@@ -200,7 +201,7 @@ async def test_harness_runs_an_isolated_fake_lm_python_scenario() -> None:
         root_lm=root,
         sub_lm=sub,
         root_interpreter_factory=lambda: DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        child_runtime_factory=child_factory,
+        child_runtime_factory=FakeChildRuntimeFactory(child_factory),
     )
 
     assert len(scores) == 1
@@ -234,7 +235,7 @@ async def test_harness_routes_one_native_semantic_call_to_configured_sub_lm() ->
         root_lm=root,
         sub_lm=sub,
         root_interpreter_factory=lambda: DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        child_runtime_factory=unexpected_child,
+        child_runtime_factory=FakeChildRuntimeFactory(unexpected_child),
     )
 
     assert scores[0].answer_correct is True
@@ -275,7 +276,7 @@ async def test_harness_routes_native_semantic_batch_to_configured_sub_lm() -> No
         root_lm=root,
         sub_lm=sub,
         root_interpreter_factory=lambda: DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
-        child_runtime_factory=unexpected_child,
+        child_runtime_factory=FakeChildRuntimeFactory(unexpected_child),
     )
 
     assert scores[0].answer_correct is True

--- a/tests/unit/backend/rlm/test_runner_execution.py
+++ b/tests/unit/backend/rlm/test_runner_execution.py
@@ -140,7 +140,7 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
     from fleet_rlm.rlm.runner import RLMRunner
     from fleet_rlm.sessions.models import TurnAccess
     from fleet_rlm.skills.models import SkillCard
-    from tests.unit.backend.rlm.fakes import EmptyCapabilities
+    from tests.unit.backend.rlm.fakes import EmptyCapabilities, FakeRLMInterpreter
 
     class Factory:
         options = None
@@ -193,7 +193,7 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
 
             return Program()
 
-    class Interpreter:
+    class Interpreter(FakeRLMInterpreter):
         observer = None
 
         def bind_observer(self, observer, *, max_chars):

--- a/tests/unit/backend/test_turn_preparation.py
+++ b/tests/unit/backend/test_turn_preparation.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import pytest
 
+from tests.unit.backend.rlm.fakes import HostCapabilityDefaults
+
 
 @pytest.mark.asyncio
 async def test_preparation_bounds_history_and_closes_in_dependency_order() -> None:
@@ -47,7 +49,7 @@ async def test_preparation_bounds_history_and_closes_in_dependency_order() -> No
             del access, ids, run, sink
             return PreparedAttachments((), ())
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec()
 
         def drain_public_details(self):
@@ -146,7 +148,7 @@ async def test_capability_preparation_is_bounded_by_turn_deadline_and_releases_e
             del access, ids, run, sink
             return PreparedAttachments((), ())
 
-    class SlowCapabilities:
+    class SlowCapabilities(HostCapabilityDefaults):
         async def prepare(self, turn, environment, attachments, *, deadline):
             del turn, environment, attachments, deadline
             await asyncio.sleep(60)
@@ -221,7 +223,7 @@ async def test_preparation_failure_removes_staged_run_bytes_but_not_session_work
                 (StagedAttachment(attachment_id, staged_path),),
             )
 
-    class FailingCapabilities:
+    class FailingCapabilities(HostCapabilityDefaults):
         async def prepare(self, turn, environment, attachments, *, deadline):
             del turn, environment, attachments, deadline
             raise RuntimeError("private capability failure")
@@ -296,7 +298,7 @@ async def test_capsule_validation_failure_releases_all_prepared_resources() -> N
                 context_mount_path="/configured/volume",
             )
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec()
 
         def drain_public_details(self):

--- a/tests/unit/backend/test_turn_preparation_database_failures.py
+++ b/tests/unit/backend/test_turn_preparation_database_failures.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 
 import pytest
 
+from tests.unit.backend.rlm.fakes import HostCapabilityDefaults
+
 
 @pytest.mark.asyncio
 async def test_connection_reset_during_capability_preparation_is_unavailable() -> None:
@@ -40,7 +42,7 @@ async def test_connection_reset_during_capability_preparation_is_unavailable() -
             del access, ids, run, sink
             return PreparedAttachments((), ())
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         async def prepare(self, turn, environment, attachments, *, deadline):
             del turn, environment, attachments, deadline
             raise DatabaseConnectionError("connection reset during TLS handshake")
@@ -158,7 +160,7 @@ async def test_connection_reset_during_post_capability_cancellation_probe_is_una
             del access, ids, run, sink
             return PreparedAttachments((), ())
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         preparation_notices = ()
 
         async def prepare(self, turn, environment, attachments, *, deadline):

--- a/tests/unit/backend/test_turn_preparation_tracing.py
+++ b/tests/unit/backend/test_turn_preparation_tracing.py
@@ -11,6 +11,8 @@ from uuid import uuid4
 
 import pytest
 
+from tests.unit.backend.rlm.fakes import HostCapabilityDefaults
+
 
 @pytest.fixture
 def fleet_trace_active() -> Iterator[None]:
@@ -87,7 +89,7 @@ def _make_preparer(*, environments: Any = None) -> Any:
             del access, ids, run, sink
             return PreparedAttachments((), ())
 
-    class Capabilities:
+    class Capabilities(HostCapabilityDefaults):
         spec = RLMExecutionSpec()
 
         def drain_public_details(self) -> tuple[Any, ...]:

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -23,6 +23,7 @@ from fleet_rlm.observability.turn_tracing import (
     turn_trace,
 )
 from fleet_rlm.rlm.tool_observer import ToolEventView, observe_tool
+from tests.unit.backend.rlm.fakes import FakeChildRuntimeFactory
 
 
 @pytest.fixture(autouse=True)
@@ -542,7 +543,7 @@ def test_recursive_child_span_records_bounded_metadata(monkeypatch: pytest.Monke
             dspy.utils.DummyLM([{"answer": "fallback"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(),
-        child_runtime_factory=_in_process_child_runtime,
+        child_runtime_factory=FakeChildRuntimeFactory(_in_process_child_runtime),
         deadline=time.monotonic() + 30,
     )
 
@@ -596,7 +597,7 @@ def test_recursive_batch_spans_finish_with_active_mlflow(
             dspy.utils.DummyLM([{"answer": "fallback"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(max_calls=2, max_parallel_children=2),
-        child_runtime_factory=_in_process_child_runtime,
+        child_runtime_factory=FakeChildRuntimeFactory(_in_process_child_runtime),
         deadline=time.monotonic() + 30,
     )
 
@@ -629,7 +630,7 @@ def test_recursive_child_span_marks_shutdown_failure(monkeypatch: pytest.MonkeyP
             dspy.utils.DummyLM([{"answer": "fallback"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(),
-        child_runtime_factory=_in_process_child_runtime,
+        child_runtime_factory=FakeChildRuntimeFactory(_in_process_child_runtime),
         deadline=time.monotonic() + 30,
     )
 
@@ -669,7 +670,7 @@ def test_recursive_child_span_marks_native_setup_failure(monkeypatch: pytest.Mon
             dspy.utils.DummyLM([{"answer": "unused"}], adapter=adapter),
         ),
         options=RecursiveRLMOptions(),
-        child_runtime_factory=_raise_setup_error,
+        child_runtime_factory=FakeChildRuntimeFactory(_raise_setup_error),
         deadline=time.monotonic() + 30,
     )
 


### PR DESCRIPTION
## Summary

- Replace optional interpreter and capability hooks with explicit runtime protocols.
- Forward factory-owned late child cleanup through recursive execution.
- Keep workspace-memory digest and provider-probe contracts explicit, with deterministic seam coverage.

## Validation

- `make clean`
- `make check` passed on the reviewed tree.
- `git diff --cached --check`

Live Daytona/provider behavior was not exercised.