### PR TITLE
refactor(rlm): adopt DSPy 3.3.0 max_iters spelling end-to-end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ Run `make check-docs` when docs, commands, Codex config, generated contracts, or
 - Under pinned DSPy 3.3.0, every `dspy.LM` model must resolve a provider; model
   roles/defaults come from the selected TOML profile, and bare compatible-base
   IDs use `normalize_model_id`. Prefer stock LMs with stateless overrides; Fleet
-  maps `max_iterations` to DSPy's `max_iters`. Root may use native
+  uses DSPy's `max_iters` end-to-end (`rlm.max_iters`, `RLMOptions.max_iters`). Root may use native
   `llm_query`/`llm_query_batched`, while Root-only `rlm_query_batched` reserves
   ordered, isolated child RLMs under a fixed native depth of one.
 - Native RLMs use a fail-closed interpreter factory and caller-owned positional interpreters; Fleet or child leases own shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,20 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - **Change:** Migrated the native Fleet RLM integration to DSPy `3.3.0`,
-  preserving Fleet's `max_iterations` configuration while adapting
-  construction and caller-owned interpreter invocation to DSPy's final contract.
+  adapting construction and caller-owned interpreter invocation to DSPy's final
+  contract.
   **Outcome:** Native Turns, live per-iteration observation, recursive children,
   and deterministic test composition retain their event and cleanup behavior
   while using the exact DSPy `3.3.0` runtime; Fleet no longer projects a second
   token-level `dspy.streamify` protocol.
+
+- **Change:** Adopted DSPy 3.3.x's `max_iters` spelling end-to-end. The legacy
+  Fleet iteration-budget spelling (TOML `rlm.*` keys, `Settings.rlm_*`,
+  `RLMOptions.*`, settings-API paths, and the MLflow `RLM.execute` span input
+  key) is removed with no alias.
+  **Outcome:** `RLMOptions.max_iters` passes verbatim to
+  `dspy.RLM(max_iters=...)` with no adapter layer; budgets are unchanged and
+  policies using the old key fail validation.
 
 - **Change:** Bumped `fastapi[standard]` from `==0.139.0` to `==0.141.1`
   (latest PyPI release, Jul 29 2026) along with `fastapi-cli` 0.0.24 -> 0.0.32,

--- a/config/fleet.toml
+++ b/config/fleet.toml
@@ -23,7 +23,7 @@ model_provider_service = "uscentral.default.zencode-oai"
 model_provider_service = "uscentral.default.zencode-oai"
 
 [defaults.rlm]
-max_iterations = 20
+max_iters = 20
 max_llm_calls = 50
 max_output_chars = 10000
 max_execution_output_chars = 4000
@@ -31,7 +31,7 @@ execution_timeout_s = 120
 recursion_enabled = false
 recursion_max_calls = 4
 recursion_max_prompt_chars = 50000
-recursion_child_max_iterations = 8
+recursion_child_max_iters = 8
 recursion_child_max_llm_calls = 12
 recursion_child_max_output_chars = 4000
 recursion_max_parallel_children = 2
@@ -200,4 +200,4 @@ cache = false
 tracing_enabled = false
 
 [profiles.daytona-bench-40.rlm]
-max_iterations = 40
+max_iters = 40

--- a/docs/how-to-guides/dspy-integration.md
+++ b/docs/how-to-guides/dspy-integration.md
@@ -95,9 +95,11 @@ clients cannot provide models, Signatures, or executable capabilities.
 
 ## DSPy 3.3.x ownership contract
 
-Fleet keeps the public configuration key `max_iterations`. The adapter in
-`rlm.dspy_contract` maps that key to DSPy 3.3.x's constructor parameter
-`max_iters`; no other Fleet configuration or public API uses the DSPy spelling.
+Fleet uses DSPy 3.3.x's `max_iters` spelling end-to-end. The public
+configuration key is `rlm.max_iters` (`Settings.rlm_max_iters`), and
+`RLMOptions.max_iters` is passed directly to `dspy.RLM(max_iters=...)` in
+`rlm.dspy_contract` with no adapter or alias. Policies that still set the
+legacy pre-3.3 iteration-budget key fail validation.
 Native RLM construction does not accept an interpreter. It installs a
 fail-closed `interpreter_factory` so an invocation without a caller-owned
 interpreter becomes a bounded `RLMConfigError` rather than silently creating a

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,7 +101,7 @@ typed Runtime Events projected through SSE or the terminal client.
 
 The `[rlm]` recursion settings include `recursion_enabled` and bound the native
 `rlm_query(prompt=prompt)` child harness: `recursion_max_calls`,
-`recursion_max_prompt_chars`, `recursion_child_max_iterations`,
+`recursion_max_prompt_chars`, `recursion_child_max_iters`,
 `recursion_child_max_llm_calls`, and `recursion_child_max_output_chars`.
 `recursion_max_parallel_children` bounds the number of independent child RLMs
 that Fleet may run concurrently; it defaults to `2` and is not a model-facing

