### PR TITLE
Add Python 3.13 compatibility CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,4 +264,9 @@ workflows:
           python_version: "3.12"
           python_tag: "py312"
           image: cimg/python:3.12.11
+      - python-compat:
+          name: python-compat-313
+          python_version: "3.13"
+          python_tag: "py313"
+          image: cimg/python:3.13.13
       - tui


### PR DESCRIPTION
## Summary

Add an explicit Python 3.13 compatibility job to the CircleCI matrix while preserving the existing full Python 3.13 quality, test, and coverage gates.

## Changes

- Add `python-compat-313` using `cimg/python:3.13.13`.
- Reuse the existing parameterized compatibility job.
- Leave `.circleci/test-suites.yml` unchanged.
- Keep the change limited to CircleCI workflow configuration.

## Validation

- `circleci config validate .circleci/config.yml`
- `circleci config process .circleci/config.yml`
- Python 3.13 import checks passed.
- Python 3.13 backend unit and contract tests passed.
- `git diff --check` passed.