### PR TITLE
Release 0.7.0: changelog consolidation, README install step, routing-cleanup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [0.7.0] - 2026-08-15
 
 ### Added
 
@@ -16,6 +16,10 @@ All notable changes to this project are documented in this file.
   enabled; operators can correlate Turns to traces without new SSE chunk types or
   Turn-path coupling. The shipped TOML policy enables local tracing for interactive
   profiles and keeps benchmark profiles off; export remains fail-soft.
+- **Change:** Added the credentialed Daytona-backed Fleet RLM MVP proof,
+  bounded receipt validation, strict cleanup, and release evidence.
+  **Outcome:** The backend MVP can be promoted only after the live proof,
+  local release gates, and human review all pass.
 
 ### Changed
 
@@ -58,15 +62,6 @@ All notable changes to this project are documented in this file.
   **Outcome:** Models gain one bounded recovery step on repetitive loops before
   the Turn is stopped, reducing spurious terminal failures while retaining the
   hard stop for genuine no-progress loops.
-
-## [0.7.0] - 2026-07-17
-
-### Added
-
-- **Change:** Added the credentialed Daytona-backed Fleet RLM MVP proof,
-  bounded receipt validation, strict cleanup, and release evidence.
-  **Outcome:** The backend MVP can be promoted only after the live proof,
-  local release gates, and human review all pass.
 
 ## [0.6.2] - 2026-06-29
 
@@ -1338,6 +1333,7 @@ All notable changes to this project are documented in this file.
 - Removed checked-in `__pycache__` directories under `src/fleet_rlm/`.
 - Moved non-runtime memory-topology notes out of package source and into docs.
 
+[0.7.0]: https://github.com/Qredence/fleet-rlm/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/Qredence/fleet-rlm/compare/v0.6.0...v0.6.2
 [0.6.0]: https://github.com/Qredence/fleet-rlm/compare/v0.5.50...v0.6.0
 [0.5.50]: https://github.com/Qredence/fleet-rlm/compare/v0.5.40...v0.5.50

--- a/README.md
+++ b/README.md
@@ -1,146 +1,152 @@
 # Fleet RLM
 
-Fleet RLM is an RLM-native backend built around FastAPI SSE, `dspy.RLM`, and
-Daytona Sandboxes with workspace-scoped durable Volumes. The canonical backend
-is `src/fleet_rlm/`; the maintained development client is the pi-tui workspace
-under `tools/fleet-tui/`.
+**Recursive language-model backend with live streaming, durable sessions, and sandboxed execution.**
 
