### PR TITLE
feat(posthog): policy-controlled product analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,26 +32,6 @@ executors:
     working_directory: ~/project
 
 commands:
-  install_pnpm:
-    steps:
-      - run:
-          name: Enable corepack and configure pnpm store
-          command: |
-            corepack enable
-            corepack prepare pnpm@10.33.2 --activate
-            pnpm config set store-dir ~/.pnpm-store
-      - restore_cache:
-          keys:
-            - v1-pnpm-{{ arch }}-{{ checksum "tools/fleet-tui/pnpm-lock.yaml" }}
-            - v1-pnpm-{{ arch }}-
-      - run:
-          name: Install TUI dependencies
-          command: pnpm --dir tools/fleet-tui install --frozen-lockfile
-      - save_cache:
-          key: v1-pnpm-{{ arch }}-{{ checksum "tools/fleet-tui/pnpm-lock.yaml" }}
-          paths:
-            - ~/.pnpm-store
-
   install_uv:
     steps:
       - restore_cache:
@@ -124,15 +104,19 @@ jobs:
             make check-docs
       - run:
           name: Security checks
-          no_output_timeout: 5m
           command: make check-security
-      - install_pnpm
       - run:
-          name: API and stream contract checks
-          no_output_timeout: 5m
+          name: Install TUI dependencies
           command: |
-            make api-check
-            make stream-check
+            corepack enable
+            corepack prepare pnpm@10.33.2 --activate
+            pnpm --dir tools/fleet-tui install --frozen-lockfile
+      - run:
+          name: API contract checks
+          command: make api-check
+      - run:
+          name: Stream contract check
+          command: make stream-check
       - run:
           name: Python dependency check
           command: uvx deptry . --config pyproject.toml
@@ -297,7 +281,14 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - install_pnpm
+      - run:
+          name: Install pnpm
+          command: |
+            corepack enable
+            corepack prepare pnpm@10.33.2 --activate
+      - run:
+          name: Install TUI dependencies
+          command: pnpm --dir tools/fleet-tui install --frozen-lockfile
       - run:
           name: TUI lint, type, and tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,26 @@ executors:
     working_directory: ~/project
 
 commands:
+  install_pnpm:
+    steps:
+      - run:
+          name: Enable corepack and configure pnpm store
+          command: |
+            corepack enable
+            corepack prepare pnpm@10.33.2 --activate
+            pnpm config set store-dir ~/.pnpm-store
+      - restore_cache:
+          keys:
+            - v1-pnpm-{{ arch }}-{{ checksum "tools/fleet-tui/pnpm-lock.yaml" }}
+            - v1-pnpm-{{ arch }}-
+      - run:
+          name: Install TUI dependencies
+          command: pnpm --dir tools/fleet-tui install --frozen-lockfile
+      - save_cache:
+          key: v1-pnpm-{{ arch }}-{{ checksum "tools/fleet-tui/pnpm-lock.yaml" }}
+          paths:
+            - ~/.pnpm-store
+
   install_uv:
     steps:
       - restore_cache:
@@ -104,15 +124,12 @@ jobs:
             make check-docs
       - run:
           name: Security checks
+          no_output_timeout: 5m
           command: make check-security
-      - run:
-          name: Install TUI dependencies
-          command: |
-            corepack enable
-            corepack prepare pnpm@10.33.2 --activate
-            pnpm --dir tools/fleet-tui install --frozen-lockfile
+      - install_pnpm
       - run:
           name: API and stream contract checks
+          no_output_timeout: 5m
           command: |
             make api-check
             make stream-check
@@ -280,14 +297,7 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - run:
-          name: Install pnpm
-          command: |
-            corepack enable
-            corepack prepare pnpm@10.33.2 --activate
-      - run:
-          name: Install TUI dependencies
-          command: pnpm --dir tools/fleet-tui install --frozen-lockfile
+      - install_pnpm
       - run:
           name: TUI lint, type, and tests
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ PLANS.md
 
 notebooks/
 .databricks
+
+# chunk review context artifacts
+.chunk/context/

--- a/config/fleet.toml
+++ b/config/fleet.toml
@@ -64,6 +64,14 @@ async_logging = true
 trace_sampling_ratio = 1.0
 trace_content_max_chars = 10000
 
+[defaults.posthog]
+# PostHog product analytics for project 15008, hosted on the EU ingestion
+# endpoint. The project token is resolved from the named environment variable;
+# analytics stay disabled when it is absent and never block startup.
+enabled = true
+project_token_env = "POSTHOG_PROJECT_TOKEN"
+host = "https://eu.i.posthog.com"
+
 [profiles.daytona.runtime]
 environment = "daytona"
 
@@ -173,6 +181,10 @@ cache = false
 [profiles.daytona-bench.mlflow]
 tracing_enabled = false
 
+# Benchmarks must also stay analytics-free.
+[profiles.daytona-bench.posthog]
+enabled = false
+
 [profiles.daytona-bench.rlm]
 # Keep host logs free of model-generated execution output; live SSE remains
 # bounded and is the operator-facing execution surface.
@@ -198,6 +210,10 @@ cache = false
 # Benchmarks must stay traceless; override the on-by-default global below.
 [profiles.daytona-bench-40.mlflow]
 tracing_enabled = false
+
+# Benchmarks must also stay analytics-free.
+[profiles.daytona-bench-40.posthog]
+enabled = false
 
 [profiles.daytona-bench-40.rlm]
 max_iters = 40

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -84,6 +84,18 @@ the same bounded payloads the TUI displays.
 > validation with an unknown-key error; delete the key. Trace content is now
 > always readable (bounded by `mlflow.trace_content_max_chars`).
 
+PostHog product analytics are policy-controlled by the optional `[posthog]`
+section. `posthog.enabled` switches analytics on or off, `posthog.project_token_env`
+names the environment variable holding the project token, and `posthog.host`
+overrides the ingestion host (the committed default targets the EU instance for
+project 15008). Analytics are enabled by the shipped `[defaults.posthog]` policy
+but stay disabled whenever the named token variable is absent, and they never
+block startup. The benchmark profiles (`daytona-bench`, `daytona-bench-40`)
+explicitly keep analytics off to stay traceless, mirroring the MLflow policy.
+Every analytics event shares one stable per-installation `distinct_id` persisted
+under the storage data root; the deterministic local user id is never used as a
+PostHog identity.
+
 Profile role tables avoid an inheritance framework. Only defaults that duplicate
 `Settings` behavior are omitted; explicit profiles keep operator-visible role
 values rather than gaining `extends`, mixins, or cross-profile aliases.
@@ -180,6 +192,7 @@ Fleet restart.
 | `FLEET_MLFLOW_EXPERIMENT_NAME` | `daytona-managed.mlflow.experiment_name_env` | Managed MLflow experiment |
 | `FLEET_MLFLOW_TRACE_CATALOG` / `FLEET_MLFLOW_TRACE_SCHEMA` | `daytona-managed.mlflow.*_env` | Unity Catalog destination |
 | `FLEET_MLFLOW_TRACE_TABLE_PREFIX` / `FLEET_MLFLOW_TRACING_SQL_WAREHOUSE_ID` | `daytona-managed.mlflow.*_env` | Trace table prefix and SQL warehouse |
+| `POSTHOG_PROJECT_TOKEN` | `posthog.project_token_env` | PostHog project token for product analytics (enabled by default, disabled when absent) |
 Model ids may use an explicit `provider/model` prefix. For an OpenAI-compatible
 base URL, bare ids are normalized with the `openai/` prefix before constructing
 `dspy.LM`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -128,6 +128,12 @@ paths:
       tags:
       - sessions
       summary: Create Session
+      description: "Create a session for the authenticated user in the current workspace.\n\
+        \nParameters:\n    body (SessionCreateRequest): Session creation data, including\
+        \ the optional title.\n    identity (LocalScopeDep): Authenticated user and\
+        \ workspace scope.\n    repo (SessionCatalogDep): Session repository used\
+        \ to create the session.\n\nReturns:\n    SessionDetailResponse: The newly\
+        \ created session details."
       operationId: create_session
       requestBody:
         required: true
@@ -236,6 +242,12 @@ paths:
       tags:
       - sessions
       summary: Patch Session
+      description: "Update the title or status of a session within the authenticated\
+        \ user's workspace.\n\nParameters:\n    body (SessionPatchRequest): Fields\
+        \ to update; at least one field is required.\n\nReturns:\n    SessionDetailResponse:\
+        \ The updated session details.\n\nRaises:\n    HTTPException: If no fields\
+        \ are provided, the title is blank, the status is invalid, or the\n      \
+        \  session cannot be updated."
       operationId: update_session
       parameters:
       - name: session_id
@@ -348,6 +360,11 @@ paths:
       tags:
       - artifacts
       summary: Download Artifact
+      description: "Download an artifact within the caller's workspace scope.\n\n\
+        Parameters:\n    artifact_id (UUID): Identifier of the artifact to download.\n\
+        \nReturns:\n    Response: The artifact content with its media type and download\
+        \ filename.\n\nRaises:\n    HTTPException: If the artifact is missing or artifact\
+        \ storage is unavailable."
       operationId: download_artifact
       parameters:
       - name: artifact_id
@@ -397,7 +414,10 @@ paths:
       tags:
       - skills
       summary: List Skills
-      description: List SkillCards authorized for the caller (metadata only).
+      description: "List skill metadata available to the caller, optionally ranked\
+        \ by a search query.\n\nParameters:\n    q (str | None): Optional query used\
+        \ to rank skills by matching terms in their names or descriptions.\n\nReturns:\n\
+        \    list[SkillCardResponse]: Response-formatted skill cards."
       operationId: list_skills
       parameters:
       - name: q
