### PR TITLE
Add opt-in CircleCI PyPI deployment workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2.1
 
+parameters:
+  deploy_pypi:
+    type: boolean
+    default: false
+  release_version:
+    type: string
+    default: ""
+
 executors:
   python:
     docker:
@@ -181,6 +189,48 @@ jobs:
           path: .scratch/coverage
           destination: coverage/daytona
 
+  # Opt-in deployment bridge for the existing GitHub Actions PyPI release.
+  # Configure GITHUB_TOKEN in a CircleCI project/context with actions:write.
+  deploy-pypi:
+    executor: python
+    resource_class: small
+    steps:
+      - checkout
+      - install_uv
+      - run:
+          name: Validate PyPI deploy inputs
+          command: |
+            test -n "<< pipeline.parameters.release_version >>" || {
+              echo "release_version must be supplied when enabling deploy_pypi" >&2
+              exit 1
+            }
+            test -n "${GITHUB_TOKEN:-}" || {
+              echo "GITHUB_TOKEN must be configured in the CircleCI project or context" >&2
+              exit 1
+            }
+      - run:
+          name: Plan a PyPI deploy
+          command: |
+            circleci run release plan \
+              --environment-name="pypi" \
+              --component-name="fleet-rlm" \
+              --target-version="<< pipeline.parameters.release_version >>"
+      - run:
+          name: Trigger and wait for GitHub Actions release
+          no_output_timeout: 45m
+          command: |
+            uv run python scripts/circleci_trigger_release.py \
+              --version="<< pipeline.parameters.release_version >>" \
+              --ref=main
+      - run:
+          name: Update deploy to SUCCESS
+          command: circleci run release update --status=SUCCESS
+          when: on_success
+      - run:
+          name: Update planned deploy to FAILED
+          command: circleci run release update --status=FAILED
+          when: on_fail
+
   python-compat:
     parameters:
       python_version:
@@ -265,3 +315,11 @@ workflows:
           python_tag: "py312"
           image: cimg/python:3.12.11
       - tui
+
+  deploy-pypi:
+    when: << pipeline.parameters.deploy_pypi >>
+    jobs:
+      - deploy-pypi:
+          filters:
+            branches:
+              only: main

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,7 @@
 | `daytona_snapshot.py` | Explicitly create or check the immutable Fleet Daytona Snapshot |
 | `codex_feedback_loop.py` | Run the local Codex feedback-loop probes |
 | `deployment_observability.py` | Inspect deployment observability inputs |
+| `circleci_trigger_release.py` | Trigger and await the GitHub Actions PyPI release from CircleCI |
 | `validate_mlflow_tracing.py` | Emit and validate a local or Managed Databricks trace using the selected Fleet TOML policy |
 | `benchmarks/rlm_eval_dataset.py` | Manage the UC-backed v2 evaluation dataset (static records + tagged production traces with expectations) |
 | `benchmarks/enable_monitoring.py` | Start, inspect, and stop server-side production monitoring scorers over UC-ingested traces |

