### PR TITLE
docs: retarget Codex Cloud delivery base to origin/main

### DIFF
--- a/.codex/cloud-preflight.zsh
+++ b/.codex/cloud-preflight.zsh
@@ -5,6 +5,10 @@ repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$repo_root"
 
 branch="$(git branch --show-current)"
+if [[ -z "$branch" ]]; then
+  echo "ERROR: Unable to determine current branch (detached HEAD?); use a feature branch based on origin/main." >&2
+  exit 1
+fi
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "ERROR: Codex Cloud must not run from $branch; use a feature branch based on origin/main." >&2
   exit 1

--- a/.codex/cloud-preflight.zsh
+++ b/.codex/cloud-preflight.zsh
@@ -6,21 +6,21 @@ cd "$repo_root"
 
 branch="$(git branch --show-current)"
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
-  echo "ERROR: Codex Cloud must not run from $branch; use dev-0.7." >&2
+  echo "ERROR: Codex Cloud must not run from $branch; use a feature branch based on origin/main." >&2
   exit 1
 fi
 
-if ! git show-ref --verify --quiet refs/remotes/origin/dev-0.7; then
-  echo "ERROR: origin/dev-0.7 is unavailable; cannot verify the Cloud base." >&2
+if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+  echo "ERROR: origin/main is unavailable; cannot verify the Cloud base." >&2
   exit 1
 fi
 
-if ! git merge-base --is-ancestor origin/dev-0.7 HEAD; then
-  echo "ERROR: HEAD is not based on origin/dev-0.7." >&2
+if ! git merge-base --is-ancestor origin/main HEAD; then
+  echo "ERROR: HEAD is not based on origin/main." >&2
   exit 1
 fi
 
-echo "Codex Cloud branch guard: current=$branch base=origin/dev-0.7"
+echo "Codex Cloud branch guard: current=$branch base=origin/main"
 git status --short --branch --untracked-files=all
 
 if (( $# == 0 )); then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - Do not hand-edit generated/synced artifacts; use the commands listed below.
 - Do not mutate user-level Codex config. Ask before deploy, push, migrations, or deletion.
 
-For the current Codex Cloud delivery sequence, use `dev-0.7` as the base branch and never use `main` or `master`. Cloud tasks may use limited internet and explicitly authorized apps/connectors; keep credentials and tokens out of the repository.
+For the current delivery sequence, base all work on `origin/main`; `main` is a protected branch whose required status checks reject direct pushes, so land changes through pull requests into `main` and never push to `main` or `master` directly. Cloud tasks may use limited internet and explicitly authorized apps/connectors; keep credentials and tokens out of the repository.
 
 ## Reading Path
 

--- a/docs/agent-harness/feedback-loop.md
+++ b/docs/agent-harness/feedback-loop.md
@@ -13,8 +13,10 @@ The safe loop requires no live Daytona or LLM credentials.
 
 ## Codex Cloud Loop
 
-Cloud tasks for this repository start from `dev-0.7`; never select `main` or
-`master`. The environment setup script is
+Cloud tasks for this repository start from a feature branch based on
+`origin/main`; never run directly on `main` or `master` — the protected
+branch rejects direct pushes, so changes land through pull requests into
+`main`. The environment setup script is
 `.codex/workspace-bootstrap.zsh`, and cached-container resumes use
 `.codex/maintenance.zsh`. Both scripts install the locked Python and TUI
 dependencies and enforce the branch guard.


### PR DESCRIPTION
## Summary

Replaces the dev-0.7-based delivery guidance with the protected-main workflow:

- `AGENTS.md`: base all work on `origin/main`; land changes through PRs into `main` (protected branch, direct pushes rejected); never push to `main`/`master` directly
- `docs/agent-harness/feedback-loop.md`: Cloud loop starts from a feature branch based on `origin/main`
- `.codex/cloud-preflight.zsh`: branch guard now verifies `origin/main` as the Cloud base

## Validation

- Root AGENTS.md stays at 150 lines (harness budget), `check_harness_engineering.py` passes
- Preflight passes from a feature branch based on `origin/main`; zsh syntax clean
- Docs quality checks pass