--- a/scripts/benchmarks/run_native_long_context.py
+++ b/scripts/benchmarks/run_native_long_context.py
@@ -264,7 +264,7 @@ def _rlm(
     """
     rlm = RLMFactory(verbose=False).create(
         models=RLMModelBundle(root_lm=_root_lm(), sub_lm=sub_lm),
-        options=RLMOptions(max_iterations=len(codes), max_llm_calls=4, max_output_chars=2_000),
+        options=RLMOptions(max_iters=len(codes), max_llm_calls=4, max_output_chars=2_000),
         tools=tools,
         signature=NativeLongContextSignature,
     )

--- a/scripts/benchmarks/run_prime_oolong.py
+++ b/scripts/benchmarks/run_prime_oolong.py
@@ -439,14 +439,14 @@ def _active_policy_metadata(payload: Mapping[str, Any]) -> tuple[str, str, str, 
     }
     root_model = values.get("llm.root.model")
     sub_model = values.get("llm.sub.model")
-    max_iterations = values.get("rlm.max_iterations")
+    max_iters = values.get("rlm.max_iters")
     if not isinstance(root_model, str) or not root_model:
         raise PrimeOolongError("Fleet active profile does not identify the root model")
     if not isinstance(sub_model, str) or not sub_model:
         raise PrimeOolongError("Fleet active profile does not identify the Sub model")
-    if not isinstance(max_iterations, int) or isinstance(max_iterations, bool) or max_iterations < 1:
+    if not isinstance(max_iters, int) or isinstance(max_iters, bool) or max_iters < 1:
         raise PrimeOolongError("Fleet active profile does not identify the RLM iteration ceiling")
-    return profile, root_model, sub_model, max_iterations
+    return profile, root_model, sub_model, max_iters
 
 
 async def _server_policy_metadata(
@@ -462,10 +462,10 @@ async def _server_policy_metadata(
         raise PrimeOolongError("Fleet active benchmark policy could not be verified") from exc
     if not isinstance(payload, Mapping):
         raise PrimeOolongError("Fleet settings response is invalid")
-    profile, root_model, sub_model, max_iterations = _active_policy_metadata(payload)
+    profile, root_model, sub_model, max_iters = _active_policy_metadata(payload)
     if profile != expected_profile:
         raise PrimeOolongError(f"expected Fleet profile {expected_profile!r}, but the live server uses {profile!r}")
-    return profile, root_model, sub_model, max_iterations
+    return profile, root_model, sub_model, max_iters
 
 
 async def _upload_context(client: httpx.AsyncClient, context: str, context_sha256: str) -> str:

--- a/scripts/optimize/optimize_signature_omni.py
+++ b/scripts/optimize/optimize_signature_omni.py
@@ -168,7 +168,7 @@ class InProcessTurnExecutor:
             max_tokens=args.worker_max_tokens,
         )
         options = RLMOptions(
-            max_iterations=args.max_iterations,
+            max_iters=args.max_iters,
             max_llm_calls=args.max_llm_calls,
             max_output_chars=args.max_output_chars,
         )
@@ -925,7 +925,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=0.005,
         help="Pareto shaping: score penalty per REPL iteration (0 disables)",
     )
-    parser.add_argument("--max-iterations", type=int, default=20)
+    parser.add_argument("--max-iters", type=int, default=20)
     parser.add_argument("--max-llm-calls", type=int, default=50)
     parser.add_argument("--max-output-chars", type=int, default=10_000)
     parser.add_argument("--worker-max-tokens", type=int, default=8_000)

--- a/src/fleet_rlm/composition/common.py
+++ b/src/fleet_rlm/composition/common.py
@@ -99,7 +99,7 @@ def build_local_storage_adapters(
 def rlm_options(settings: Settings) -> RLMOptions:
     """Project Settings onto the exact native DSPy RLM options."""
     return RLMOptions(
-        max_iterations=settings.rlm_max_iterations,
+        max_iters=settings.rlm_max_iters,
         max_llm_calls=settings.rlm_max_llm_calls,
         max_output_chars=settings.rlm_max_output_chars,
     )
@@ -116,7 +116,7 @@ def recursive_rlm_options(settings: Settings) -> RecursiveRLMOptions:
         enabled=settings.rlm_recursion_enabled,
         max_calls=settings.rlm_recursion_max_calls,
         max_prompt_chars=settings.rlm_recursion_max_prompt_chars,
-        child_max_iterations=settings.rlm_recursion_child_max_iterations,
+        child_max_iters=settings.rlm_recursion_child_max_iters,
         child_max_llm_calls=settings.rlm_recursion_child_max_llm_calls,
         child_max_output_chars=settings.rlm_recursion_child_max_output_chars,
         max_parallel_children=settings.rlm_recursion_max_parallel_children,

--- a/src/fleet_rlm/config.py
+++ b/src/fleet_rlm/config.py
@@ -199,7 +199,7 @@ class Settings(BaseModel):
         le=8,
         description="Daytona Admission bound for process-wide acquiring or active Interpreter Leases",
     )
-    rlm_max_iterations: int = Field(default=20, gt=0)
+    rlm_max_iters: int = Field(default=20, gt=0)
     rlm_max_llm_calls: int = Field(default=50, gt=0)
     rlm_max_output_chars: int = Field(default=10_000, gt=0)
     rlm_max_execution_output_chars: int = Field(default=4_000, gt=0)
@@ -207,7 +207,7 @@ class Settings(BaseModel):
     rlm_recursion_enabled: bool = False
     rlm_recursion_max_calls: int = Field(default=4, gt=0)
     rlm_recursion_max_prompt_chars: int = Field(default=50_000, gt=0)
-    rlm_recursion_child_max_iterations: int = Field(default=8, gt=0)
+    rlm_recursion_child_max_iters: int = Field(default=8, gt=0)
     rlm_recursion_child_max_llm_calls: int = Field(default=12, gt=0)
     rlm_recursion_child_max_output_chars: int = Field(default=4_000, gt=0)
     rlm_recursion_max_parallel_children: int = Field(default=2, gt=0, le=8)
@@ -365,7 +365,7 @@ _TABLE_KEYS: dict[str, frozenset[str]] = {
     "llm": frozenset({"root", "sub"}),
     "rlm": frozenset(
         {
-            "max_iterations",
+            "max_iters",
             "max_llm_calls",
             "max_output_chars",
             "max_execution_output_chars",
@@ -373,7 +373,7 @@ _TABLE_KEYS: dict[str, frozenset[str]] = {
             "recursion_enabled",
             "recursion_max_calls",
             "recursion_max_prompt_chars",
-            "recursion_child_max_iterations",
+            "recursion_child_max_iters",
             "recursion_child_max_llm_calls",
             "recursion_child_max_output_chars",
             "recursion_max_parallel_children",
@@ -575,7 +575,7 @@ def _flatten_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
         "max_active_daytona_leases": runtime.get("max_active_daytona_leases"),
         "run_heartbeat_seconds": runtime.get("heartbeat_seconds"),
         "run_stale_after_seconds": runtime.get("stale_after_seconds"),
-        "rlm_max_iterations": rlm.get("max_iterations"),
+        "rlm_max_iters": rlm.get("max_iters"),
         "rlm_max_llm_calls": rlm.get("max_llm_calls"),
         "rlm_max_output_chars": rlm.get("max_output_chars"),
         "rlm_max_execution_output_chars": rlm.get("max_execution_output_chars"),
@@ -583,7 +583,7 @@ def _flatten_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
         "rlm_recursion_enabled": rlm.get("recursion_enabled", False),
         "rlm_recursion_max_calls": rlm.get("recursion_max_calls", 4),
         "rlm_recursion_max_prompt_chars": rlm.get("recursion_max_prompt_chars", 50_000),
-        "rlm_recursion_child_max_iterations": rlm.get("recursion_child_max_iterations", 8),
+        "rlm_recursion_child_max_iters": rlm.get("recursion_child_max_iters", 8),
         "rlm_recursion_child_max_llm_calls": rlm.get("recursion_child_max_llm_calls", 12),
         "rlm_recursion_child_max_output_chars": rlm.get("recursion_child_max_output_chars", 4_000),
         "rlm_recursion_max_parallel_children": rlm.get("recursion_max_parallel_children", 2),
@@ -940,7 +940,7 @@ def redacted_policy_summary(settings: Settings, *, profile: str) -> str:
     return (
         f"profile={profile} environment={settings.run_environment} "
         f"root_model={root.model} sub_model={sub.model} "
-        f"rlm_iterations={settings.rlm_max_iterations} "
+        f"rlm_iters={settings.rlm_max_iters} "
         f"rlm_llm_calls={settings.rlm_max_llm_calls} "
         f"rlm_verbose={settings.rlm_verbose} log_level={settings.log_level} "
         f"volume={settings.volume_name} "

--- a/src/fleet_rlm/config_policy.py
+++ b/src/fleet_rlm/config_policy.py
@@ -134,7 +134,7 @@ _FIELDS: tuple[PolicyField, ...] = (
         ("none", "low", "medium", "high"),
         settings_field="sub_llm_reasoning_effort",
     ),
-    PolicyField("rlm.max_iterations", "RLM", "Maximum iterations", "number", settings_field="rlm_max_iterations"),
+    PolicyField("rlm.max_iters", "RLM", "Maximum iterations", "number", settings_field="rlm_max_iters"),
     PolicyField("rlm.max_llm_calls", "RLM", "Maximum LLM calls", "number", settings_field="rlm_max_llm_calls"),
     PolicyField(
         "rlm.max_output_chars", "RLM", "Maximum output characters", "number", settings_field="rlm_max_output_chars"
@@ -171,11 +171,11 @@ _FIELDS: tuple[PolicyField, ...] = (
         settings_field="rlm_recursion_max_prompt_chars",
     ),
     PolicyField(
-        "rlm.recursion_child_max_iterations",
+        "rlm.recursion_child_max_iters",
         "RLM",
         "Child maximum iterations",
         "number",
-        settings_field="rlm_recursion_child_max_iterations",
+        settings_field="rlm_recursion_child_max_iters",
     ),
     PolicyField(
         "rlm.recursion_child_max_llm_calls",

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -537,7 +537,7 @@ def build_run_preparation(
 ) -> DefaultRunPreparer:
     """Compose Daytona Run preparation without mutating resource ownership."""
     options = RLMOptions(
-        max_iterations=settings.rlm_max_iterations,
+        max_iters=settings.rlm_max_iters,
         max_llm_calls=settings.rlm_max_llm_calls,
         max_output_chars=settings.rlm_max_output_chars,
     )

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -323,15 +323,19 @@ def assert_dspy_version() -> None:
 
 @dataclass(frozen=True, slots=True)
 class RLMOptions:
-    """The three execution limits owned by native ``dspy.RLM``."""
+    """The three execution limits owned by native ``dspy.RLM``.
 
-    max_iterations: int = 20
+    Field names mirror the DSPy 3.3.x constructor keyword for keyword;
+    ``max_iters`` is passed to ``dspy.RLM(max_iters=...)`` with no alias.
+    """
+
+    max_iters: int = 20
     max_llm_calls: int = 50
     max_output_chars: int = 10_000
 
     def __post_init__(self) -> None:
         for name, value in (
-            ("max_iterations", self.max_iterations),
+            ("max_iters", self.max_iters),
             ("max_llm_calls", self.max_llm_calls),
             ("max_output_chars", self.max_output_chars),
         ):
@@ -798,7 +802,7 @@ def build_native_rlm(
     """
     return dspy.RLM(
         signature,
-        max_iters=options.max_iterations,
+        max_iters=options.max_iters,
         max_llm_calls=options.max_llm_calls,
         max_output_chars=options.max_output_chars,
         verbose=verbose,

--- a/src/fleet_rlm/rlm/provider_probe.py
+++ b/src/fleet_rlm/rlm/provider_probe.py
@@ -89,7 +89,7 @@ async def probe_root_lm(
     )
     rlm = build_native_rlm(
         signature=_ProviderProbeSignature,
-        options=RLMOptions(max_iterations=4, max_llm_calls=4, max_output_chars=2_000),
+        options=RLMOptions(max_iters=4, max_llm_calls=4, max_output_chars=2_000),
         tools=[recursive.tool],
     )
     try:

--- a/src/fleet_rlm/rlm/recursive_calls.py
+++ b/src/fleet_rlm/rlm/recursive_calls.py
@@ -51,7 +51,7 @@ class RecursiveRLMOptions:
     enabled: bool = False
     max_calls: int = 4
     max_prompt_chars: int = 50_000
-    child_max_iterations: int = 8
+    child_max_iters: int = 8
     child_max_llm_calls: int = 12
     child_max_output_chars: int = 4_000
     max_parallel_children: int = 2
@@ -60,7 +60,7 @@ class RecursiveRLMOptions:
         for name, value in (
             ("max_calls", self.max_calls),
             ("max_prompt_chars", self.max_prompt_chars),
-            ("child_max_iterations", self.child_max_iterations),
+            ("child_max_iters", self.child_max_iters),
             ("child_max_llm_calls", self.child_max_llm_calls),
             ("child_max_output_chars", self.child_max_output_chars),
             ("max_parallel_children", self.max_parallel_children),
@@ -552,7 +552,7 @@ class RecursiveRLMExecutor:
         child = build_native_rlm(
             signature=RecursiveSubtaskSignature,
             options=RLMOptions(
-                max_iterations=self._options.child_max_iterations,
+                max_iters=self._options.child_max_iters,
                 max_llm_calls=self._options.child_max_llm_calls,
                 max_output_chars=self._options.child_max_output_chars,
             ),

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -768,7 +768,7 @@ class RLMRunner:
             turn_phase_span(
                 "RLM.execute",
                 inputs={
-                    "max_iterations": context.execution.options.max_iterations,
+                    "max_iters": context.execution.options.max_iters,
                     "max_llm_calls": context.execution.options.max_llm_calls,
                     "max_output_chars": context.execution.options.max_output_chars,
                 },

--- a/src/fleet_rlm/skills/bundled/dspy-rlm/references/rlm-contract.md
+++ b/src/fleet_rlm/skills/bundled/dspy-rlm/references/rlm-contract.md
@@ -48,17 +48,17 @@ independent verification in separate iterations.
 | `max_llm_calls` | 50 | Max sub-LM calls (`llm_query` / batched) |
 | `max_output_chars` | 10000 | Truncates **REPL step output** fed back into the loop (not a silent truncate of SUBMIT) |
 
-Fleet keeps the public `RLMOptions.max_iterations` configuration field and maps
-it to DSPy 3.3.x's `max_iters` constructor parameter in
-`rlm.dspy_contract`. Do not rename the Fleet field.
-
-Fleet maps these via `FLEET_RLM_MAX_ITERATIONS`, `FLEET_RLM_MAX_LLM_CALLS`, and `FLEET_RLM_MAX_OUTPUT_CHARS`.
+Fleet uses DSPy 3.3.x's `max_iters` spelling end-to-end: `RLMOptions.max_iters`,
+`Settings.rlm_max_iters`, and the TOML policy key `rlm.max_iters` are passed
+directly to `dspy.RLM(max_iters=...)` in `rlm.dspy_contract` with no alias.
+Settings resolve only from the selected TOML policy; ambient `FLEET_*`
+environment variables are ignored.
 
 ## Fleet-to-DSPy construction and ownership
 
 | Fleet surface | Fleet value | DSPy 3.3.x surface |
 |---|---|---|
-| Fleet iteration budget | `max_iterations` | `max_iters` |
+| Fleet iteration budget | `max_iters` | `max_iters` |
 | Native construction | `build_native_rlm(...)` without an interpreter | `dspy.RLM(..., interpreter_factory=...)` |
 | Native async execution | Existing caller-owned interpreter | `await rlm.acall(interpreter, **named_inputs)` |
 | Native streaming | Existing caller-owned interpreter | `stream_program(interpreter, **named_inputs)` |
@@ -87,7 +87,7 @@ keyword-only and are not routed through the native positional call contract.
   recursive history.
 - **Daytona** (primary durable path): custom interpreter, Session Workspace tools, Artifact candidates promoted on Turn Commit.
 - Recursive child calls are bounded by the policy keys `recursion_max_calls`,
-  `recursion_max_prompt_chars`, `recursion_child_max_iterations`,
+  `recursion_max_prompt_chars`, `recursion_child_max_iters`,
   `recursion_child_max_llm_calls`, and `recursion_child_max_output_chars`.
 - MLflow `RLM.*_lm` spans record recursive depth, call order, bounded context-size
   metadata, response shape, and per-call provider token usage when DSPy exposes it;

--- a/tests/contracts/backend/test_host_tool_submit_binding.py
+++ b/tests/contracts/backend/test_host_tool_submit_binding.py
@@ -56,7 +56,7 @@ def test_stock_rlm_resets_tools_registered_on_inject() -> None:
     interp._tools_registered = True
     rlm = build_native_rlm(
         signature=FleetRLMSignature,
-        options=RLMOptions(max_iterations=1),
+        options=RLMOptions(max_iters=1),
     )
     rlm._inject_execution_context(interp, {})
     assert interp._tools_registered is False

--- a/tests/contracts/backend/test_native_multi_turn_long_context.py
+++ b/tests/contracts/backend/test_native_multi_turn_long_context.py
@@ -182,7 +182,7 @@ def _rlm(
     interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
     rlm = RLMFactory().create(
         models=RLMModelBundle(root_lm=root_lm, sub_lm=sub_lm),
-        options=RLMOptions(max_iterations=len(action), max_llm_calls=4),
+        options=RLMOptions(max_iters=len(action), max_llm_calls=4),
         tools=tools,
         signature="request -> answer: str",
     )

--- a/tests/contracts/backend/test_native_rlm_tracer.py
+++ b/tests/contracts/backend/test_native_rlm_tracer.py
@@ -182,7 +182,7 @@ async def test_native_rlm_preserves_state_tools_submit_prediction_and_trajectory
     interpreter.bind_observer(observed.append, max_chars=1_000)
     rlm = RLMFactory().create(
         models=RLMModelBundle(root_lm=object(), sub_lm=object()),  # type: ignore[arg-type]
-        options=RLMOptions(max_iterations=2),
+        options=RLMOptions(max_iters=2),
         tools=(observe_tool(dspy.Tool(helper), observed.append, ToolEventView.metadata_only()),),
         signature="request -> answer",
     )
@@ -225,7 +225,7 @@ async def test_native_repl_history_and_python_state_are_isolated_per_turn() -> N
     first_interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
     first = RLMFactory().create(
         models=models,
-        options=RLMOptions(max_iterations=3),
+        options=RLMOptions(max_iters=3),
         signature="request -> answer: str",
     )
     actions = _ThreeIterationActions()
@@ -250,7 +250,7 @@ async def test_native_repl_history_and_python_state_are_isolated_per_turn() -> N
     second_interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
     second = RLMFactory().create(
         models=models,
-        options=RLMOptions(max_iterations=1),
+        options=RLMOptions(max_iters=1),
         signature="request -> answer: str",
     )
     fresh_action = _FreshTurnAction()
@@ -273,7 +273,7 @@ async def test_native_extract_fallback_receives_accumulated_repl_history() -> No
     interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
     rlm = RLMFactory().create(
         models=RLMModelBundle(root_lm=object(), sub_lm=object()),  # type: ignore[arg-type]
-        options=RLMOptions(max_iterations=2),
+        options=RLMOptions(max_iters=2),
         signature="request -> answer: str",
     )
     rlm.generate_action = _TwoIterationNoSubmit()
@@ -296,7 +296,7 @@ async def test_native_rlm_repairs_invalid_submit_and_typed_extract_fallback() ->
     repaired_interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
     repaired = RLMFactory().create(
         models=models,
-        options=RLMOptions(max_iterations=2),
+        options=RLMOptions(max_iters=2),
         signature="request -> answer: str",
     )
     repaired.generate_action = _InvalidThenValidSubmit()
@@ -305,7 +305,7 @@ async def test_native_rlm_repairs_invalid_submit_and_typed_extract_fallback() ->
     extracted_interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
     extracted = RLMFactory().create(
         models=models,
-        options=RLMOptions(max_iterations=1),
+        options=RLMOptions(max_iters=1),
         signature="request -> answer: str",
     )
     extracted.generate_action = _NeverSubmit()
@@ -334,7 +334,7 @@ async def test_native_rlm_rejects_invalid_host_tool_type_before_host_logic() -> 
     interpreter.bind_observer(observed.append, max_chars=1_000)
     rlm = RLMFactory().create(
         models=RLMModelBundle(root_lm=object(), sub_lm=object()),  # type: ignore[arg-type]
-        options=RLMOptions(max_iterations=2),
+        options=RLMOptions(max_iters=2),
         tools=(observe_tool(dspy.Tool(helper), observed.append, ToolEventView.metadata_only()),),
         signature="request -> answer: str",
     )
@@ -383,7 +383,7 @@ async def test_runner_completes_native_repair_and_extract_as_prediction_result(f
     async def not_cancelled() -> bool:
         return False
 
-    options = RLMOptions(max_iterations=1 if fallback else 2)
+    options = RLMOptions(max_iters=1 if fallback else 2)
     context = RLMExecutionContext(
         identity=RunIdentity(run_id=uuid4(), session_id=uuid4(), access=TurnAccess(uuid4(), uuid4())),
         session=SessionView(

--- a/tests/contracts/backend/test_rlm_history_retrieval.py
+++ b/tests/contracts/backend/test_rlm_history_retrieval.py
@@ -87,7 +87,7 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
         ),
         execution=ExecutionRuntime(
             models=SimpleNamespace(root_lm=object(), sub_lm=object()),
-            options=RLMOptions(max_iterations=1),
+            options=RLMOptions(max_iters=1),
             deadline=asyncio.get_running_loop().time() + 10,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,
@@ -186,7 +186,7 @@ async def test_native_rlm_continues_history_across_truncated_pages() -> None:
         ),
         execution=ExecutionRuntime(
             models=SimpleNamespace(root_lm=object(), sub_lm=object()),
-            options=RLMOptions(max_iterations=1),
+            options=RLMOptions(max_iters=1),
             deadline=asyncio.get_running_loop().time() + 10,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,

--- a/tests/contracts/backend/test_settings_api.py
+++ b/tests/contracts/backend/test_settings_api.py
@@ -39,7 +39,7 @@ def test_settings_policy_is_loopback_only_and_revision_checked(monkeypatch, tmp_
             json={
                 "revision": body["revision"],
                 "scope": "defaults",
-                "path": "rlm.max_iterations",
+                "path": "rlm.max_iters",
                 "value": 21,
             },
         )
@@ -51,7 +51,7 @@ def test_settings_policy_is_loopback_only_and_revision_checked(monkeypatch, tmp_
             json={
                 "revision": body["revision"],
                 "scope": "defaults",
-                "path": "rlm.max_iterations",
+                "path": "rlm.max_iters",
                 "value": 22,
             },
         )

--- a/tests/live/backend/test_daytona_cancel_during_execution.py
+++ b/tests/live/backend/test_daytona_cancel_during_execution.py
@@ -34,7 +34,7 @@ def _case_settings(tmp_path: Path) -> Settings:
     return _live_settings(tmp_path).model_copy(
         update={
             "volume_name": f"fleet-rlm-live-cancel-{uuid4()}",
-            "rlm_max_iterations": 4,
+            "rlm_max_iters": 4,
             "rlm_max_llm_calls": 6,
             "turn_timeout_seconds": 300,
             "run_stale_after_seconds": 600,

--- a/tests/live/backend/test_daytona_deadline_cleanup.py
+++ b/tests/live/backend/test_daytona_deadline_cleanup.py
@@ -55,7 +55,7 @@ def _case_settings(tmp_path: Path) -> Settings:
     return _live_settings(tmp_path).model_copy(
         update={
             "volume_name": f"fleet-rlm-live-deadline-{uuid4()}",
-            "rlm_max_iterations": 4,
+            "rlm_max_iters": 4,
             "rlm_max_llm_calls": 6,
             "turn_timeout_seconds": _TURN_TIMEOUT_SECONDS,
             "run_stale_after_seconds": 600,

--- a/tests/live/backend/test_daytona_recursive_batch.py
+++ b/tests/live/backend/test_daytona_recursive_batch.py
@@ -135,7 +135,7 @@ def _load_live_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Sett
         update={
             "database_url": database_url,
             "volume_name": f"fleet-rlm-recursive-batch-{uuid4()}",
-            "rlm_max_iterations": 8,
+            "rlm_max_iters": 8,
             "rlm_max_llm_calls": 14,
             "turn_timeout_seconds": 900,
             # Daytona Root + two child sandboxes can exceed the default 60s claim

--- a/tests/live/backend/test_fleet_rlm_daytona_mvp.py
+++ b/tests/live/backend/test_fleet_rlm_daytona_mvp.py
@@ -182,7 +182,7 @@ def _live_settings(tmp_path: Path) -> Settings:
         update={
             "database_url": database_url,
             "volume_name": f"fleet-rlm-live-mvp-{uuid4()}",
-            "rlm_max_iterations": 8,
+            "rlm_max_iters": 8,
             "rlm_max_llm_calls": 12,
             "turn_timeout_seconds": 840,
             # Live product evidence is RuntimeEvents → SSE → TUI. Keep optional
@@ -567,7 +567,7 @@ async def _replace_binding(resources: Any, binding: SandboxBinding) -> SandboxBi
 def test_direct_pi_digit_uses_deterministic_repl_without_optional_capabilities(tmp_path: Path) -> None:
     settings = _live_settings(tmp_path).model_copy(
         update={
-            "rlm_max_iterations": 3,
+            "rlm_max_iters": 3,
             "turn_timeout_seconds": 840,
         }
     )

--- a/tests/live/backend/test_memory_candidate_live.py
+++ b/tests/live/backend/test_memory_candidate_live.py
@@ -150,7 +150,7 @@ def _live_qre140_settings(tmp_path: Path) -> Settings:
     settings = _live_settings(tmp_path).model_copy(
         update={
             "rlm_autonomous_memory_categories": ("operator preference",),
-            "rlm_max_iterations": 4,
+            "rlm_max_iters": 4,
             "rlm_max_llm_calls": 8,
             "rlm_execution_timeout_s": 560,
             "turn_timeout_seconds": 560,

--- a/tests/live/backend/test_memory_semantics_live.py
+++ b/tests/live/backend/test_memory_semantics_live.py
@@ -350,9 +350,7 @@ def _skill_events(chunks: list[dict[str, Any]], skill_id: str) -> list[dict[str,
 
 
 def test_live_old_relevant_memory_recovered_beyond_tail_window(tmp_path: Path) -> None:
-    settings = _case_settings(
-        tmp_path, "relevance", rlm_max_iterations=4, rlm_max_llm_calls=6, turn_timeout_seconds=560
-    )
+    settings = _case_settings(tmp_path, "relevance", rlm_max_iters=4, rlm_max_llm_calls=6, turn_timeout_seconds=560)
     ledger = _CaptureLedger()
     started = time.perf_counter()
     with _QRE142Runner(settings) as run:
@@ -442,7 +440,7 @@ def test_live_provenance_and_supersession_through_promotion(tmp_path: Path) -> N
         tmp_path,
         "supersession",
         rlm_autonomous_memory_categories=("operator preference",),
-        rlm_max_iterations=6,
+        rlm_max_iters=6,
         rlm_max_llm_calls=8,
         turn_timeout_seconds=560,
     )
@@ -539,7 +537,7 @@ def test_live_memory_candidates_default_off_and_mlflow_fail_soft(
     settings = _case_settings(
         tmp_path,
         "default-off",
-        rlm_max_iterations=3,
+        rlm_max_iters=3,
         rlm_max_llm_calls=4,
         turn_timeout_seconds=560,
         mlflow_tracing_enabled=True,
@@ -591,7 +589,7 @@ def test_live_failed_run_discards_memory_candidates(tmp_path: Path) -> None:
         tmp_path,
         "failed-run",
         rlm_autonomous_memory_categories=("operator preference",),
-        rlm_max_iterations=8,
+        rlm_max_iters=8,
         rlm_max_llm_calls=8,
         turn_timeout_seconds=180,
         rlm_execution_timeout_s=280,
@@ -636,7 +634,7 @@ def test_live_failed_run_discards_memory_candidates(tmp_path: Path) -> None:
 
 def test_live_skill_consumes_declared_resource_with_truthful_card(tmp_path: Path) -> None:
     settings = _case_settings(
-        tmp_path, "skill-resource", rlm_max_iterations=4, rlm_max_llm_calls=6, turn_timeout_seconds=560
+        tmp_path, "skill-resource", rlm_max_iters=4, rlm_max_llm_calls=6, turn_timeout_seconds=560
     )
     ledger = _CaptureLedger()
     started = time.perf_counter()
@@ -691,7 +689,7 @@ def test_live_skill_consumes_declared_resource_with_truthful_card(tmp_path: Path
 
 def test_live_custom_signature_skill_coexistence(tmp_path: Path) -> None:
     settings = _case_settings(
-        tmp_path, "custom-signature", rlm_max_iterations=4, rlm_max_llm_calls=6, turn_timeout_seconds=560
+        tmp_path, "custom-signature", rlm_max_iters=4, rlm_max_llm_calls=6, turn_timeout_seconds=560
     )
     ledger = _CaptureLedger()
     started = time.perf_counter()

--- a/tests/live/backend/test_phase1_daytona_stream.py
+++ b/tests/live/backend/test_phase1_daytona_stream.py
@@ -206,7 +206,7 @@ def _load_live_settings(tmp_path: Path) -> Settings:
         update={
             "database_url": database_url,
             "volume_name": f"fleet-rlm-phase1-stream-{uuid4()}",
-            "rlm_max_iterations": 5,
+            "rlm_max_iters": 5,
             "rlm_max_llm_calls": 8,
             "turn_timeout_seconds": 840,
         }

--- a/tests/live/backend/test_phase2_daytona_recursive.py
+++ b/tests/live/backend/test_phase2_daytona_recursive.py
@@ -157,7 +157,7 @@ def _load_live_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Sett
         update={
             "database_url": database_url,
             "volume_name": f"fleet-rlm-phase2-recursive-{uuid4()}",
-            "rlm_max_iterations": 7,
+            "rlm_max_iters": 7,
             "rlm_max_llm_calls": 10,
             "turn_timeout_seconds": 900,
         }

--- a/tests/unit/backend/daytona/test_optimization_evaluator.py
+++ b/tests/unit/backend/daytona/test_optimization_evaluator.py
@@ -265,7 +265,7 @@ def _lifecycle(factory: _LifecycleFactory, proof: object) -> StrictDaytonaEvalua
         policy=OptimizationSandboxPolicy("fleet-test-v1", ("gateway.example.test",)),
         proof=proof,
         models=StrictEvaluationModels(root_lm=object(), sub_lm=object()),  # type: ignore[arg-type]
-        options=RLMOptions(max_iterations=2, max_llm_calls=3, max_output_chars=100),
+        options=RLMOptions(max_iters=2, max_llm_calls=3, max_output_chars=100),
     )
 
 
@@ -295,7 +295,7 @@ def test_lifecycle_rejects_proof_for_a_different_domain_policy() -> None:
             policy=OptimizationSandboxPolicy("fleet-test-v1", ("other-gateway.example.test",)),
             proof=_proof(),
             models=StrictEvaluationModels(root_lm=object(), sub_lm=object()),  # type: ignore[arg-type]
-            options=RLMOptions(max_iterations=2, max_llm_calls=3, max_output_chars=100),
+            options=RLMOptions(max_iters=2, max_llm_calls=3, max_output_chars=100),
         )
 
     assert events == []

--- a/tests/unit/backend/rlm/test_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_contract.py
@@ -173,7 +173,7 @@ def test_rlm_options_match_the_product_defaults() -> None:
     from fleet_rlm.rlm.dspy_contract import RLMOptions
 
     assert RLMOptions() == RLMOptions(
-        max_iterations=20,
+        max_iters=20,
         max_llm_calls=50,
         max_output_chars=10_000,
     )
@@ -189,7 +189,7 @@ def test_build_native_rlm_preserves_exact_public_constructor_inputs() -> None:
     sub_lm = object()
     kwargs: dict[str, Any] = {
         "signature": TaskSignature,
-        "options": RLMOptions(max_iterations=7, max_llm_calls=11, max_output_chars=2048),
+        "options": RLMOptions(max_iters=7, max_llm_calls=11, max_output_chars=2048),
         "tools": [_lookup],
         "sub_lm": sub_lm,
     }
@@ -215,7 +215,7 @@ def test_build_native_rlm_fails_closed_without_a_caller_owned_interpreter() -> N
     from fleet_rlm.rlm.dspy_contract import RLMOptions, build_native_rlm
     from fleet_rlm.rlm.errors import RLMConfigError
 
-    rlm = build_native_rlm(signature="request -> answer", options=RLMOptions(max_iterations=1))
+    rlm = build_native_rlm(signature="request -> answer", options=RLMOptions(max_iters=1))
 
     with pytest.raises(RLMConfigError, match="caller-owned interpreter"):
         rlm(request="missing interpreter")
@@ -238,7 +238,7 @@ async def test_native_json_action_contract_parses_first_and_followup_iterations(
     )
     rlm = build_native_rlm(
         signature="request -> answer",
-        options=RLMOptions(max_iterations=2),
+        options=RLMOptions(max_iters=2),
         sub_lm=lm,
         verbose=False,
     )
@@ -307,7 +307,7 @@ async def test_native_rlm_callback_observes_completed_action_without_altering_pr
     interpreter = Interpreter()
     rlm = build_native_rlm(
         signature=TaskSignature,
-        options=RLMOptions(max_iterations=1),
+        options=RLMOptions(max_iters=1),
     )
     rlm.generate_action = Action()
     bind_native_rlm_observer(rlm, observed.append, max_chars=64)

--- a/tests/unit/backend/rlm/test_recursive_runner_flow.py
+++ b/tests/unit/backend/rlm/test_recursive_runner_flow.py
@@ -66,7 +66,7 @@ async def test_root_child_root_flow_preserves_parent_repl_and_typed_submit() -> 
         ),
         execution=ExecutionRuntime(
             models=RLMModelBundle(root, sub),
-            options=RLMOptions(max_iterations=4, max_llm_calls=4),
+            options=RLMOptions(max_iters=4, max_llm_calls=4),
             deadline=time.monotonic() + 30,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,
@@ -170,7 +170,7 @@ async def test_runner_rejects_recursive_tool_after_authority_revocation() -> Non
         ),
         execution=ExecutionRuntime(
             models=RLMModelBundle(root, sub),
-            options=RLMOptions(max_iterations=2, max_llm_calls=2),
+            options=RLMOptions(max_iters=2, max_llm_calls=2),
             deadline=time.monotonic() + 30,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,
@@ -225,7 +225,7 @@ async def test_normal_daytona_policy_omits_recursive_tool_and_guidance() -> None
         ),
         execution=ExecutionRuntime(
             models=RLMModelBundle(root, sub),
-            options=RLMOptions(max_iterations=2, max_llm_calls=2),
+            options=RLMOptions(max_iters=2, max_llm_calls=2),
             deadline=time.monotonic() + 30,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,
@@ -293,7 +293,7 @@ async def test_failed_child_cleanup_prevents_successful_root_outcome() -> None:
         ),
         execution=ExecutionRuntime(
             models=RLMModelBundle(root, sub),
-            options=RLMOptions(max_iterations=4, max_llm_calls=4),
+            options=RLMOptions(max_iters=4, max_llm_calls=4),
             deadline=time.monotonic() + 30,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,
@@ -367,7 +367,7 @@ async def test_runner_wait_owned_retains_pending_recursive_workers_until_child_l
         ),
         execution=ExecutionRuntime(
             models=RLMModelBundle(root, sub),
-            options=RLMOptions(max_iterations=4, max_llm_calls=4),
+            options=RLMOptions(max_iters=4, max_llm_calls=4),
             deadline=time.monotonic() + 0.15,
             interpreter=DaytonaCodeInterpreter(backend=InProcessInterpreterBackend()),
             cancellation_requested=not_cancelled,

--- a/tests/unit/backend/rlm/test_runner_execution.py
+++ b/tests/unit/backend/rlm/test_runner_execution.py
@@ -296,7 +296,7 @@ async def test_runner_uses_supported_async_call_and_returns_typed_outcome(
         (
             "RLM.execute",
             {
-                "max_iterations": context.execution.options.max_iterations,
+                "max_iters": context.execution.options.max_iters,
                 "max_llm_calls": context.execution.options.max_llm_calls,
                 "max_output_chars": context.execution.options.max_output_chars,
             },

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -323,7 +323,7 @@ def test_daytona_benchmark_profiles_use_compatible_models_without_cache_or_mlflo
             assert "reasoning_effort" not in llm
 
     assert document["profiles"]["daytona-bench"]["rlm"] == {"verbose": False}
-    assert document["profiles"]["daytona-bench-40"]["rlm"] == {"max_iterations": 40}
+    assert document["profiles"]["daytona-bench-40"]["rlm"] == {"max_iters": 40}
 
 
 def _select_profile(tmp_path: Path, *, profile: str, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -370,7 +370,7 @@ def test_daytona_benchmark_profiles_resolve_without_mlflow(
     assert settings.daytona_snapshot == "fleet-rlm-python313-v5"
     assert settings.root_llm_cache is False
     assert settings.sub_llm_cache is False
-    assert settings.rlm_max_iterations == iterations
+    assert settings.rlm_max_iters == iterations
     assert settings.mlflow_tracing_enabled is False
 
 
@@ -411,7 +411,7 @@ cache = false
 num_retries = 4
 temperature = 0.2
 [defaults.rlm]
-max_iterations = 3
+max_iters = 3
 max_llm_calls = 4
 max_output_chars = 500
 max_execution_output_chars = 250
@@ -451,7 +451,7 @@ def test_runtime_settings_deep_merge_profile_and_keep_role_policy(
 
     assert settings.run_environment == "daytona"
     assert settings.live_enabled is True
-    assert settings.rlm_max_iterations == 3
+    assert settings.rlm_max_iters == 3
     assert settings.max_url_bytes == 30
     assert settings.root_lm.model == "openai/root"
     assert settings.sub_lm.temperature == 0.2
@@ -510,7 +510,7 @@ def test_runtime_settings_ignores_stale_environment_policy_overrides(
     settings = config.load_runtime_settings()
 
     assert settings.root_model == "openai/root"
-    assert settings.rlm_max_iterations == 3
+    assert settings.rlm_max_iters == 3
 
 
 def test_runtime_settings_resolves_only_toml_declared_environment_values(

--- a/tests/unit/backend/test_config_policy.py
+++ b/tests/unit/backend/test_config_policy.py
@@ -58,16 +58,16 @@ def test_policy_update_preserves_comments_and_validates_all_profiles(tmp_path: P
 
     after = service.update(
         scope="defaults",
-        path="rlm.max_iterations",
+        path="rlm.max_iters",
         value=21,
         revision=before.revision,
     )
 
-    assert _field(after, "defaults", "rlm.max_iterations")["value"] == 21
+    assert _field(after, "defaults", "rlm.max_iters")["value"] == 21
     content = policy.read_text(encoding="utf-8")
     assert "# Prime Oolong mechanics profile" in content
-    assert "max_iterations = 21" in content
-    assert _field(after, "daytona", "rlm.max_iterations")["value"] == 21
+    assert "max_iters = 21" in content
+    assert _field(after, "daytona", "rlm.max_iters")["value"] == 21
 
 
 def test_policy_can_add_a_profile_override_for_an_inherited_setting(tmp_path: Path) -> None:
@@ -76,13 +76,13 @@ def test_policy_can_add_a_profile_override_for_an_inherited_setting(tmp_path: Pa
 
     service.update(
         scope="daytona-bench",
-        path="rlm.max_iterations",
+        path="rlm.max_iters",
         value=12,
         revision=before.revision,
     )
 
     assert "[profiles.daytona-bench.rlm]" in policy.read_text(encoding="utf-8")
-    assert _field(service.read(), "daytona-bench", "rlm.max_iterations")["value"] == 12
+    assert _field(service.read(), "daytona-bench", "rlm.max_iters")["value"] == 12
 
 
 def test_policy_can_disable_live_execution_for_all_profiles(tmp_path: Path) -> None:
@@ -103,10 +103,10 @@ def test_policy_can_disable_live_execution_for_all_profiles(tmp_path: Path) -> N
 def test_policy_rejects_stale_revision_and_invalid_database_environment_reference(tmp_path: Path) -> None:
     service, _ = _service(tmp_path)
     before = service.read()
-    service.update(scope="defaults", path="rlm.max_iterations", value=21, revision=before.revision)
+    service.update(scope="defaults", path="rlm.max_iters", value=21, revision=before.revision)
 
     with pytest.raises(PolicyConflictError):
-        service.update(scope="defaults", path="rlm.max_iterations", value=22, revision=before.revision)
+        service.update(scope="defaults", path="rlm.max_iters", value=22, revision=before.revision)
 
     current = service.read()
     with pytest.raises(FleetConfigurationError, match="uppercase environment variable"):

--- a/tests/unit/backend/test_rlm_factory.py
+++ b/tests/unit/backend/test_rlm_factory.py
@@ -95,7 +95,7 @@ def test_invalid_options_fail_before_construction() -> None:
     from fleet_rlm.rlm.errors import RLMConfigError
 
     with pytest.raises(RLMConfigError):
-        RLMOptions(max_iterations=0)
+        RLMOptions(max_iters=0)
     with pytest.raises(RLMConfigError):
         RLMOptions(max_llm_calls=-1)
     with pytest.raises(RLMConfigError):
@@ -113,7 +113,7 @@ def test_factory_passes_explicit_constructor_kwargs() -> None:
     root = MagicMock(name="root_lm")
     sub = MagicMock(name="sub_lm")
     options = RLMOptions(
-        max_iterations=7,
+        max_iters=7,
         max_llm_calls=11,
         max_output_chars=2048,
     )

--- a/tests/unit/backend/test_rlm_options.py
+++ b/tests/unit/backend/test_rlm_options.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.parametrize("field", ["max_iterations", "max_llm_calls", "max_output_chars"])
+@pytest.mark.parametrize("field", ["max_iters", "max_llm_calls", "max_output_chars"])
 def test_rlm_options_reject_nonpositive_values(field: str) -> None:
     from fleet_rlm.rlm.dspy_contract import RLMOptions
 

--- a/tests/unit/backend/test_skill_catalog.py
+++ b/tests/unit/backend/test_skill_catalog.py
@@ -40,8 +40,8 @@ def test_dspy_rlm_skill_defines_recursive_not_retrieval_language_model() -> None
     assert "Turn output is too large" in resource.content
     assert "active Fleet Signature" in resource.content
     assert "every required output field" in resource.content
-    assert "`max_iterations`" in resource.content
-    assert "| Fleet iteration budget | `max_iterations` | `max_iters` |" in resource.content
+    assert "`max_iters`" in resource.content
+    assert "| Fleet iteration budget | `max_iters` | `max_iters` |" in resource.content
     assert "caller-owned interpreter" in resource.content
     assert '["skill_markdown"]' in skill.instructions
     assert '["content"]' in skill.instructions

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -438,11 +438,11 @@ def test_annotate_trace_io_marks_root_span_error_when_failed(monkeypatch: pytest
 def test_turn_phase_span_records_bounded_metadata_when_a_turn_span_is_active(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = _install_fake_mlflow(monkeypatch)
 
-    with turn_phase_span("RLM.execute", inputs={"max_iterations": 20, "max_llm_calls": 50}):
+    with turn_phase_span("RLM.execute", inputs={"max_iters": 20, "max_llm_calls": 50}):
         pass
 
     assert calls.start_span_names == ["RLM.execute"]
-    assert calls.span_inputs[-1] == {"max_iterations": 20, "max_llm_calls": 50}
+    assert calls.span_inputs[-1] == {"max_iters": 20, "max_llm_calls": 50}
     assert calls.span_outputs[-1] == {"phase_status": "completed"}
 
 
@@ -505,7 +505,7 @@ def test_turn_phase_span_setup_failure_is_soft(monkeypatch: pytest.MonkeyPatch) 
     _install_fake_mlflow(monkeypatch, explode=True)
     executed = False
 
-    with turn_phase_span("RLM.execute", inputs={"max_iterations": 20}):
+    with turn_phase_span("RLM.execute", inputs={"max_iters": 20}):
         executed = True
 
     assert executed

--- a/tests/unit/scripts/test_run_prime_oolong.py
+++ b/tests/unit/scripts/test_run_prime_oolong.py
@@ -403,7 +403,7 @@ class _Client:
                         "fields": [
                             {"path": "llm.root.model", "value": "model"},
                             {"path": "llm.sub.model", "value": "sub-model"},
-                            {"path": "rlm.max_iterations", "value": 20},
+                            {"path": "rlm.max_iters", "value": 20},
                         ],
                     }
                 ],

--- a/tools/fleet-tui/src/tests/fleet-api-client.test.ts
+++ b/tools/fleet-tui/src/tests/fleet-api-client.test.ts
@@ -274,7 +274,7 @@ describe("FleetApiClient", () => {
     await client.updateSettings({
       revision: "a".repeat(64),
       scope: "defaults",
-      path: "rlm.max_iterations",
+      path: "rlm.max_iters",
       value: 21,
     });
 
@@ -291,7 +291,7 @@ describe("FleetApiClient", () => {
         body: JSON.stringify({
           revision: "a".repeat(64),
           scope: "defaults",
-          path: "rlm.max_iterations",
+          path: "rlm.max_iters",
           value: 21,
         }),
       }),


### PR DESCRIPTION
## Summary

Removes the legacy `max_iterations` identifier across the runtime, policy, scripts, docs, and tests so Fleet and the pinned DSPy 3.3.0 constructor share one spelling.

- `RLMOptions.max_iters` passes verbatim to `dspy.RLM(max_iters=...)` (adapter layer removed)
- Settings: `rlm_max_iters` / `rlm_recursion_child_max_iters`
- TOML keys: `rlm.max_iters` / `rlm.recursion_child_max_iters` (config/fleet.toml updated)
- Settings-API paths and the MLflow `RLM.execute` span input key renamed
- `optimize_signature_omni.py` CLI flag `--max-iterations` → `--max-iters`
- Docs, bundled dspy-rlm skill reference, AGENTS.md, CHANGELOG updated

## Behavior

No behavior change; budgets are unchanged. Policies using the old key fail validation. The seam-lock assertion in `tests/contracts/backend/test_dspy_rlm_constructor.py` intentionally keeps the negative check that DSPy 3.3.x has no `max_iterations` parameter.

## Validation

- `make check` (backend pytest lane, ruff, TUI biome/lint/typecheck/vitest, api-check, codebase-tree, profile-matrix, docs-quality, harness-engineering)
- `git diff --check` clean