--- a/scripts/circleci_trigger_release.py
+++ b/scripts/circleci_trigger_release.py
@@ -1,0 +1,143 @@
+"""Trigger and await the repository's GitHub Actions PyPI release workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+class ReleaseTriggerError(RuntimeError):
+    """Raised when the GitHub release workflow cannot be dispatched or completed."""
+
+
+def _request_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(url, data=data, headers=headers, method=method)
+    try:
+        with urlopen(request, timeout=30) as response:
+            body = response.read()
+            decoded = json.loads(body) if body else {}
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        status = getattr(exc, "code", "unavailable")
+        raise ReleaseTriggerError(f"GitHub API request failed with HTTP {status}") from exc
+
+    if not isinstance(decoded, dict):
+        raise ReleaseTriggerError("GitHub API returned an unexpected response")
+    return response.status, decoded
+
+
+def _repository(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    owner = os.getenv("CIRCLE_PROJECT_USERNAME", "").strip()
+    name = os.getenv("CIRCLE_PROJECT_REPONAME", "").strip()
+    if not owner or not name:
+        raise ReleaseTriggerError("CircleCI repository metadata is unavailable")
+    return f"{owner}/{name}"
+
+
+def _find_run(
+    *,
+    api_root: str,
+    headers: dict[str, str],
+    ref: str,
+    started_at: float,
+    deadline: float,
+) -> dict[str, Any]:
+    url = f"{api_root}/actions/workflows/release.yml/runs?event=workflow_dispatch&branch={ref}&per_page=20"
+    while time.time() < deadline:
+        _, payload = _request_json(url, headers=headers)
+        candidates = []
+        for run in payload.get("workflow_runs", []):
+            if not isinstance(run, dict) or "created_at" not in run:
+                continue
+            created_at = datetime.fromisoformat(str(run["created_at"]).replace("Z", "+00:00"))
+            if created_at.timestamp() >= started_at - 10:
+                candidates.append(run)
+        if candidates:
+            return max(candidates, key=lambda run: int(run["id"]))
+        time.sleep(10)
+    raise ReleaseTriggerError("timed out waiting for the dispatched GitHub release run")
+
+
+def _wait_for_run(*, api_root: str, headers: dict[str, str], run: dict[str, Any], deadline: float) -> None:
+    url = f"{api_root}/actions/runs/{run['id']}"
+    while time.time() < deadline:
+        _, payload = _request_json(url, headers=headers)
+        status = payload.get("status")
+        conclusion = payload.get("conclusion")
+        print(f"GitHub release status: {status} ({conclusion or 'pending'})", flush=True)
+        if status == "completed":
+            if conclusion != "success":
+                raise ReleaseTriggerError(f"GitHub release completed with conclusion: {conclusion}")
+            return
+        time.sleep(20)
+    raise ReleaseTriggerError("timed out waiting for the GitHub release run to complete")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="PyPI version accepted by release.yml")
+    parser.add_argument("--repository", help="GitHub owner/name; defaults to CircleCI metadata")
+    parser.add_argument("--ref", default="main", help="Git ref used for workflow_dispatch")
+    args = parser.parse_args(argv)
+
+    token = os.getenv("GITHUB_TOKEN", "").strip()
+    if not token:
+        print("GITHUB_TOKEN must be configured in the CircleCI project or context", file=sys.stderr)
+        return 1
+
+    try:
+        repository = _repository(args.repository)
+        api_root = f"https://api.github.com/repos/{repository}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "fleet-rlm-circleci-pypi-deploy",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        started_at = time.time()
+        status, _ = _request_json(
+            f"{api_root}/actions/workflows/release.yml/dispatches",
+            headers=headers,
+            method="POST",
+            payload={"ref": args.ref, "inputs": {"version": args.version}},
+        )
+        if status != 204:
+            raise ReleaseTriggerError(f"GitHub release dispatch returned HTTP {status}")
+
+        run = _find_run(
+            api_root=api_root,
+            headers=headers,
+            ref=args.ref,
+            started_at=started_at,
+            deadline=time.time() + 300,
+        )
+        print(f"GitHub release run: {run['html_url']}", flush=True)
+        _wait_for_run(
+            api_root=api_root,
+            headers=headers,
+            run=run,
+            deadline=started_at + 2700,
+        )
+    except ReleaseTriggerError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a real, opt-in CircleCI deployment workflow for the repository's existing GitHub Actions PyPI release so CircleCI deploy markers can track package releases.

## Changes

- Add a disabled-by-default `deploy_pypi` workflow parameter and release-version input.
- Add `deploy-pypi` with deploy-marker plan/success/failure steps.
- Trigger and await the existing `.github/workflows/release.yml` workflow through GitHub's API.
- Require `GITHUB_TOKEN` at runtime without storing credentials in the repository.
- Document the new script in `scripts/README.md`.

## Usage

Enable the workflow explicitly with `deploy_pypi: true` and provide `release_version`. Configure a CircleCI project/context `GITHUB_TOKEN` with permission to dispatch Actions workflows.

## Validation

- `circleci config validate .circleci/config.yml`
- Processed config verified with `deploy_pypi: true`
- Ruff and Python compilation passed.
- `make check-codebase-tree` passed.
- `make check-docs` passed.
- `git diff --check` passed.