### PR TITLE
fix(ci): escape release validation heredoc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
               exit 1
             }
             export RELEASE_VERSION="<< pipeline.parameters.release_version >>"
-            python - <<'PY'
+            python - \<<'PY'
             import os
             import tomllib
 


### PR DESCRIPTION
Fixes the CircleCI release bridge config parser error by escaping the Python heredoc opener in `.circleci/config.yml`.\n\nValidated locally with `circleci config validate`, `circleci config process`, and `git diff --check`.