### PR TITLE
chore(release): bump version to 0.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,20 @@ jobs:
               echo "GITHUB_TOKEN must be configured in the CircleCI project or context" >&2
               exit 1
             }
+            export RELEASE_VERSION="<< pipeline.parameters.release_version >>"
+            python - <<'PY'
+            import os
+            import tomllib
+
+            requested = os.environ["RELEASE_VERSION"].removeprefix("v")
+            with open("pyproject.toml", "rb") as handle:
+                project_version = tomllib.load(handle)["project"]["version"]
+            if project_version != requested:
+                raise SystemExit(
+                    f"release_version {requested!r} does not match pyproject.toml {project_version!r}"
+                )
+            print(f"Preparing fleet-rlm {project_version} for the PyPI deployment bridge")
+            PY
       - run:
           name: Plan a PyPI deploy
           command: |

--- a/.circleci/test-suites.yml
+++ b/.circleci/test-suites.yml
@@ -1,6 +1,6 @@
 ---
 name: pytest-unit
-discover: bash -c 'find tests/unit tests/contracts -type f -name "*.py" ! -name "__init__.py" -print | sort'
+discover: bash -c 'find tests/unit tests/contracts -type f -name "*.py" ! -name "__init__.py" ! -name "fakes.py" -print | sort'
 run: bash -c 'set -f; mkdir -p test-results; .venv/bin/pytest -p no:warnings -m "not live_llm and not live_daytona and not benchmark and not db" --junit-xml=<< outputs.junit >> << test.atoms >>'
 outputs:
   junit: test-results/pytest-unit.xml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.7.1
+  version: 0.7.2
 paths:
   /api/sessions/{session_id}/turns:
     post:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-rlm"
-version = "0.7.1"
+version = "0.7.2"
 description = "RLM-native FastAPI backend with DSPy and Daytona"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1151,7 +1151,7 @@ wheels = [
 
 [[package]]
 name = "fleet-rlm"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Bump Fleet RLM package, lockfile, and generated OpenAPI metadata to 0.7.2.
- Add an active CircleCI PyPI deployment preflight that rejects a release parameter mismatching `pyproject.toml`.
- Use the existing `CHANGELOG.md` 0.7.2 section as the GitHub release note source.

## Validation

- `make check`
- `make check-security`
- `make check-release`
- `make api-check`
- `make build-release`
- `twine check`
- `circleci config validate/process` for the active, deploy, and rollback configs
- `git diff --check`

The deployment remains opt-in through CircleCI `deploy_pypi=true` with `release_version=0.7.2`.