@@ -458,6 +478,11 @@ paths:
       tags:
       - runs
       summary: Request Run Cancellation
+      description: "Request cancellation for a run.\n\nParameters:\n    run_id (UUID):\
+        \ The identifier of the run to cancel.\n    identity (LocalScopeDep): The\
+        \ authenticated user's workspace scope.\n    lifecycle (RunLifecycleDep):\
+        \ The run lifecycle service.\n\nReturns:\n    CancellationResponse: The run\
+        \ identifier and resulting cancellation state."
       operationId: request_run_cancellation
       parameters:
       - name: run_id
@@ -497,6 +522,11 @@ paths:
       tags:
       - settings
       summary: Patch Settings Policy
+      description: "Update the settings policy's default profile or a specified field.\n\
+        \nParameters:\n    body (SettingsPolicyPatchRequest): The requested profile\
+        \ or field update, including the expected revision.\n\nReturns:\n    SettingsPolicyResponse:\
+        \ The updated settings policy.\n\nRaises:\n    HTTPException: If the revision\
+        \ conflicts, the update is invalid, or the policy is unavailable."
       operationId: update_settings_policy
       requestBody:
         content:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     # MLflow 3 tracing: DSPy autolog + Databricks tracking backend.
     "mlflow>=3.15,<4",
     "tomlkit>=0.13,<1",
+    "posthog>=7.39.1,<8",
 ]
 
 [project.urls]

--- a/src/fleet_rlm/api/routes/artifacts.py
+++ b/src/fleet_rlm/api/routes/artifacts.py
@@ -12,6 +12,7 @@ from fleet_rlm.api.errors import http_error
 from fleet_rlm.api.schemas import ArtifactResponse
 from fleet_rlm.artifacts.errors import ArtifactNotFoundError
 from fleet_rlm.artifacts.models import ArtifactAccess, ArtifactRef
+from fleet_rlm.posthog_client import get_client, get_distinct_id
 
 router = APIRouter(prefix="/api/artifacts", tags=["artifacts"])
 _SAFE_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