-## Install and run
+Fleet RLM runs [DSPy](https://github.com/stanfordnlp/dspy) `dspy.RLM` behind a compact FastAPI + SSE API. Each turn executes in an isolated [Daytona](https://www.daytona.io/) sandbox with workspace-scoped volumes, host-mediated tools, and a terminal client that streams reasoning, code, and output as it happens.
+
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/Qredence/fleet-rlm/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/Qredence/fleet-rlm/tree/main)
+[![PyPI](https://img.shields.io/pypi/v/fleet-rlm?style=flat-square&logo=pypi&logoColor=white)](https://pypi.org/project/fleet-rlm/)
+[![Python](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-2EA44F?style=flat-square)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-Read%20the%20Docs-2C9ED0?style=flat-square&logo=readthedocs&logoColor=white)](https://fleet-rlm.readthedocs.io/)
+[![DSPy](https://img.shields.io/badge/DSPy-3.3+-8B5CF6?style=flat-square)](https://dspy.ai/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-SSE-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
+
+---
+
+## Why Fleet RLM
+
+- **RLM-native** — One fresh `dspy.RLM` per turn with Python REPL execution, native sub-LM queries, and optional recursive child RLMs.
+- **Operator-visible streaming** — Reasoning, tool calls, interpreter code, and stdout flow over SSE to the maintained [pi-tui terminal](tools/fleet-tui/).
+- **Durable by default** — Sessions, turns, attachments, artifacts, and workspace memory survive across runs.
+- **Sandboxed execution** — Daytona interpreters run in isolated sandboxes with bounded workspace volumes and host-mediated memory tools.
+- **Policy-driven runtime** — Non-secret behavior lives in `config/fleet.toml`; secrets stay in `FLEET_*` environment variables.
+
+## Quick start
+
+### 1. Install
 
 ```bash
+git clone https://github.com/Qredence/fleet-rlm.git
+cd fleet-rlm
 uv sync --all-extras --dev
-
-# supervised backend + pi-tui
-uv run fleet cli   # Daytona
-
-# backend only
-uv run fleet web
-uv run fleet-rlm serve-api --port 8000
 ```
 
-Select the non-secret runtime policy with `[config] default_profile` in
-`config/fleet.toml` or the TUI `/profiles` command, then restart Fleet.
-`fleet cli` requires a selected Daytona profile. A mismatch fails before runtime
-services start.
+You need **Node 22.19+** and **pnpm** for the terminal client (`fleet cli`).
 
-`fleet cli` requires Node 22.19+ and pnpm. It waits for backend readiness, writes
-backend output under `.fleet_rlm/logs/`, and stops the backend when pi-tui exits.
-Forward terminal arguments after `--`, for example:
+### 2. Configure credentials
 
-```bash
-uv run fleet cli -- --session <uuid>
-```
-
-The terminal uses an alternate-screen viewport and does not own a model, provider key, or
-Sandbox. See the [terminal guide](docs/how-to-guides/terminal-tui.md) and
-[configuration reference](docs/reference/configuration.md).
-
-### Daytona
-
-Daytona is the full Fleet runtime. The shipped `daytona-recursive` default uses
-an OpenCode Go API key and base URL, plus the Daytona key and database URL. The
-`daytona-managed` and benchmark profiles use the Databricks AI Gateway instead.
-See the [generated profile matrix](docs/reference/profile-matrix.md) for the
-policy-derived environment names and token limits. Initialize the configured
-database explicitly; startup never applies migrations automatically.
+Pick a runtime profile in `config/fleet.toml` (`default_profile`; shipped default is `daytona-recursive`), then export the provider and Daytona variables for that profile. See the [profile matrix](docs/reference/profile-matrix.md) for the exact `FLEET_*` names.
 
 ```bash
 export FLEET_DATABASE_URL='postgresql+asyncpg://...'
 export FLEET_DAYTONA_API_KEY='...'
 export FLEET_OPENCODE_GO_API_KEY='...'
 export FLEET_OPENCODE_GO_BASE_URL='https://<gateway>/v1'
-make daytona-snapshot-check
+
 uv run python scripts/db_init.py
+```
+
+Startup never applies migrations automatically — initialize the database explicitly before serving.
+
+### 3. Run
+
+**Supervised backend + terminal** (recommended for local development):
+
+```bash
+uv run fleet cli
+```
+
+**Backend only:**
+
+```bash
+uv run fleet web
+# or
 uv run fleet-rlm serve-api --port 8000
 ```
 
-The committed default is `default_profile = "daytona-recursive"`. Set
-`default_profile = "daytona"` for the non-recursive interactive profile, or
-select another documented profile before restarting Fleet.
-
-Use `uv run fleet doctor daytona` for an opt-in disposable provider, database,
-mount, and interpreter probe before diagnosing a Turn.
-
-## Backend API
-
-- `POST /api/sessions/{session_id}/turns` — local-scope idempotent SSE execution.
-- `/api/sessions` — Session CRUD and ordered committed Turn history.
-- `/api/attachments` — durable Attachment upload and metadata lookup.
-- `/api/artifacts/{artifact_id}` — committed metadata and verified content.
-- `GET /api/volume/tree` — Daytona-only bounded read-only logical Workspace
-  Volume paths.
-- `/api/skills` — bounded system Skill Card discovery for the five bundled
-  Skills.
-- `PUT /api/runs/{run_id}/cancellation` — durable Run cancellation.
-
-There is no `/api/v1`, WebSocket execution, optimization/evaluation API,
-runtime-admin API, caller-selected BYOK profile API, or public Artifact creation.
-The Volume tree is a read-only, process-local view rather than a general-purpose
-Sandbox filesystem browser.
-See the [HTTP API](docs/reference/http-api.md) and generated
-[OpenAPI](openapi.yaml).
-
-## Architecture
-
-One Turn validates its deterministic local scope, Attachments, and exact Skill
-selections before opening SSE. `TurnCoordinator` begins and prepares execution,
-`RLMRunner` runs one fresh native `dspy.RLM`, and `RunLifecycle.finish()` owns
-result snapshot handling, Artifact publication, and atomic Turn Commit. The
-coordinator then projects the terminal suffix and cleans up Run resources.
-
-The Root uses Python, native Sub-LM queries, or isolated child RLMs according to
-the cheapest-sufficient delegation ladder. Recursive children remain one native
-level deep; Root-only `rlm_query_batched` provides ordered, bounded sibling
-fan-out, and Root verifies and synthesizes their evidence before `SUBMIT`.
-
-Daytona Turns acquire a fresh Interpreter Lease and use Workspace Volume Scope.
-Each Turn receives a bounded newest-record digest of Workspace Memory in its
-`session_context`; the full `memory/MEMORIES.md` log remains behind the
-host-mediated Memory Tools. The RLM may append a record only when the user
-explicitly asks to remember something. Memory is immediate workspace state,
-not Session History or a Turn-commit record, and survives failed Runs and
-Sandbox replacement. Full Session history stays host-side behind the bounded
-`read_session_history` Tool.
-
-Read the [architecture](docs/architecture.md), [backend context](src/fleet_rlm/CONTEXT.md),
-and [codebase map](docs/reference/codebase-map.md).
-
-## Database
-
-Alembic owns live schema evolution through one canonical baseline. For an
-explicit disposable/live database:
+Resume a durable session:
 
 ```bash
-uv run alembic upgrade head
-uv run alembic check
+uv run fleet cli -- --session <session-uuid>
 ```
 
-Runtime startup never calls SQLAlchemy `create_all` for a live PostgreSQL
-database.
-
-## Validation and release evidence
+Before your first turn, verify Daytona connectivity:
 
 ```bash
-make check
-make check-security
-make build-release
-make check-release
-git diff --check
+uv run fleet doctor daytona
 ```
 
-`make api-sync` regenerates `openapi.yaml`,
-`tools/fleet-tui/src/generated/openapi.ts`, and
-`tools/fleet-tui/src/generated/fleet-ui-chunk-validation.ts`;
-`make api-check` verifies all three.
+> **Profile mismatch fails fast.** `fleet cli` requires a Daytona profile that matches your credentials. Select profiles with `/profiles` in the TUI or edit `default_profile`, then restart Fleet.
 
-Credentialed promotion additionally requires a passing receipt tied to the
-exact candidate SHA:
+## How a turn works
+
+```text
+Client  →  POST /api/sessions/{id}/turns  →  SSE stream
+                │
+                ├─ validate scope, attachments, skills
+                ├─ TurnCoordinator opens run + prepares context
+                ├─ RLMRunner executes one native dspy.RLM in Daytona
+                ├─ stream reasoning, tools, code, output events
+                └─ RunLifecycle commits result, artifacts, and turn history
+```
+
+The root agent can answer directly, delegate to sub-LMs, or fan out bounded recursive child RLMs. Session history stays host-side; workspace memory (`memory/MEMORIES.md`) persists across sandbox replacement.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `uv run fleet cli` | Start backend + pi-tui terminal (Daytona profile required) |
+| `uv run fleet web` | Start backend only on port 8000 |
+| `uv run fleet doctor daytona` | Opt-in disposable probe of provider, DB, mounts, interpreter |
+| `uv run python scripts/db_init.py` | Initialize or upgrade database to Alembic head |
+| `make check` | Default validation lane (backend + TUI) |
+
+Backend logs for supervised runs: `.fleet_rlm/logs/`.
+
+## API surface
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/sessions/{session_id}/turns` | Idempotent turn execution over SSE |
+| `/api/sessions` | Session CRUD and committed turn history |
+| `/api/attachments` | Durable attachment upload and lookup |
+| `/api/artifacts/{artifact_id}` | Committed artifact metadata and content |
+| `GET /api/volume/tree` | Bounded read-only workspace volume tree (Daytona) |
+| `/api/skills` | Bundled skill card discovery |
+| `PUT /api/runs/{run_id}/cancellation` | Durable run cancellation |
+
+Full contract: [HTTP API reference](docs/reference/http-api.md) and [OpenAPI](openapi.yaml).
+
+## Project layout
+
+| Path | Role |
+| --- | --- |
+| `src/fleet_rlm/` | Canonical Python backend |
+| `tools/fleet-tui/` | Maintained pi-tui terminal client |
+| `config/fleet.toml` | Runtime policy (profiles, limits, tracing) |
+| `migrations/` | Alembic schema |
+| `docs/` | Architecture, guides, and reference |
+
+## Development
 
 ```bash
-FLEET_LIVE=1 uv run python scripts/live_daytona_verify.py \
-  --output .scratch/release-ready-mvp/assets/daytona-mvp-proof.json
+make check                 # lint, typecheck, tests (default lane)
+make api-sync              # regenerate OpenAPI + TUI types
+make check-security        # security scans
 ```
 
-The verifier keeps credentials out of Sandboxes and writes only bounded local
-evidence. A historical pass does not promote a later SHA. See the
-[DSPy RLM and Daytona guide](docs/how-to-guides/dspy-integration.md).
+Contributing workflow and architecture rules: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Key docs:
+
+- [Architecture](docs/architecture.md)
+- [Configuration](docs/reference/configuration.md)
+- [Terminal UI guide](docs/how-to-guides/terminal-tui.md)
+- [DSPy + Daytona integration](docs/how-to-guides/dspy-integration.md)
+- [Testing strategy](docs/how-to-guides/testing-strategy.md)
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Fleet RLM runs [DSPy](https://github.com/stanfordnlp/dspy) `dspy.RLM` behind a c
 git clone https://github.com/Qredence/fleet-rlm.git
 cd fleet-rlm
 uv sync --all-extras --dev
+pnpm --dir tools/fleet-tui install --frozen-lockfile
 ```
 
-You need **Node 22.19+** and **pnpm** for the terminal client (`fleet cli`).
+You need **Node 22.19+** and **pnpm** for the terminal client (`fleet cli`). `uv sync` does not install TUI dependencies; run the `pnpm` step above before `fleet cli`.
 
 ### 2. Configure credentials
 

--- a/scripts/generate_profile_matrix.py
+++ b/scripts/generate_profile_matrix.py
@@ -40,10 +40,10 @@ def render() -> str:
         f"The active default is `{active}`.",
         "",
         "Provider environment names are the only values required by the credentialed live verifier. "
-        "Managed-policy names are additionally required when `daytona-managed` is selected.",
+        + "Managed-policy names are additionally required when `daytona-managed` is selected.",
         "",
         "| Profile | Default | Provider | Root/Sub model | Root/Sub max tokens | Recursion | MLflow | "
-        "Provider environment names | Managed-policy environment names |",
+        + "Provider environment names | Managed-policy environment names |",
         "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
     for contract in load_profile_environment_contracts():
@@ -59,8 +59,8 @@ def render() -> str:
         [
             "",
             "The verifier uses the selected row's provider environment names and never checks a hard-coded provider "
-            "credential. `FLEET_DATABASE_URL` is replaced by a temporary SQLite URL in the live proof; it is a "
-            "required selected-policy value only for the managed profile.",
+            + "credential. `FLEET_DATABASE_URL` is replaced by a temporary SQLite URL in the live proof; it is a "
+            + "required selected-policy value only for the managed profile.",
             "",
         ]
     )

--- a/src/fleet_rlm/rlm/routing_eval.py
+++ b/src/fleet_rlm/rlm/routing_eval.py
@@ -312,6 +312,36 @@ class _RoutingScenarioSignature(dspy.Signature):
     answer: str = dspy.OutputField()
 
 
+class _TrackingChildRuntimeFactory:
+    """Count child acquisitions while forwarding optional factory-owned cleanup.
+
+    ``RecursiveRLMExecutor`` looks for ``wait_owned`` and
+    ``raise_if_cleanup_failed`` on the factory it was given so timed-out
+    provider acquisitions adopted by the factory are awaited under the same
+    cleanup boundary as retained child workers. The tracking wrapper must
+    forward those optional hooks when the underlying factory provides them;
+    otherwise a late-adopted Sandbox could be orphaned in this lane.
+    """
+
+    def __init__(self, inner: Callable[[int], Any]) -> None:
+        self._inner = inner
+        self.created = 0
+
+    def __call__(self, call_index: int) -> Any:
+        self.created += 1
+        return self._inner(call_index)
+
+    def wait_owned(self) -> None:
+        factory_wait_owned = getattr(self._inner, "wait_owned", None)
+        if callable(factory_wait_owned):
+            factory_wait_owned()
+
+    def raise_if_cleanup_failed(self) -> None:
+        factory_raise = getattr(self._inner, "raise_if_cleanup_failed", None)
+        if callable(factory_raise):
+            factory_raise()
+
+
 async def _maybe_await(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await value
@@ -344,12 +374,7 @@ async def run_routing_scenario(
         captured = []
         started = time.perf_counter()
         deadline = time.monotonic() + deadline_seconds
-        created_children = 0
-
-        def tracked_child_factory(call_index: int) -> Any:
-            nonlocal created_children
-            created_children += 1
-            return child_runtime_factory(call_index)
+        tracked_child_factory = _TrackingChildRuntimeFactory(child_runtime_factory)
 
         recursive = RecursiveRLMExecutor(
             models=RLMModelBundle(root_lm=root_lm, sub_lm=sub_lm),
@@ -399,7 +424,7 @@ async def run_routing_scenario(
             child_iterations=summary.child_iterations,
             recursive_prompt_chars=summary.maximum_prompt_chars,
             latency_ms=details_facts.latency_ms,
-            sandbox_count=created_children,
+            sandbox_count=tracked_child_factory.created,
             recursive_batch_calls=summary.recursive_batch_calls,
             peak_child_concurrency=summary.peak_child_concurrency,
         )

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -463,7 +463,6 @@ class RLMRunner:
         observations = _ObservationBuffer(EventRecorder(context.identity.run_id, context.identity.session_id))
         async for event in self._initial_events(context, observations):
             yield event
-        spec = context.capabilities.spec
         spec, relay, guards, task, recursive_executor = self._start_worker(context)
         ownership.task = task
         if recursive_executor is not None:

--- a/tests/contracts/backend/test_stream_contract_parity.py
+++ b/tests/contracts/backend/test_stream_contract_parity.py
@@ -9,11 +9,7 @@ from fleet_rlm.composition.testing import create_testing_app
 from fleet_rlm.sessions.assistant_parts import AssistantPartModelUnion
 from fleet_rlm.sessions.committed_turn import CommittedTurn
 
-_ASSISTANT_TYPES = {
-    model.model_fields["type"].default
-    for model in AssistantPartModelUnion
-    for default in (model.model_fields["type"].default,)
-}
+_ASSISTANT_TYPES = {model.model_fields["type"].default for model in AssistantPartModelUnion}
 _TRANSPORT_SEMANTICS = set(FLEET_UI_CHUNK_TYPES)
 
 

--- a/tests/unit/backend/rlm/test_routing_eval.py
+++ b/tests/unit/backend/rlm/test_routing_eval.py
@@ -282,3 +282,42 @@ async def test_harness_routes_native_semantic_batch_to_configured_sub_lm() -> No
     assert scores[0].routing_match is True
     assert scores[0].facts.tool_counts["llm_query_batched"] == 1
     assert len(sub.history) == 3
+
+
+def test_tracking_child_factory_forwards_optional_factory_cleanup() -> None:
+    """The routing harness forwards factory-owned cleanup hooks it does not use."""
+
+    from fleet_rlm.rlm.routing_eval import _TrackingChildRuntimeFactory
+
+    class _FakeLease:
+        pass
+
+    class _Factory:
+        def __init__(self) -> None:
+            self.created: list[int] = []
+            self.waited = 0
+            self.raised = 0
+
+        def __call__(self, call_index: int) -> _FakeLease:
+            self.created.append(call_index)
+            return _FakeLease()
+
+        def wait_owned(self) -> None:
+            self.waited += 1
+
+        def raise_if_cleanup_failed(self) -> None:
+            self.raised += 1
+
+    factory = _Factory()
+    tracked = _TrackingChildRuntimeFactory(factory)
+    assert isinstance(tracked(3), _FakeLease)
+    tracked.wait_owned()
+    tracked.raise_if_cleanup_failed()
+    assert tracked.created == 1
+    assert factory.created == [3]
+    assert factory.waited == 1
+    assert factory.raised == 1
+
+    plain_tracked = _TrackingChildRuntimeFactory(lambda _index: _FakeLease())
+    plain_tracked.wait_owned()
+    plain_tracked.raise_if_cleanup_failed()


### PR DESCRIPTION
Release preparation for fleet-rlm 0.7.0 (PyPI).

## Changes vs origin/main (a048f5f90)

- **docs: rewrite README** (e48dbd894) + **review feedback** (a8aeb54b6): clearer quickstart, modern badges, required TUI `pnpm install` step — supersedes open PR #438.
- **docs: fold 0.7.0 release section and drop empty audit stub** (57676e34d): CHANGELOG `[Unreleased]` folded into `[0.7.0] - 2026-08-15`, compare link added, removed the tracked 0-byte `fleet-rlm-audit.md`.
- **fix(rlm): forward factory-owned cleanup hooks in routing harness** (edbfdd9e): `_TrackingChildRuntimeFactory` now forwards `wait_owned`/`raise_if_cleanup_failed` so late-adopted Daytona acquisitions are awaited in the routing-evaluation lane.
- **fix: resolve remaining code-quality scanner findings** (01646287d): dead spec assignment, profile-matrix string concat, parity-test simplification — supersedes open PR #433.

## Validation

- `make check` (full lane), `make check-security`, `make build-release` (wheel + sdist, twine check) all pass locally on this content.
- Version aligned at 0.7.0 across pyproject/`__init__.py`/`openapi.yaml`; AGENTS.md/CONTEXT-MAP freshness checks pass; no legacy API surfaces (`/api/v1`, WebSocket, frontend) remain.

After merge: tag `v0.7.0` and publish to PyPI.