### PR TITLE
Configure deploy settings

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -1,0 +1,93 @@
+version: 2.1
+
+commands:
+  install_uv:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-uv-bin-{{ arch }}
+      - run:
+          name: Install uv (skip if cached)
+          command: |
+            if [ ! -f "$HOME/.local/bin/uv" ]; then
+              curl -LsSf https://astral.sh/uv/install.sh | sh
+            fi
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+      - save_cache:
+          key: v1-uv-bin-{{ arch }}
+          paths:
+            - ~/.local/bin/uv
+            - ~/.local/bin/uvx
+
+executors:
+  python:
+    docker:
+      # The -node variant adds Node.js so openapi-typescript (npx) can run in
+      # the same job as the python gates (api-check regenerates TUI types).
+      - image: cimg/python:3.13.13-node
+    working_directory: ~/project
+    environment:
+      UV_CACHE_DIR: ~/.cache/uv
+jobs:
+  deploy-pypi:
+    executor: python
+    resource_class: small
+    environment:
+      COMPONENT_NAME: "fleet-rlm"
+      ENVIRONMENT_NAME: "pypi"
+      TARGET_VERSION: "<< pipeline.deploy.target_version >>"
+    steps:
+      - checkout
+      - install_uv
+      - run:
+          name: Plan release
+          command: |
+            circleci run release plan \
+              --environment-name=${ENVIRONMENT_NAME} \
+              --component-name=${COMPONENT_NAME} \
+              --target-version=${TARGET_VERSION}
+      - run:
+          name: Perform deployment
+          no_output_timeout: 45m
+          command: |
+            uv run python scripts/circleci_trigger_release.py \
+              --version="${TARGET_VERSION}" \
+              --ref=main
+      - run:
+          name: Update deployment status to failed
+          command: circleci run release update --status=FAILED
+          when: on_fail
+  cancel-deploy-pypi:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Update planned release to CANCELED
+          command: |
+            circleci run release update deploy-pypi \
+              --status=CANCELED
+  deploy-pypi-release:
+    type: release
+    plan_name: deploy-pypi
+    validation:
+      enabled: true
+      auto_rollback_on_failure: true
+
+
+workflows:
+  deploy:
+    jobs:
+      - deploy-pypi:
+          filters:
+            branches:
+              only: main
+      - deploy-pypi-release:
+          requires:
+            - deploy-pypi
+          filters:
+            branches:
+              only: main
+      - cancel-deploy-pypi:
+          requires:
+            - deploy-pypi:
+              - canceled