@@ -93,6 +94,18 @@ async def download_artifact(
     extension = {"text": ".txt", "markdown": ".md", "json": ".json"}[ref.kind]
     stem = _SAFE_FILENAME.sub("-", ref.title or "artifact").strip(".-") or "artifact"
     filename = f"{stem}{extension}"
+    ph = get_client()
+    if ph is not None:
+        ph.capture(
+            distinct_id=get_distinct_id(),
+            event="artifact_downloaded",
+            properties={
+                "workspace_id": str(identity.workspace_id),
+                "artifact_id": str(artifact_id),
+                "artifact_kind": ref.kind,
+                "artifact_byte_size": ref.byte_size,
+            },
+        )
     return Response(
         content=data,
         media_type=ref.media_type,

--- a/src/fleet_rlm/api/routes/artifacts.py
+++ b/src/fleet_rlm/api/routes/artifacts.py
@@ -81,13 +81,13 @@ async def download_artifact(
 ) -> Response:
     """
     Download an artifact within the caller's workspace scope.
-    
+
     Parameters:
         artifact_id (UUID): Identifier of the artifact to download.
-    
+
     Returns:
         Response: The artifact content with its media type and download filename.
-    
+
     Raises:
         HTTPException: If the artifact is missing or artifact storage is unavailable.
     """

--- a/src/fleet_rlm/api/routes/artifacts.py
+++ b/src/fleet_rlm/api/routes/artifacts.py
@@ -79,6 +79,18 @@ async def download_artifact(
     identity: LocalScopeDep,
     reader: ArtifactReaderDep,
 ) -> Response:
+    """
+    Download an artifact within the caller's workspace scope.
+    
+    Parameters:
+        artifact_id (UUID): Identifier of the artifact to download.
+    
+    Returns:
+        Response: The artifact content with its media type and download filename.
+    
+    Raises:
+        HTTPException: If the artifact is missing or artifact storage is unavailable.
+    """
     try:
         content = await reader.content(
             ArtifactAccess(identity.user_id, identity.workspace_id),

--- a/src/fleet_rlm/api/routes/runs.py
+++ b/src/fleet_rlm/api/routes/runs.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from fleet_rlm.api.dependencies import LocalScopeDep, RunLifecycleDep
 from fleet_rlm.api.errors import http_error
 from fleet_rlm.chat.run_lifecycle import RunNotFoundError
+from fleet_rlm.posthog_client import get_client, get_distinct_id
 from fleet_rlm.sessions.models import TurnAccess
 
 router = APIRouter(prefix="/api/runs", tags=["runs"])
@@ -35,4 +36,15 @@ async def request_run_cancellation(
         status = await lifecycle.request_cancel(TurnAccess(identity.user_id, identity.workspace_id), run_id)
     except RunNotFoundError as exc:
         raise http_error(404, "run_not_found", "Run not found") from exc
+    ph = get_client()
+    if ph is not None:
+        ph.capture(
+            distinct_id=get_distinct_id(),
+            event="run_cancellation_requested",
+            properties={
+                "workspace_id": str(identity.workspace_id),
+                "run_id": str(run_id),
+                "cancellation_state": status,
+            },
+        )
     return CancellationResponse(run_id=run_id, state=status)

--- a/src/fleet_rlm/api/routes/runs.py
+++ b/src/fleet_rlm/api/routes/runs.py
@@ -32,6 +32,17 @@ async def request_run_cancellation(
     identity: LocalScopeDep,
     lifecycle: RunLifecycleDep,
 ) -> CancellationResponse:
+    """
+    Request cancellation for a run.
+    
+    Parameters:
+    	run_id (UUID): The identifier of the run to cancel.
+    	identity (LocalScopeDep): The authenticated user's workspace scope.
+    	lifecycle (RunLifecycleDep): The run lifecycle service.
+    
+    Returns:
+    	CancellationResponse: The run identifier and resulting cancellation state.
+    """
     try:
         status = await lifecycle.request_cancel(TurnAccess(identity.user_id, identity.workspace_id), run_id)
     except RunNotFoundError as exc:

--- a/src/fleet_rlm/api/routes/runs.py
+++ b/src/fleet_rlm/api/routes/runs.py
@@ -34,14 +34,14 @@ async def request_run_cancellation(
 ) -> CancellationResponse:
     """
     Request cancellation for a run.
-    
+
     Parameters:
-    	run_id (UUID): The identifier of the run to cancel.
-    	identity (LocalScopeDep): The authenticated user's workspace scope.
-    	lifecycle (RunLifecycleDep): The run lifecycle service.
-    
+        run_id (UUID): The identifier of the run to cancel.
+        identity (LocalScopeDep): The authenticated user's workspace scope.
+        lifecycle (RunLifecycleDep): The run lifecycle service.
+
     Returns:
-    	CancellationResponse: The run identifier and resulting cancellation state.
+        CancellationResponse: The run identifier and resulting cancellation state.
     """
     try:
         status = await lifecycle.request_cancel(TurnAccess(identity.user_id, identity.workspace_id), run_id)

--- a/src/fleet_rlm/api/routes/sessions.py
+++ b/src/fleet_rlm/api/routes/sessions.py
@@ -20,6 +20,7 @@ from fleet_rlm.api.schemas import (
     UIMessageResponse,
 )
 from fleet_rlm.api.ui_message import assistant_turn_to_ui_message, user_turn_to_ui_message
+from fleet_rlm.posthog_client import get_client, get_distinct_id
 from fleet_rlm.sessions.catalog import SequenceCursor
 from fleet_rlm.sessions.errors import SessionNotFoundError
 from fleet_rlm.sessions.models import AssistantTurnRecord, SessionRecord
@@ -65,6 +66,13 @@ async def create_session(
         workspace_id=identity.workspace_id,
         title=title[:255],
     )
+    ph = get_client()
+    if ph is not None:
+        ph.capture(
+            distinct_id=get_distinct_id(),
+            event="session_created",
+            properties={"workspace_id": str(identity.workspace_id)},
+        )
     return SessionDetailResponse(
         id=record.id,
         title=record.title,
@@ -160,6 +168,19 @@ async def patch_session(
         # Internal validation failures must not leak exception text into the
         # public contract; collapse them to the closed invalid_request code.
         raise http_error(422, "invalid_request", "Invalid request") from exc
+    ph = get_client()
+    if ph is not None:
+        ph.capture(
+            distinct_id=get_distinct_id(),
+            event="session_updated",
+            properties={
+                "workspace_id": str(identity.workspace_id),
+                "session_id": str(session_id),
+                "title_changed": body.title is not None,
+                "status_changed": body.status is not None,
+                "new_status": body.status,
+            },
+        )
     return SessionDetailResponse(
         id=record.id,
         title=record.title,

--- a/src/fleet_rlm/api/routes/sessions.py
+++ b/src/fleet_rlm/api/routes/sessions.py
@@ -60,6 +60,17 @@ async def create_session(
     identity: LocalScopeDep,
     repo: SessionCatalogDep,
 ) -> SessionDetailResponse:
+    """
+    Create a session for the authenticated user in the current workspace.
+    
+    Parameters:
+    	body (SessionCreateRequest): Session creation data, including the optional title.
+    	identity (LocalScopeDep): Authenticated user and workspace scope.
+    	repo (SessionCatalogDep): Session repository used to create the session.
+    
+    Returns:
+    	SessionDetailResponse: The newly created session details.
+    """
     title = (body.title or "New Session").strip() or "New Session"
     record = await repo.create(
         user_id=identity.user_id,
@@ -148,6 +159,18 @@ async def patch_session(
     identity: LocalScopeDep,
     repo: SessionCatalogDep,
 ) -> SessionDetailResponse:
+    """
+    Update the title or status of a session within the authenticated user's workspace.
+    
+    Parameters:
+        body (SessionPatchRequest): Fields to update; at least one field is required.
+    
+    Returns:
+        SessionDetailResponse: The updated session details.
+    
+    Raises:
+        HTTPException: If no fields are provided, the title is blank, the status is invalid, or the session cannot be updated.
+    """
     if body.title is None and body.status is None:
         raise http_error(422, "session_no_fields", "No fields to update")
     if body.title is not None and not body.title.strip():

--- a/src/fleet_rlm/api/routes/sessions.py
+++ b/src/fleet_rlm/api/routes/sessions.py
@@ -62,14 +62,14 @@ async def create_session(
 ) -> SessionDetailResponse:
     """
     Create a session for the authenticated user in the current workspace.
-    
+
     Parameters:
-    	body (SessionCreateRequest): Session creation data, including the optional title.
-    	identity (LocalScopeDep): Authenticated user and workspace scope.
-    	repo (SessionCatalogDep): Session repository used to create the session.
-    
+        body (SessionCreateRequest): Session creation data, including the optional title.
+        identity (LocalScopeDep): Authenticated user and workspace scope.
+        repo (SessionCatalogDep): Session repository used to create the session.
+
     Returns:
-    	SessionDetailResponse: The newly created session details.
+        SessionDetailResponse: The newly created session details.
     """
     title = (body.title or "New Session").strip() or "New Session"
     record = await repo.create(
@@ -161,15 +161,16 @@ async def patch_session(
 ) -> SessionDetailResponse:
     """
     Update the title or status of a session within the authenticated user's workspace.
-    
+
     Parameters:
         body (SessionPatchRequest): Fields to update; at least one field is required.
-    
+
     Returns:
         SessionDetailResponse: The updated session details.
-    
+
     Raises:
-        HTTPException: If no fields are provided, the title is blank, the status is invalid, or the session cannot be updated.
+        HTTPException: If no fields are provided, the title is blank, the status is invalid, or the
+            session cannot be updated.
     """
     if body.title is None and body.status is None:
         raise http_error(422, "session_no_fields", "No fields to update")

--- a/src/fleet_rlm/api/routes/settings.py
+++ b/src/fleet_rlm/api/routes/settings.py
@@ -44,6 +44,18 @@ def get_settings_policy(policy: ConfigPolicyDep) -> SettingsPolicyResponse:
     dependencies=[Depends(require_loopback_client)],
 )
 def patch_settings_policy(body: SettingsPolicyPatchRequest, policy: ConfigPolicyDep) -> SettingsPolicyResponse:
+    """
+    Update the settings policy's default profile or a specified field.
+    
+    Parameters:
+    	body (SettingsPolicyPatchRequest): The requested profile or field update, including the expected revision.
+    
+    Returns:
+    	SettingsPolicyResponse: The updated settings policy.
+    
+    Raises:
+    	HTTPException: If the revision conflicts, the update is invalid, or the policy is unavailable.
+    """
     try:
         if body.profile is not None:
             result = _response(policy.set_default_profile(body.profile, revision=body.revision))

--- a/src/fleet_rlm/api/routes/settings.py
+++ b/src/fleet_rlm/api/routes/settings.py
@@ -46,15 +46,15 @@ def get_settings_policy(policy: ConfigPolicyDep) -> SettingsPolicyResponse:
 def patch_settings_policy(body: SettingsPolicyPatchRequest, policy: ConfigPolicyDep) -> SettingsPolicyResponse:
     """
     Update the settings policy's default profile or a specified field.
-    
+
     Parameters:
-    	body (SettingsPolicyPatchRequest): The requested profile or field update, including the expected revision.
-    
+        body (SettingsPolicyPatchRequest): The requested profile or field update, including the expected revision.
+
     Returns:
-    	SettingsPolicyResponse: The updated settings policy.
-    
+        SettingsPolicyResponse: The updated settings policy.
+
     Raises:
-    	HTTPException: If the revision conflicts, the update is invalid, or the policy is unavailable.
+        HTTPException: If the revision conflicts, the update is invalid, or the policy is unavailable.
     """
     try:
         if body.profile is not None:

--- a/src/fleet_rlm/api/routes/settings.py
+++ b/src/fleet_rlm/api/routes/settings.py
@@ -9,6 +9,7 @@ from fleet_rlm.api.errors import http_error
 from fleet_rlm.api.schemas import SettingsPolicyPatchRequest, SettingsPolicyResponse
 from fleet_rlm.config import FleetConfigurationError
 from fleet_rlm.config_policy import PolicyAccessError, PolicyConflictError
+from fleet_rlm.posthog_client import get_client, get_distinct_id
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
@@ -45,10 +46,26 @@ def get_settings_policy(policy: ConfigPolicyDep) -> SettingsPolicyResponse:
 def patch_settings_policy(body: SettingsPolicyPatchRequest, policy: ConfigPolicyDep) -> SettingsPolicyResponse:
     try:
         if body.profile is not None:
-            return _response(policy.set_default_profile(body.profile, revision=body.revision))
+            result = _response(policy.set_default_profile(body.profile, revision=body.revision))
+            ph = get_client()
+            if ph is not None:
+                ph.capture(
+                    distinct_id=get_distinct_id(),
+                    event="settings_policy_updated",
+                    properties={"update_kind": "profile"},
+                )
+            return result
         if body.scope is None or body.path is None or body.value is None:
             raise http_error(422, "settings_policy_invalid", "Settings value is invalid")
-        return _response(policy.update(scope=body.scope, path=body.path, value=body.value, revision=body.revision))
+        result = _response(policy.update(scope=body.scope, path=body.path, value=body.value, revision=body.revision))
+        ph = get_client()
+        if ph is not None:
+            ph.capture(
+                distinct_id=get_distinct_id(),
+                event="settings_policy_updated",
+                properties={"update_kind": "field", "scope": body.scope, "path": body.path},
+            )
+        return result
     except PolicyConflictError as exc:
         raise http_error(409, "settings_revision_conflict", "Settings changed; reload before saving") from exc
     except (PolicyAccessError, FleetConfigurationError) as exc:

--- a/src/fleet_rlm/api/routes/skills.py
+++ b/src/fleet_rlm/api/routes/skills.py
@@ -7,9 +7,10 @@ from uuid import UUID
 
 from fastapi import APIRouter, Query
 
-from fleet_rlm.api.dependencies import SkillCatalogDep
+from fleet_rlm.api.dependencies import LocalScopeDep, SkillCatalogDep
 from fleet_rlm.api.errors import http_error
 from fleet_rlm.api.schemas import SkillCardResponse
+from fleet_rlm.posthog_client import get_client, get_distinct_id
 from fleet_rlm.skills.models import SkillCard
 
 router = APIRouter(tags=["skills"])
@@ -44,10 +45,23 @@ def _rank(cards: tuple[SkillCard, ...], query: str | None) -> tuple[SkillCard, .
 @router.get("/api/skills", response_model=list[SkillCardResponse], operation_id="list_skills")
 def list_skills(
     catalog: SkillCatalogDep,
+    identity: LocalScopeDep,
     q: Annotated[str | None, Query(description="Optional ranking query")] = None,
 ) -> list[SkillCardResponse]:
     """List SkillCards authorized for the caller (metadata only)."""
-    return [_to_response(card) for card in _rank(catalog.cards(), q)]
+    cards = _rank(catalog.cards(), q)
+    ph = get_client()
+    if ph is not None:
+        ph.capture(
+            distinct_id=get_distinct_id(),
+            event="skill_listed",
+            properties={
+                "workspace_id": str(identity.workspace_id),
+                "result_count": len(cards),
+                "has_query": q is not None and q.strip() != "",
+            },
+        )
+    return [_to_response(card) for card in cards]
 
 
 @router.get("/api/skills/{skill_id}", response_model=SkillCardResponse, operation_id="get_skill")

--- a/src/fleet_rlm/api/routes/skills.py
+++ b/src/fleet_rlm/api/routes/skills.py
@@ -50,12 +50,12 @@ def list_skills(
 ) -> list[SkillCardResponse]:
     """
     List skill metadata available to the caller, optionally ranked by a search query.
-    
+
     Parameters:
-    	q (str | None): Optional query used to rank skills by matching terms in their names or descriptions.
-    
+        q (str | None): Optional query used to rank skills by matching terms in their names or descriptions.
+
     Returns:
-    	list[SkillCardResponse]: Response-formatted skill cards.
+        list[SkillCardResponse]: Response-formatted skill cards.
     """
     cards = _rank(catalog.cards(), q)
     ph = get_client()

--- a/src/fleet_rlm/api/routes/skills.py
+++ b/src/fleet_rlm/api/routes/skills.py
@@ -48,7 +48,15 @@ def list_skills(
     identity: LocalScopeDep,
     q: Annotated[str | None, Query(description="Optional ranking query")] = None,
 ) -> list[SkillCardResponse]:
-    """List SkillCards authorized for the caller (metadata only)."""
+    """
+    List skill metadata available to the caller, optionally ranked by a search query.
+    
+    Parameters:
+    	q (str | None): Optional query used to rank skills by matching terms in their names or descriptions.
+    
+    Returns:
+    	list[SkillCardResponse]: Response-formatted skill cards.
+    """
     cards = _rank(catalog.cards(), q)
     ph = get_client()
     if ph is not None:

--- a/src/fleet_rlm/api/routes/turns.py
+++ b/src/fleet_rlm/api/routes/turns.py
@@ -29,6 +29,7 @@ from fleet_rlm.chat.run_preparation import (
 )
 from fleet_rlm.chat.turn_coordinator import OpenedTurnStream
 from fleet_rlm.observability.failure_diagnostics import normalize_turn_failure
+from fleet_rlm.posthog_client import get_client, get_distinct_id
 from fleet_rlm.sessions.models import TurnAccess, TurnInput
 from fleet_rlm.skills.errors import InvalidSkillSelectionError
 from fleet_rlm.skills.models import SkillSelectionRef
@@ -180,6 +181,7 @@ async def create_turn(
     _headers: Annotated[None, Depends(_stream_headers)],
 ) -> AsyncIterator[ServerSentEvent]:
     """Stream one Turn, opening claim and preparation inside the SSE generator."""
+    ph = get_client()
     yield _preparation_prelude()
     heartbeat_seconds = float(settings.run_heartbeat_seconds)
     open_task: asyncio.Task[OpenedTurnStream] | None = None
@@ -214,10 +216,35 @@ async def create_turn(
             raise
         if message == "Turn is unavailable":
             _log_preparation_unavailable(_correlation_id(request), exc)
+        if ph is not None:
+            ph.capture(
+                distinct_id=get_distinct_id(),
+                event="turn_failed",
+                properties={
+                    "workspace_id": str(identity.workspace_id),
+                    "session_id": str(session_id),
+                    "failure_phase": "open",
+                    "failure_message": message,
+                },
+            )
         for chunk in _open_failure_frames(message):
             yield ServerSentEvent(data=chunk)
         yield ServerSentEvent(raw_data="[DONE]")
         return
+
+    skill_count = len(body.skill_selections)
+    if ph is not None:
+        ph.capture(
+            distinct_id=get_distinct_id(),
+            event="turn_created",
+            properties={
+                "workspace_id": str(identity.workspace_id),
+                "session_id": str(session_id),
+                "skill_count": skill_count,
+                "has_attachments": len(body.attachment_ids) > 0,
+                "attachment_count": len(body.attachment_ids),
+            },
+        )
 
     projector = AISDKUIProjector()
     try:
@@ -225,6 +252,22 @@ async def create_turn(
             for chunk in projector.project(event):
                 yield ServerSentEvent(data=chunk)
         yield ServerSentEvent(raw_data="[DONE]")
+    except (asyncio.CancelledError, GeneratorExit):
+        # Client disconnect is not a turn failure; never capture it.
+        raise
+    except BaseException as exc:
+        if ph is not None:
+            ph.capture(
+                distinct_id=get_distinct_id(),
+                event="turn_failed",
+                properties={
+                    "workspace_id": str(identity.workspace_id),
+                    "session_id": str(session_id),
+                    "failure_phase": "stream",
+                    "failure_message": normalize_turn_failure(exc).message,
+                },
+            )
+        raise
     finally:
         await opened.aclose()
 

--- a/src/fleet_rlm/app.py
+++ b/src/fleet_rlm/app.py
@@ -126,7 +126,15 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        """Own tracing setup and provider composition for one application lifespan."""
+        """
+        Manage application resources for the duration of a FastAPI application lifespan.
+        
+        Parameters:
+        	app (FastAPI): Application instance whose runtime state and composition are initialized.
+        
+        Raises:
+        	RuntimeError: If the configured runtime environment is unsupported.
+        """
         from fleet_rlm.observability.mlflow_runtime import MLflowRuntime
 
         settings_obj: Settings = app.state.settings

--- a/src/fleet_rlm/app.py
+++ b/src/fleet_rlm/app.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI
 
 from . import __version__
 from .config import Settings, configure_logging, load_runtime_settings
+from .posthog_client import init_posthog, shutdown_posthog
 
 if TYPE_CHECKING:
     from fleet_rlm.composition.inventory import RuntimeDatabaseLifecycle, RuntimeInventory
@@ -133,6 +134,7 @@ def create_app(
         if not isinstance(mlflow_runtime, MLflowRuntime):
             mlflow_runtime = MLflowRuntime(settings_obj)
             app.state.mlflow_runtime = mlflow_runtime
+        init_posthog(settings_obj)
         await mlflow_runtime.start()
         try:
             if _composition_installer is not None:
@@ -161,6 +163,7 @@ def create_app(
             raise RuntimeError("Fleet only supports the Daytona runtime")
         finally:
             await mlflow_runtime.close()
+            shutdown_posthog()
 
     app = FastAPI(
         title=resolved.app_name,

--- a/src/fleet_rlm/app.py
+++ b/src/fleet_rlm/app.py
@@ -130,10 +130,10 @@ def create_app(
         Manage application resources for the duration of a FastAPI application lifespan.
 
         Parameters:
-        	app (FastAPI): Application instance whose runtime state and composition are initialized.
+            app (FastAPI): Application instance whose runtime state and composition are initialized.
 
         Raises:
-        	RuntimeError: If the configured runtime environment is unsupported.
+            RuntimeError: If the configured runtime environment is unsupported.
         """
         from fleet_rlm.observability.mlflow_runtime import MLflowRuntime
 

--- a/src/fleet_rlm/app.py
+++ b/src/fleet_rlm/app.py
@@ -128,10 +128,10 @@ def create_app(
     async def lifespan(app: FastAPI):
         """
         Manage application resources for the duration of a FastAPI application lifespan.
-        
+
         Parameters:
         	app (FastAPI): Application instance whose runtime state and composition are initialized.
-        
+
         Raises:
         	RuntimeError: If the configured runtime environment is unsupported.
         """
@@ -142,35 +142,38 @@ def create_app(
         if not isinstance(mlflow_runtime, MLflowRuntime):
             mlflow_runtime = MLflowRuntime(settings_obj)
             app.state.mlflow_runtime = mlflow_runtime
-        init_posthog(settings_obj)
-        await mlflow_runtime.start()
+
         try:
-            if _composition_installer is not None:
-                async with _local_db_lifespan(app, settings_obj, _composition_installer):
-                    yield
-                return
+            init_posthog(settings_obj)
+            await mlflow_runtime.start()
+            try:
+                if _composition_installer is not None:
+                    async with _local_db_lifespan(app, settings_obj, _composition_installer):
+                        yield
+                    return
 
-            if settings_obj.run_environment == "daytona":
-                from fleet_rlm.composition import (
-                    dispose_daytona_composition,
-                    install_daytona_composition,
-                    require_daytona_settings,
-                )
+                if settings_obj.run_environment == "daytona":
+                    from fleet_rlm.composition import (
+                        dispose_daytona_composition,
+                        install_daytona_composition,
+                        require_daytona_settings,
+                    )
 
-                require_daytona_settings(settings_obj)
-                installed = False
-                try:
-                    await install_daytona_composition(app, settings_obj)
-                    installed = True
-                    yield
-                finally:
-                    if installed:
-                        await dispose_daytona_composition(app)
-                return
+                    require_daytona_settings(settings_obj)
+                    installed = False
+                    try:
+                        await install_daytona_composition(app, settings_obj)
+                        installed = True
+                        yield
+                    finally:
+                        if installed:
+                            await dispose_daytona_composition(app)
+                    return
 
-            raise RuntimeError("Fleet only supports the Daytona runtime")
+                raise RuntimeError("Fleet only supports the Daytona runtime")
+            finally:
+                await mlflow_runtime.close()
         finally:
-            await mlflow_runtime.close()
             shutdown_posthog()
 
     app = FastAPI(

--- a/src/fleet_rlm/config.py
+++ b/src/fleet_rlm/config.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import tomllib
+import urllib.parse
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
@@ -272,6 +273,18 @@ class Settings(BaseModel):
     mlflow_trace_schema: str | None = Field(default=None)
     mlflow_trace_table_prefix: str | None = Field(default=None)
     mlflow_tracing_sql_warehouse_id: str | None = Field(default=None)
+    posthog_enabled: bool = Field(
+        default=False,
+        description="Enable PostHog product analytics selected by the Fleet policy",
+    )
+    posthog_project_token: SecretStr | None = Field(
+        default=None,
+        description="PostHog project token resolved from posthog.project_token_env",
+    )
+    posthog_host: str | None = Field(
+        default=None,
+        description="PostHog ingestion host selected by the Fleet policy",
+    )
     _dotenv_values: dict[str, str] = PrivateAttr(default_factory=dict)
     _active_profile: str | None = PrivateAttr(default=None)
 
@@ -304,6 +317,18 @@ class Settings(BaseModel):
             text = text.split(" #", 1)[0].rstrip().strip("'\"")
         if not (text.startswith("http://") or text.startswith("https://")):
             return None
+        return text.rstrip("/")
+
+    @field_validator("posthog_host")
+    @classmethod
+    def _validate_posthog_host(cls, value: str | None) -> str | None:
+        """PostHog ingestion hosts must be real http(s) endpoints."""
+        if value is None or value == "":
+            return None
+        text = str(value).strip()
+        parsed = urllib.parse.urlparse(text)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("posthog_host must be an absolute http(s) URL")
         return text.rstrip("/")
 
     @field_validator("daytona_snapshot", mode="before")
@@ -404,6 +429,7 @@ _TABLE_KEYS: dict[str, frozenset[str]] = {
             "tracing_sql_warehouse_id_env",
         }
     ),
+    "posthog": frozenset({"enabled", "project_token_env", "host"}),
 }
 _ROLE_KEYS = frozenset(
     {
@@ -517,6 +543,11 @@ def _validate_policy_table(value: object, location: str, *, allow_partial_llm: b
                 if key in mlflow and reference in mlflow:
                     raise FleetConfigurationError(f"{location}.mlflow cannot define both {key} and {reference}")
                 _validate_optional_environment_reference(mlflow.get(reference), f"{location}.mlflow.{reference}")
+        elif name == "posthog":
+            _validate_optional_environment_reference(
+                _require_mapping(child, f"{location}.posthog").get("project_token_env"),
+                f"{location}.posthog.project_token_env",
+            )
 
 
 def _validate_environment_reference(value: object, location: str) -> str:
@@ -567,6 +598,7 @@ def _flatten_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
     log = table("logging")
     llm = table("llm")
     mlflow = table("mlflow")
+    posthog = table("posthog")
     values: dict[str, Any] = {
         "app_name": application.get("name"),
         "run_environment": runtime.get("environment"),
@@ -600,6 +632,9 @@ def _flatten_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
         "volume_name": daytona.get("volume_name"),
         "volume_mount_path": daytona.get("volume_mount_path"),
         "log_level": log.get("level"),
+        "posthog_enabled": posthog.get("enabled", False),
+        "posthog_project_token_env": posthog.get("project_token_env"),
+        "posthog_host": posthog.get("host"),
     }
     if "tracing_enabled" in mlflow:
         values["mlflow_tracing_enabled"] = mlflow["tracing_enabled"]
@@ -639,6 +674,8 @@ def _flatten_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
     optional = {
         "database_url_env",
         "daytona_api_key_env",
+        "posthog_project_token_env",
+        "posthog_host",
         "daytona_snapshot",
         "daytona_org_id",
         "root_llm_model_provider_service",
@@ -890,6 +927,9 @@ def load_runtime_settings() -> Settings:
     values["database_url"] = _resolve_environment_value(database_url_env, dotenv)
     daytona_api_key = _resolve_environment_value(daytona_api_key_env, dotenv)
     values["daytona_api_key"] = SecretStr(daytona_api_key) if daytona_api_key is not None else None
+    posthog_project_token_env = values.pop("posthog_project_token_env", None)
+    posthog_project_token = _resolve_environment_value(posthog_project_token_env, dotenv)
+    values["posthog_project_token"] = SecretStr(posthog_project_token) if posthog_project_token is not None else None
     for settings_field in (
         "root_llm_base_url",
         "sub_llm_base_url",

--- a/src/fleet_rlm/config.py
+++ b/src/fleet_rlm/config.py
@@ -309,7 +309,15 @@ class Settings(BaseModel):
     @field_validator("llm_base_url", mode="before")
     @classmethod
     def _sanitize_llm_base_url(cls, value: object) -> str | None:
-        """Only keep real http(s) bases; ignore secrets/comments pasted into .env."""
+        """
+        Normalize an optional LLM service base URL.
+        
+        Parameters:
+            value (object): Candidate URL value to sanitize.
+        
+        Returns:
+            str | None: The normalized HTTP(S) URL without trailing slashes, or `None` for empty or invalid values.
+        """
         if value is None or value == "":
             return None
         text = str(value).strip().strip("'\"")
@@ -322,7 +330,18 @@ class Settings(BaseModel):
     @field_validator("posthog_host")
     @classmethod
     def _validate_posthog_host(cls, value: str | None) -> str | None:
-        """PostHog ingestion hosts must be real http(s) endpoints."""
+        """
+        Validate and normalize the optional PostHog ingestion host.
+        
+        Parameters:
+            value (str | None): PostHog ingestion host URL.
+        
+        Returns:
+            str | None: The normalized URL without a trailing slash, or ``None`` for an empty value.
+        
+        Raises:
+            ValueError: If the value is not an absolute HTTP or HTTPS URL.
+        """
         if value is None or value == "":
             return None
         text = str(value).strip()
@@ -334,6 +353,18 @@ class Settings(BaseModel):
     @field_validator("daytona_snapshot", mode="before")
     @classmethod
     def _sanitize_daytona_snapshot(cls, value: object) -> str | None:
+        """
+        Normalize and validate a Daytona snapshot name.
+        
+        Parameters:
+            value (object): Candidate snapshot name.
+        
+        Returns:
+            str | None: The validated snapshot name, or `None` for empty values.
+        
+        Raises:
+            ValueError: If the snapshot name is not immutable or does not end with a positive version number.
+        """
         if value is None:
             return None
         text = str(value).strip()
@@ -551,6 +582,19 @@ def _validate_policy_table(value: object, location: str, *, allow_partial_llm: b
 
 
 def _validate_environment_reference(value: object, location: str) -> str:
+    """
+    Validate and return an uppercase environment-variable name.
+    
+    Parameters:
+    	value (object): Value to validate as an environment-variable name
+    	location (str): Configuration location used in validation errors
+    
+    Returns:
+    	str: The validated environment-variable name
+    
+    Raises:
+    	FleetConfigurationError: If the value is not a valid uppercase environment-variable name
+    """
     if not isinstance(value, str) or not _ENVIRONMENT_NAME.fullmatch(value):
         raise FleetConfigurationError(f"{location} must name an uppercase environment variable")
     return value
@@ -898,14 +942,13 @@ def _require_managed_profile_environment_values(
 
 def load_runtime_settings() -> Settings:
     """
-    Load and validate the active Fleet runtime configuration.
-
+    Load and validate the runtime settings for the active Fleet profile.
+    
     Returns:
-        Settings: The resolved runtime settings for the selected profile.
-
+        Settings: Resolved runtime settings, including environment-backed values.
+    
     Raises:
-        FleetConfigurationError: If the configuration file is missing or contains invalid, incomplete,
-            or unsupported settings.
+        FleetConfigurationError: If the policy is missing, incomplete, invalid, or unsupported, or required environment values are unavailable.
     """
     dotenv = dotenv_values(".env")
     document = _read_policy_document(_CONFIG_PATH)

--- a/src/fleet_rlm/config.py
+++ b/src/fleet_rlm/config.py
@@ -311,10 +311,10 @@ class Settings(BaseModel):
     def _sanitize_llm_base_url(cls, value: object) -> str | None:
         """
         Normalize an optional LLM service base URL.
-        
+
         Parameters:
             value (object): Candidate URL value to sanitize.
-        
+
         Returns:
             str | None: The normalized HTTP(S) URL without trailing slashes, or `None` for empty or invalid values.
         """
@@ -332,13 +332,13 @@ class Settings(BaseModel):
     def _validate_posthog_host(cls, value: str | None) -> str | None:
         """
         Validate and normalize the optional PostHog ingestion host.
-        
+
         Parameters:
             value (str | None): PostHog ingestion host URL.
-        
+
         Returns:
             str | None: The normalized URL without a trailing slash, or ``None`` for an empty value.
-        
+
         Raises:
             ValueError: If the value is not an absolute HTTP or HTTPS URL.
         """
@@ -355,13 +355,13 @@ class Settings(BaseModel):
     def _sanitize_daytona_snapshot(cls, value: object) -> str | None:
         """
         Normalize and validate a Daytona snapshot name.
-        
+
         Parameters:
             value (object): Candidate snapshot name.
-        
+
         Returns:
             str | None: The validated snapshot name, or `None` for empty values.
-        
+
         Raises:
             ValueError: If the snapshot name is not immutable or does not end with a positive version number.
         """
@@ -584,16 +584,16 @@ def _validate_policy_table(value: object, location: str, *, allow_partial_llm: b
 def _validate_environment_reference(value: object, location: str) -> str:
     """
     Validate and return an uppercase environment-variable name.
-    
+
     Parameters:
-    	value (object): Value to validate as an environment-variable name
-    	location (str): Configuration location used in validation errors
-    
+        value (object): Value to validate as an environment-variable name
+        location (str): Configuration location used in validation errors
+
     Returns:
-    	str: The validated environment-variable name
-    
+        str: The validated environment-variable name
+
     Raises:
-    	FleetConfigurationError: If the value is not a valid uppercase environment-variable name
+        FleetConfigurationError: If the value is not a valid uppercase environment-variable name
     """
     if not isinstance(value, str) or not _ENVIRONMENT_NAME.fullmatch(value):
         raise FleetConfigurationError(f"{location} must name an uppercase environment variable")
@@ -943,12 +943,13 @@ def _require_managed_profile_environment_values(
 def load_runtime_settings() -> Settings:
     """
     Load and validate the runtime settings for the active Fleet profile.
-    
+
     Returns:
         Settings: Resolved runtime settings, including environment-backed values.
-    
+
     Raises:
-        FleetConfigurationError: If the policy is missing, incomplete, invalid, or unsupported, or required environment values are unavailable.
+        FleetConfigurationError: If the policy is missing, incomplete, invalid, or unsupported, or
+            required environment values are unavailable.
     """
     dotenv = dotenv_values(".env")
     document = _read_policy_document(_CONFIG_PATH)

--- a/src/fleet_rlm/config_policy.py
+++ b/src/fleet_rlm/config_policy.py
@@ -279,6 +279,9 @@ _FIELDS: tuple[PolicyField, ...] = (
         "Tracing SQL warehouse environment variable",
         "text",
     ),
+    PolicyField("posthog.enabled", "PostHog", "Analytics enabled", "boolean", settings_field="posthog_enabled"),
+    PolicyField("posthog.project_token_env", "PostHog", "Project token environment variable", "text"),
+    PolicyField("posthog.host", "PostHog", "Ingestion host", "text", settings_field="posthog_host"),
 )
 _FIELD_BY_PATH = {field.path: field for field in _FIELDS}
 

--- a/src/fleet_rlm/posthog_client.py
+++ b/src/fleet_rlm/posthog_client.py
@@ -52,13 +52,11 @@ def _load_or_create_instance_id(data_root: str) -> str:
 
 
 def init_posthog(settings: Settings) -> None:
-    """Initialise the singleton PostHog client from the selected TOML policy.
-
-    Called once during the FastAPI lifespan startup. Re-initialisation is
-    idempotent: a previous client is shut down first, and when the policy
-    disables PostHog, or enables it without a resolvable project token, the
-    module stays a no-op and startup never fails (fail-soft, mirroring the
-    MLflow runtime).
+    """
+    Initialize the singleton PostHog client according to the configured analytics policy.
+    
+    Parameters:
+        settings (Settings): Application settings containing the analytics policy, project token, host, and data root.
     """
     global _client, _atexit_registered, _distinct_id
 
@@ -88,10 +86,7 @@ def init_posthog(settings: Settings) -> None:
 
 
 def shutdown_posthog() -> None:
-    """Flush and shut down the PostHog client.
-
-    Called once during the FastAPI lifespan shutdown.
-    """
+    """Shut down the active PostHog client and clear the client reference."""
     global _client
     if _client is not None:
         _client.shutdown()
@@ -99,14 +94,19 @@ def shutdown_posthog() -> None:
 
 
 def get_client() -> Posthog | None:
-    """Return the live PostHog client, or *None* when analytics are disabled."""
+    """Provides access to the active PostHog analytics client.
+    
+    Returns:
+        Posthog | None: The active client, or `None` when analytics are disabled.
+    """
     return _client
 
 
 def get_distinct_id() -> str:
-    """Return the stable per-installation analytics identity.
-
-    All events must use this single identity so every install maps to exactly
-    one PostHog user. Falls back to a process-random id when never initialised.
+    """
+    Provide the analytics identity for the current installation.
+    
+    Returns:
+        str: The persistent installation identity, or a process-random identity if initialization has not occurred.
     """
     return _distinct_id or str(uuid.uuid4())

--- a/src/fleet_rlm/posthog_client.py
+++ b/src/fleet_rlm/posthog_client.py
@@ -1,0 +1,112 @@
+"""PostHog analytics client for Fleet RLM.
+
+Initialised once in the FastAPI lifespan and shared across the process.
+The client is optional and policy-controlled: the selected ``config/fleet.toml``
+profile decides whether analytics are enabled and which environment variable
+holds the project token. A disabled or unconfigured client is a no-op so the
+app always boots cleanly.
+
+All events share one stable per-installation ``distinct_id`` persisted under
+``<data_root>/analytics-instance-id``. The deterministic ``LocalScope.user_id``
+is identical across installs and would collapse every deployment into one
+PostHog user, so it is never used as the analytics identity.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import uuid
+from pathlib import Path
+
+from posthog import Posthog
+
+from fleet_rlm.config import Settings
+
+logger = logging.getLogger(__name__)
+
+_client: Posthog | None = None
+_distinct_id: str | None = None
+_atexit_registered = False
+
+
+def _load_or_create_instance_id(data_root: str) -> str:
+    """Return the persistent per-installation analytics identity.
+
+    Reads or writes a fresh ``uuid4`` under ``data_root``. The id is stable
+    across restarts and unique per install; persistence failures never block
+    startup and fall back to a process-random id.
+    """
+    path = Path(data_root) / "analytics-instance-id"
+    try:
+        if path.is_file():
+            existing = path.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+        fresh = str(uuid.uuid4())
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(fresh, encoding="utf-8")
+        return fresh
+    except OSError:
+        return str(uuid.uuid4())
+
+
+def init_posthog(settings: Settings) -> None:
+    """Initialise the singleton PostHog client from the selected TOML policy.
+
+    Called once during the FastAPI lifespan startup. Re-initialisation is
+    idempotent: a previous client is shut down first, and when the policy
+    disables PostHog, or enables it without a resolvable project token, the
+    module stays a no-op and startup never fails (fail-soft, mirroring the
+    MLflow runtime).
+    """
+    global _client, _atexit_registered, _distinct_id
+
+    if _client is not None:
+        _client.shutdown()
+        _client = None
+
+    if not settings.posthog_enabled:
+        logger.info("PostHog analytics disabled by the selected policy")
+        return
+
+    token = settings.posthog_project_token.get_secret_value() if settings.posthog_project_token is not None else None
+    if not token:
+        logger.error("PostHog: enabled by policy but no project token resolved — analytics are disabled")
+        return
+
+    _distinct_id = _load_or_create_instance_id(settings.data_root)
+    _client = Posthog(
+        token,
+        host=settings.posthog_host or None,
+        enable_exception_autocapture=False,
+    )
+    if not _atexit_registered:
+        atexit.register(shutdown_posthog)
+        _atexit_registered = True
+    logger.info("PostHog analytics initialised (host=%s)", settings.posthog_host or "default")
+
+
+def shutdown_posthog() -> None:
+    """Flush and shut down the PostHog client.
+
+    Called once during the FastAPI lifespan shutdown.
+    """
+    global _client
+    if _client is not None:
+        _client.shutdown()
+        _client = None
+
+
+def get_client() -> Posthog | None:
+    """Return the live PostHog client, or *None* when analytics are disabled."""
+    return _client
+
+
+def get_distinct_id() -> str:
+    """Return the stable per-installation analytics identity.
+
+    All events must use this single identity so every install maps to exactly
+    one PostHog user. Falls back to a process-random id when never initialised.
+    """
+    return _distinct_id or str(uuid.uuid4())

--- a/src/fleet_rlm/posthog_client.py
+++ b/src/fleet_rlm/posthog_client.py
@@ -54,7 +54,12 @@ def _load_or_create_instance_id(data_root: str) -> str:
 def init_posthog(settings: Settings) -> None:
     """
     Initialize the singleton PostHog client according to the configured analytics policy.
-    
+
+    Called once during the FastAPI lifespan startup. Re-initialisation is idempotent: a previous
+    client is shut down first. When the policy disables PostHog, or enables it without a
+    resolvable project token, the module stays a no-op and startup never fails (fail-soft,
+    mirroring the MLflow runtime).
+
     Parameters:
         settings (Settings): Application settings containing the analytics policy, project token, host, and data root.
     """
@@ -86,7 +91,10 @@ def init_posthog(settings: Settings) -> None:
 
 
 def shutdown_posthog() -> None:
-    """Shut down the active PostHog client and clear the client reference."""
+    """Shut down the active PostHog client and clear the client reference.
+
+    Called once during the FastAPI lifespan shutdown.
+    """
     global _client
     if _client is not None:
         _client.shutdown()
@@ -94,8 +102,8 @@ def shutdown_posthog() -> None:
 
 
 def get_client() -> Posthog | None:
-    """Provides access to the active PostHog analytics client.
-    
+    """Return the active PostHog analytics client.
+
     Returns:
         Posthog | None: The active client, or `None` when analytics are disabled.
     """
@@ -105,8 +113,9 @@ def get_client() -> Posthog | None:
 def get_distinct_id() -> str:
     """
     Provide the analytics identity for the current installation.
-    
-    Returns:
-        str: The persistent installation identity, or a process-random identity if initialization has not occurred.
+
+    All events must use this single identity so every install maps to exactly one PostHog user.
+    Returns the persistent installation identity, or a process-random identity if initialization
+    has not occurred.
     """
     return _distinct_id or str(uuid.uuid4())

--- a/tests/unit/backend/test_mlflow_runtime.py
+++ b/tests/unit/backend/test_mlflow_runtime.py
@@ -160,3 +160,86 @@ def test_app_lifespan_starts_tracing_and_closes_explicitly(monkeypatch: pytest.M
         assert client.get("/openapi.json").status_code == 200
     assert calls == ["configure", "flush"]
     assert app.state.mlflow_runtime.state is MLflowRuntimeState.CLOSED
+
+
+def test_mlflow_runtime_start_failure_still_shuts_down_posthog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify shutdown_posthog() is called even when mlflow_runtime.start() raises."""
+    from fleet_rlm.posthog_client import shutdown_posthog
+
+    shutdown_posthog()
+    posthog_calls: list[str] = []
+    configure_calls: list[str] = []
+
+    def track_init(_settings: Settings) -> None:
+        posthog_calls.append("init")
+
+    def track_shutdown() -> None:
+        posthog_calls.append("shutdown")
+
+    def fail_configure(_settings: Settings) -> bool:
+        configure_calls.append("configure")
+        raise RuntimeError("mlflow unavailable")
+
+    def install(app, settings, *, database):
+        del app, settings
+        return SimpleNamespace(
+            run_state_store=SimpleNamespace(),
+            run_cleanup_supervisor=None,
+            database=database,
+        )
+
+    monkeypatch.setattr("fleet_rlm.app.init_posthog", track_init)
+    monkeypatch.setattr("fleet_rlm.app.shutdown_posthog", track_shutdown)
+    monkeypatch.setattr("fleet_rlm.observability.tracing.configure_tracing", fail_configure)
+    app = create_app(settings=_settings(), _composition_installer=install)
+
+    assert posthog_calls == []
+    with pytest.raises(RuntimeError, match="mlflow unavailable"), TestClient(app):
+        pass
+    # Verify shutdown_posthog was called despite mlflow_runtime.start() raising
+    assert posthog_calls == ["init", "shutdown"]
+    assert configure_calls == ["configure"]
+
+
+def test_mlflow_runtime_close_failure_still_shuts_down_posthog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify shutdown_posthog() is called even when mlflow_runtime.close() raises."""
+    from fleet_rlm.posthog_client import shutdown_posthog
+
+    shutdown_posthog()
+    posthog_calls: list[str] = []
+    flush_calls: list[str] = []
+
+    def track_init(_settings: Settings) -> None:
+        posthog_calls.append("init")
+
+    def track_shutdown() -> None:
+        posthog_calls.append("shutdown")
+
+    def configure(_settings: Settings) -> bool:
+        return True
+
+    def fail_flush() -> None:
+        flush_calls.append("flush")
+        raise RuntimeError("flush failed")
+
+    def install(app, settings, *, database):
+        del app, settings
+        return SimpleNamespace(
+            run_state_store=SimpleNamespace(),
+            run_cleanup_supervisor=None,
+            database=database,
+        )
+
+    monkeypatch.setattr("fleet_rlm.app.init_posthog", track_init)
+    monkeypatch.setattr("fleet_rlm.app.shutdown_posthog", track_shutdown)
+    monkeypatch.setattr("fleet_rlm.observability.tracing.configure_tracing", configure)
+    monkeypatch.setattr("fleet_rlm.observability.tracing.flush_tracing", fail_flush)
+    app = create_app(settings=_settings(), _composition_installer=install)
+
+    assert posthog_calls == []
+    # mlflow_runtime.close() raises during cleanup, but shutdown_posthog should still be called
+    with pytest.raises(RuntimeError, match="flush failed"), TestClient(app):
+        pass
+    # Verify shutdown_posthog was called despite mlflow_runtime.close() raising
+    assert posthog_calls == ["init", "shutdown"]
+    assert flush_calls == ["flush"]

--- a/tests/unit/backend/test_mlflow_runtime.py
+++ b/tests/unit/backend/test_mlflow_runtime.py
@@ -178,7 +178,7 @@ def test_mlflow_runtime_start_failure_still_shuts_down_posthog(monkeypatch: pyte
 
     def fail_configure(_settings: Settings) -> bool:
         configure_calls.append("configure")
-        raise RuntimeError("mlflow unavailable")
+        raise FleetConfigurationError("mlflow unavailable")
 
     def install(app, settings, *, database):
         del app, settings
@@ -194,7 +194,7 @@ def test_mlflow_runtime_start_failure_still_shuts_down_posthog(monkeypatch: pyte
     app = create_app(settings=_settings(), _composition_installer=install)
 
     assert posthog_calls == []
-    with pytest.raises(RuntimeError, match="mlflow unavailable"), TestClient(app):
+    with pytest.raises(FleetConfigurationError, match="mlflow unavailable"), TestClient(app):
         pass
     # Verify shutdown_posthog was called despite mlflow_runtime.start() raising
     assert posthog_calls == ["init", "shutdown"]
@@ -218,7 +218,8 @@ def test_mlflow_runtime_close_failure_still_shuts_down_posthog(monkeypatch: pyte
     def configure(_settings: Settings) -> bool:
         return True
 
-    def fail_flush() -> None:
+    def fail_close(self: MLflowRuntime) -> None:
+        del self
         flush_calls.append("flush")
         raise RuntimeError("flush failed")
 
@@ -233,7 +234,7 @@ def test_mlflow_runtime_close_failure_still_shuts_down_posthog(monkeypatch: pyte
     monkeypatch.setattr("fleet_rlm.app.init_posthog", track_init)
     monkeypatch.setattr("fleet_rlm.app.shutdown_posthog", track_shutdown)
     monkeypatch.setattr("fleet_rlm.observability.tracing.configure_tracing", configure)
-    monkeypatch.setattr("fleet_rlm.observability.tracing.flush_tracing", fail_flush)
+    monkeypatch.setattr(MLflowRuntime, "close", fail_close)
     app = create_app(settings=_settings(), _composition_installer=install)
 
     assert posthog_calls == []

--- a/tests/unit/backend/test_posthog_client.py
+++ b/tests/unit/backend/test_posthog_client.py
@@ -21,14 +21,15 @@ from fleet_rlm.posthog_client import (
 def _fake_posthog(created: list[tuple[str, str | None, bool]], shutdowns: list[str] | None = None) -> object:
     """
     Create a mock PostHog constructor that records client creation and shutdown events.
-    
+
     Parameters:
         created (list[tuple[str, str | None, bool]]): Collection receiving client initialization arguments.
         shutdowns (list[str] | None): Collection receiving tokens when mock clients shut down.
-    
+
     Returns:
         object: Callable mock constructor for creating clients with a shutdown method.
     """
+
     def build(token: str, host: str | None = None, enable_exception_autocapture: bool = True) -> object:
         created.append((token, host, enable_exception_autocapture))
         if shutdowns is None:

--- a/tests/unit/backend/test_posthog_client.py
+++ b/tests/unit/backend/test_posthog_client.py
@@ -19,6 +19,16 @@ from fleet_rlm.posthog_client import (
 
 
 def _fake_posthog(created: list[tuple[str, str | None, bool]], shutdowns: list[str] | None = None) -> object:
+    """
+    Create a mock PostHog constructor that records client creation and shutdown events.
+    
+    Parameters:
+        created (list[tuple[str, str | None, bool]]): Collection receiving client initialization arguments.
+        shutdowns (list[str] | None): Collection receiving tokens when mock clients shut down.
+    
+    Returns:
+        object: Callable mock constructor for creating clients with a shutdown method.
+    """
     def build(token: str, host: str | None = None, enable_exception_autocapture: bool = True) -> object:
         created.append((token, host, enable_exception_autocapture))
         if shutdowns is None:

--- a/tests/unit/backend/test_posthog_client.py
+++ b/tests/unit/backend/test_posthog_client.py
@@ -1,0 +1,184 @@
+"""Unit contracts for the policy-controlled PostHog analytics client."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from fleet_rlm.config import Settings
+from fleet_rlm.posthog_client import (
+    _load_or_create_instance_id,
+    get_client,
+    get_distinct_id,
+    init_posthog,
+    shutdown_posthog,
+)
+
+
+def _fake_posthog(created: list[tuple[str, str | None, bool]], shutdowns: list[str] | None = None) -> object:
+    def build(token: str, host: str | None = None, enable_exception_autocapture: bool = True) -> object:
+        created.append((token, host, enable_exception_autocapture))
+        if shutdowns is None:
+            return SimpleNamespace(shutdown=lambda: None)
+        return SimpleNamespace(shutdown=lambda: shutdowns.append(token))
+
+    return build
+
+
+def test_init_disabled_policy_leaves_client_disabled(monkeypatch) -> None:
+    shutdown_posthog()
+    created: list[tuple[str, str | None, bool]] = []
+    monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
+
+    init_posthog(Settings(_env_file=None, posthog_enabled=False))
+
+    assert get_client() is None
+    assert created == []
+
+
+def test_init_enabled_without_token_stays_disabled(monkeypatch) -> None:
+    shutdown_posthog()
+    created: list[tuple[str, str | None, bool]] = []
+    monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
+
+    init_posthog(Settings(_env_file=None, posthog_enabled=True))
+
+    assert get_client() is None
+    assert created == []
+
+
+def test_reinit_with_disabled_policy_shuts_down_previous_client(monkeypatch, tmp_path: Path) -> None:
+    shutdown_posthog()
+    created: list[tuple[str, str | None, bool]] = []
+    shutdowns: list[str] = []
+    monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created, shutdowns))
+    settings = Settings(
+        _env_file=None,
+        posthog_enabled=True,
+        posthog_project_token="phc-test-token",
+        data_root=str(tmp_path),
+    )
+
+    init_posthog(settings)
+    assert get_client() is not None
+
+    init_posthog(Settings(_env_file=None, posthog_enabled=False))
+
+    assert get_client() is None
+    assert shutdowns == ["phc-test-token"]
+    shutdown_posthog()
+
+
+def test_posthog_host_must_be_absolute_http_url() -> None:
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, posthog_host="eu.i.posthog.com")
+
+
+def test_posthog_host_normalizes_trailing_slash() -> None:
+    settings = Settings(_env_file=None, posthog_host="https://eu.i.posthog.com/")
+
+    assert settings.posthog_host == "https://eu.i.posthog.com"
+
+
+def test_init_enabled_with_token_creates_client_and_disables_exception_autocapture(monkeypatch, tmp_path: Path) -> None:
+    shutdown_posthog()
+    created: list[tuple[str, str | None, bool]] = []
+    monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
+
+    init_posthog(
+        Settings(
+            _env_file=None,
+            posthog_enabled=True,
+            posthog_project_token="phc-test-token",
+            posthog_host="https://eu.i.posthog.com",
+            data_root=str(tmp_path),
+        )
+    )
+
+    assert get_client() is not None
+    assert created == [("phc-test-token", "https://eu.i.posthog.com", False)]
+    shutdown_posthog()
+
+
+def test_distinct_id_is_stable_and_persisted_across_restarts(monkeypatch, tmp_path: Path) -> None:
+    shutdown_posthog()
+    created: list[tuple[str, str | None, bool]] = []
+    monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
+    settings = Settings(
+        _env_file=None,
+        posthog_enabled=True,
+        posthog_project_token="phc-test-token",
+        data_root=str(tmp_path),
+    )
+
+    init_posthog(settings)
+    first = get_distinct_id()
+    assert first
+    assert first != "local_operator"
+    shutdown_posthog()
+
+    init_posthog(settings)
+    assert get_distinct_id() == first
+    shutdown_posthog()
+
+
+def test_distinct_id_is_persisted_instance_id_not_deterministic_local_user_id(monkeypatch, tmp_path: Path) -> None:
+    shutdown_posthog()
+    created: list[tuple[str, str | None, bool]] = []
+    monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
+    settings = Settings(
+        _env_file=None,
+        posthog_enabled=True,
+        posthog_project_token="phc-test-token",
+        data_root=str(tmp_path),
+    )
+
+    init_posthog(settings)
+
+    stored = (tmp_path / "analytics-instance-id").read_text(encoding="utf-8").strip()
+    assert stored == get_distinct_id()
+    assert stored != "fleet-rlm/local-user"
+    shutdown_posthog()
+
+
+def test_load_or_create_instance_id_reads_existing_file(tmp_path: Path) -> None:
+    instance_id = "persisted-instance-id"
+    (tmp_path / "analytics-instance-id").write_text(f"{instance_id}\n", encoding="utf-8")
+
+    assert _load_or_create_instance_id(str(tmp_path)) == instance_id
+
+
+def test_load_or_create_instance_id_writes_fresh_id(tmp_path: Path) -> None:
+    instance_id = _load_or_create_instance_id(str(tmp_path))
+
+    assert instance_id
+    assert (tmp_path / "analytics-instance-id").read_text(encoding="utf-8").strip() == instance_id
+
+
+def test_default_profile_enables_posthog_and_resolves_token(monkeypatch) -> None:
+    import fleet_rlm.config as config
+
+    monkeypatch.setenv("FLEET_DAYTONA_API_KEY", "test-daytona-key")
+    monkeypatch.setenv("FLEET_OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.setenv("FLEET_OPENCODE_GO_BASE_URL", "https://gateway.example.test/v1")
+    monkeypatch.setenv("POSTHOG_PROJECT_TOKEN", "phc-policy-token")
+
+    settings = config.load_runtime_settings()
+
+    assert settings.posthog_enabled is True
+    assert settings.posthog_host == "https://eu.i.posthog.com"
+    assert settings.posthog_project_token is not None
+    assert settings.posthog_project_token.get_secret_value() == "phc-policy-token"
+
+
+def test_benchmark_profiles_disable_posthog() -> None:
+    from fleet_rlm.config import _deep_merge, _flatten_policy, _read_policy_document
+
+    document = _read_policy_document(Path("config/fleet.toml"))
+
+    for profile in ("daytona-bench", "daytona-bench-40"):
+        flattened = _flatten_policy(_deep_merge(document.defaults, document.profiles[profile]))
+        assert flattened["posthog_enabled"] is False

--- a/tools/fleet-tui/src/generated/openapi.ts
+++ b/tools/fleet-tui/src/generated/openapi.ts
@@ -35,7 +35,18 @@ export interface paths {
         /** List Sessions */
         get: operations["list_sessions"];
         put?: never;
-        /** Create Session */
+        /**
+         * Create Session
+         * @description Create a session for the authenticated user in the current workspace.
+         *
+         *     Parameters:
+         *         body (SessionCreateRequest): Session creation data, including the optional title.
+         *         identity (LocalScopeDep): Authenticated user and workspace scope.
+         *         repo (SessionCatalogDep): Session repository used to create the session.
+         *
+         *     Returns:
+         *         SessionDetailResponse: The newly created session details.
+         */
         post: operations["create_session"];
         delete?: never;
         options?: never;
@@ -57,7 +68,20 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        /** Patch Session */
+        /**
+         * Patch Session
+         * @description Update the title or status of a session within the authenticated user's workspace.
+         *
+         *     Parameters:
+         *         body (SessionPatchRequest): Fields to update; at least one field is required.
+         *
+         *     Returns:
+         *         SessionDetailResponse: The updated session details.
+         *
+         *     Raises:
+         *         HTTPException: If no fields are provided, the title is blank, the status is invalid, or the
+         *             session cannot be updated.
+         */
         patch: operations["update_session"];
         trace?: never;
     };
@@ -119,7 +143,19 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Download Artifact */
+        /**
+         * Download Artifact
+         * @description Download an artifact within the caller's workspace scope.
+         *
+         *     Parameters:
+         *         artifact_id (UUID): Identifier of the artifact to download.
+         *
+         *     Returns:
+         *         Response: The artifact content with its media type and download filename.
+         *
+         *     Raises:
+         *         HTTPException: If the artifact is missing or artifact storage is unavailable.
+         */
         get: operations["download_artifact"];
         put?: never;
         post?: never;
@@ -138,7 +174,13 @@ export interface paths {
         };
         /**
          * List Skills
-         * @description List SkillCards authorized for the caller (metadata only).
+         * @description List skill metadata available to the caller, optionally ranked by a search query.
+         *
+         *     Parameters:
+         *         q (str | None): Optional query used to rank skills by matching terms in their names or descriptions.
+         *
+         *     Returns:
+         *         list[SkillCardResponse]: Response-formatted skill cards.
          */
         get: operations["list_skills"];
         put?: never;
@@ -174,7 +216,18 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
-        /** Request Run Cancellation */
+        /**
+         * Request Run Cancellation
+         * @description Request cancellation for a run.
+         *
+         *     Parameters:
+         *         run_id (UUID): The identifier of the run to cancel.
+         *         identity (LocalScopeDep): The authenticated user's workspace scope.
+         *         lifecycle (RunLifecycleDep): The run lifecycle service.
+         *
+         *     Returns:
+         *         CancellationResponse: The run identifier and resulting cancellation state.
+         */
         put: operations["request_run_cancellation"];
         post?: never;
         delete?: never;
@@ -197,7 +250,19 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        /** Patch Settings Policy */
+        /**
+         * Patch Settings Policy
+         * @description Update the settings policy's default profile or a specified field.
+         *
+         *     Parameters:
+         *         body (SettingsPolicyPatchRequest): The requested profile or field update, including the expected revision.
+         *
+         *     Returns:
+         *         SettingsPolicyResponse: The updated settings policy.
+         *
+         *     Raises:
+         *         HTTPException: If the revision conflicts, the update is invalid, or the policy is unavailable.
+         */
         patch: operations["update_settings_policy"];
         trace?: never;
     };

--- a/uv.lock
+++ b/uv.lock
@@ -239,6 +239,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "bidict"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1155,6 +1164,7 @@ dependencies = [
     { name = "httpx2" },
     { name = "mlflow" },
     { name = "packaging" },
+    { name = "posthog" },
     { name = "psycopg" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1214,6 +1224,7 @@ requires-dist = [
     { name = "httpx2", specifier = ">=2.5.0" },
     { name = "mlflow", specifier = ">=3.15,<4" },
     { name = "packaging", specifier = ">=24,<27" },
+    { name = "posthog", specifier = ">=7.39.1,<8" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "psycopg", specifier = ">=3.3.4,<4" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'server'", specifier = ">=3.3.4,<4" },
@@ -2732,6 +2743,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/77/3737f60571995ba07677b058bb1523b7c26f28570806b8ffaf83a66df18c/posthog-7.39.1.tar.gz", hash = "sha256:0d184596e35057457fc1094883646fd23de2d6338db8b9c3ea770643fb55d8a2", size = 428586, upload-time = "2026-08-14T13:50:24.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/79/ee5c01937bfb0c80415929e25aa1e8296c48e26fc9a10fe1d9f665f0f478/posthog-7.39.1-py3-none-any.whl", hash = "sha256:e76e82fe571314a0a9bc11d039fd1a1a8d210cd0f737899d41b31f61b73bf08c", size = 504259, upload-time = "2026-08-14T13:50:22.896Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a fail-soft, policy-controlled PostHog product-analytics client. The selected `config/fleet.toml` profile decides whether analytics are enabled, which env var holds the project token, and the ingestion host. A disabled or unconfigured client is a no-op — startup never fails (mirrors the MLflow runtime pattern).

## Policy

```toml
[defaults.posthog]
enabled = true
project_token_env = "POSTHOG_PROJECT_TOKEN"
host = "https://eu.i.posthog.com"   # EU ingestion for project 15008
```

- `daytona-bench` / `daytona-bench-40` explicitly disable analytics (stay traceless, mirroring MLflow).
- Token is a `SecretStr`, resolved from the named env var, never required and never logged.
- `posthog_host` must be an absolute http(s) URL (new validator, trailing slash normalized).

## Client

- Singleton init/shutdown wired into the FastAPI lifespan; re-init is idempotent (previous client shut down first).
- One stable per-installation `distinct_id` persisted at `<data_root>/analytics-instance-id`. The deterministic `LocalScope.user_id` is never used — it is identical across installs and would collapse every deployment into one PostHog user.
- PostHog exception autocapture disabled (`enable_exception_autocapture=False`); failures are captured via sanitized `normalize_turn_failure` messages only.

## Events

| Event | Where |
|---|---|
| `session_created`, `session_updated` | `POST /api/sessions`, `PATCH /api/sessions/{id}` |
| `turn_created` | `POST /api/sessions/{id}/turns` (post-open, pre-stream) |
| `turn_failed` | turn open-failure and stream-failure phases; client disconnect excluded |
| `artifact_downloaded` | `GET /api/artifacts/{id}` |
| `run_cancellation_requested` | `POST /api/runs/{id}/cancel` |
| `skill_listed` | `GET /api/skills` |
| `settings_policy_updated` | `PATCH /api/settings/policy` |

## Other changes

- Settings API exposes `posthog.enabled` / `posthog.project_token_env` / `posthog.host` (applies on next restart).
- `posthog>=7.39.1,<8` added; `uv.lock` updated.
- Docs: configuration reference + environment inputs table.
- `.gitignore`: ignore `.chunk/context/` (local review artifacts).

## Validation

- `make check` full gate green: ruff, format, `ty check`, backend unit+contract suite (incl. 12 new PostHog tests), api-check, TUI check, codebase-tree check, docs checks.
- `git diff --check` clean; no secrets in the diff.