### PR TITLE
chore(release): bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.7.1] - 2026-08-15
+
+### Changed
+
+- **Change:** Added explicit Python 3.13 compatibility coverage and an
+  opt-in CircleCI PyPI deployment path with Smart Deployments metadata.
+  **Outcome:** Python 3.13 compatibility and release promotion are covered
+  by the repository's supported CI workflow without changing runtime behavior.
+
 ## [0.7.0] - 2026-08-15
 
 ### Added

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.7.0
+  version: 0.7.1
 paths:
   /api/sessions/{session_id}/turns:
     post:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-rlm"
-version = "0.7.0"
+version = "0.7.1"
 description = "RLM-native FastAPI backend with DSPy and Daytona"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1142,7 +1142,7 @@ wheels = [
 
 [[package]]
 name = "fleet-rlm"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- bump the package and generated OpenAPI contract to 0.7.1
- add the required 0.7.1 changelog entry
- retain the Python 3.13 compatibility and opt-in CircleCI PyPI deployment coverage

## Validation

- `make check-release`
- `make api-check`
- `make build-release`
- `git diff --check`

The release is intentionally prepared through a pull request because `main` is protected.