--- a/.circleci/rollback.yml
+++ b/.circleci/rollback.yml
@@ -1,0 +1,91 @@
+version: 2.1
+
+commands:
+  install_uv:
+    steps:
+      - restore_cache:
+          keys:
+            - v1-uv-bin-{{ arch }}
+      - run:
+          name: Install uv (skip if cached)
+          command: |
+            if [ ! -f "$HOME/.local/bin/uv" ]; then
+              curl -LsSf https://astral.sh/uv/install.sh | sh
+            fi
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
+      - save_cache:
+          key: v1-uv-bin-{{ arch }}
+          paths:
+            - ~/.local/bin/uv
+            - ~/.local/bin/uvx
+
+executors:
+  python:
+    docker:
+      # The -node variant adds Node.js so openapi-typescript (npx) can run in
+      # the same job as the python gates (api-check regenerates TUI types).
+      - image: cimg/python:3.13.13-node
+    working_directory: ~/project
+    environment:
+      UV_CACHE_DIR: ~/.cache/uv
+jobs:
+  deploy-pypi-rollback:
+    executor: python
+    resource_class: small
+    environment:
+      COMPONENT_NAME: "<< pipeline.deploy.component_name >>"
+      ENVIRONMENT_NAME: "<< pipeline.deploy.environment_name >>"
+      TARGET_VERSION: "<< pipeline.deploy.target_version >>"
+    steps:
+      - checkout
+      - install_uv
+      - run:
+          name: Plan rollback
+          command: |
+            circleci run release plan deploy-pypi-rollback \
+              --environment-name=${ENVIRONMENT_NAME} \
+              --component-name=${COMPONENT_NAME} \
+              --target-version=${TARGET_VERSION} \
+              --rollback
+      - run:
+          name: Perform rollback
+          command: |
+            # TODO: add rollback logic using ${TARGET_VERSION}
+            echo "Rolling back PyPI deployment to version ${TARGET_VERSION}"
+      - run:
+          name: Update deployment status to failed
+          command: circleci run release update deploy-pypi-rollback --status=FAILED
+          when: on_fail
+  cancel-deploy-pypi-rollback:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - run:
+          name: Update planned release to CANCELED
+          command: |
+            circleci run release update deploy-pypi-rollback \
+              --status=CANCELED
+  deploy-pypi-rollback-release:
+    type: release
+    plan_name: deploy-pypi-rollback
+    validation:
+      enabled: true
+
+
+workflows:
+  rollback:
+    jobs:
+      - deploy-pypi-rollback:
+          filters:
+            branches:
+              only: main
+      - deploy-pypi-rollback-release:
+          requires:
+            - deploy-pypi-rollback
+          filters:
+            branches:
+              only: main
+      - cancel-deploy-pypi-rollback:
+          requires:
+            - deploy-pypi-rollback:
+              - canceled


### PR DESCRIPTION
This PR adds deploy configuration to your CircleCI project, generated by Smart Deployments.

**Check the items below before merging.** The configuration was generated for you, and these are the settings that most often need a human eye.

Learn more in our [deploy documentation](https://circleci.com/docs/guides/deploy/set-up-smart-deployments/).

## Before you merge

- [ ] Resolve every `TODO` and placeholder left in the generated config.
- [ ] Confirm every context, environment variable and secret the new jobs reference already exists in this organization.
- [ ] Read the whole diff. Generation can restructure existing jobs, not only add new ones.
- [ ] Confirm the new jobs run on the branches and filters you intend, and not on every pipeline.

### Deploy markers

- [ ] `environment_name` is set explicitly and matches the environment name you already use. `prod` and `production` are tracked as two separate environments, and leaving it unset creates one called `default`.
- [ ] `component_name` is set explicitly if this project has, or will have, more than one component. Otherwise the deploy fails with `Multiple components found within project` or silently falls back to the repository name.
- [ ] `namespace` is intentional. An empty namespace resolves to `default`, and each component instance is tracked as `{namespace}.{component_name}`.
- [ ] `target_version` resolves to the version you are actually deploying. An empty value is accepted and produces a marker you cannot tie back to a release.
- [ ] The marker steps run in the job that actually performs the deploy.
- [ ] The deploy reports a final `success` or `failed` status on every exit path. Without it the version never shows as live.
- [ ] `plan_name` on the release job matches the plan step's `name` exactly, and is unique within the workflow.

### Rollback

- [ ] Each rollback job mirrors a deploy job from your main config (e.g. `deploy` → `deploy-rollback`) and reuses the same deployment tooling.
- [ ] If any job contains `# TODO: add rollback logic`, replace it with steps that deploy `TARGET_VERSION`.
- [ ] The rollback command uses `TARGET_VERSION`, not a fixed tag or `HEAD`.
- [ ] Each plan command includes `--rollback`.
- [ ] Identity fields in `.circleci/rollback.yml` match your deploy markers in `config.yml`.

### Deploy pipeline

- [ ] Each job in `.circleci/deploy.yml` mirrors a deploy job from your main config and uses the same deployment tooling.
- [ ] If any job contains `# TODO: add deployment logic`, replace it with your CI deploy steps.
- [ ] The deployment command uses `TARGET_VERSION` for the version being deployed.
- [ ] Identity fields in `.circleci/deploy.yml` match your deploy markers in `config.yml`.