### PR TITLE
feat: deliver P29-P33 milestone hardening

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
 * [Evaluation and monitoring](how-to-guides/evaluation-optimization.md)
 * [Terminal UI](how-to-guides/terminal-tui.md)
 * [Workspace Memory degradation diagnostics](how-to-guides/workspace-memory-degradation.md)
+* [Maintainability freeze](how-to-guides/maintainability-freeze.md)
 * [Reference](reference/index.md)
   * [Configuration](reference/configuration.md)
   * [Runtime Profile Matrix](reference/profile-matrix.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 * [Official Oolong benchmark](how-to-guides/official-oolong.md)
 * [Evaluation and monitoring](how-to-guides/evaluation-optimization.md)
 * [Terminal UI](how-to-guides/terminal-tui.md)
+* [Workspace Memory degradation diagnostics](how-to-guides/workspace-memory-degradation.md)
 * [Reference](reference/index.md)
   * [Configuration](reference/configuration.md)
   * [Runtime Profile Matrix](reference/profile-matrix.md)

--- a/docs/agent-harness/architecture-invariants.md
+++ b/docs/agent-harness/architecture-invariants.md
@@ -55,6 +55,29 @@ and its matching automated check in the same patch.
   replace Run Ownership, child-runtime state, or Daytona lease/quarantine
   receipts; those domains retain their specialized state and fallback policy.
 
+## Final maintainability freeze (P34)
+
+- Every deep seam has one owner and one canonical representation. A private
+  helper is acceptable when it keeps a boundary local; duplicate adapters,
+  pass-through wrappers, repeated normalization/serialization, and dead aliases
+  are not.
+- `daytona/memory_diagnostics.py` classifies optional read-side degradation into
+  the closed `MemoryFailureCategory` vocabulary. Diagnostics are bounded and
+  sanitized; mutation and list paths remain strict. A new catch site must use
+  the existing classifier rather than inventing a parallel warning format.
+- `config.py` is the source of truth for `FleetFieldPolicy` metadata and
+  `config_policy.py` derives its editor inventory from it. No second complete
+  configuration-field mirror is allowed.
+- `tools/fleet-tui/src/tui/tests/turn-reducer-invariants.test.ts` is the
+  deterministic P32 proof that live and durable projections converge through
+  one canonical reducer. Wire adapters own casing and framing compatibility;
+  the reducer does not.
+- P34 excludes model routing/tuning, recursion or throughput changes, schema
+  changes, Memory format changes, and public contract changes. A cleanup is
+  valid only after all consumers and the full deterministic matrix have been
+  checked. The live Daytona gate remains separately required evidence when the
+  delivery claims live certification.
+
 ## Product identity
 
 Fleet is one product: a durable conversational RLM Session. Judge every change

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,6 +278,13 @@ gated and has not been run.
 
 ## Compatibility and status
 
+The maintainability baseline is frozen by the [P34 certification guide](how-to-guides/maintainability-freeze.md).
+It records the one-owner seams for lifecycle settlement, native RLM
+observation, recursive child cleanup, the Workspace agent, Memory diagnostics,
+configuration metadata, and canonical TUI reduction. The freeze is structural:
+it does not authorize model-routing, latency, throughput, schema, Memory-format,
+or public HTTP/SSE changes.
+
 There is no legacy backend, `/api/v1`, WebSocket execution, dual-serve, data
 migration layer, classic terminal renderer, or maintained Web frontend. A
 future graphical client is a separate effort. The current module ownership is

--- a/docs/how-to-guides/maintainability-freeze.md
+++ b/docs/how-to-guides/maintainability-freeze.md
@@ -1,0 +1,77 @@
+# Maintainability freeze
+
+P34 is the certification gate for the P26–P33 maintainability hardening. It
+freezes implementation ownership and verifies that the structural changes did
+not change Fleet's public behavior, persistence model, Workspace Memory format,
+provider lifecycle, or native DSPy execution contract.
+
+## Ownership matrix
+
+| Concern | Canonical owner | Regression proof |
+| --- | --- | --- |
+| Turn stream, terminal ordering, and final cleanup | `chat/turn_coordinator.py` | coordinator and stream contract suites |
+| Result validation, Artifact publication, and atomic Turn commit | `chat/run_lifecycle.py` | result snapshot and lifecycle contract suites |
+| Native RLM execution and worker observation | `rlm/runner.py`, `rlm/worker_execution.py`, `rlm/observation.py`, `rlm/execution_trace.py` | native RLM and recursive delegation suites |
+| Waits for already-started asynchronous effects | `runtime/owned_effect.py` | owned-effect and cancellation suites |
+| Recursive child acquisition, settlement, and late ownership | `daytona/recursive_child_*.py` | child cleanup, cancellation, and provider-boundary suites |
+| Installed and fallback Workspace agent protocol | `daytona/workspace_agent.py`, `daytona/workspace_agent_runtime.py` | Workspace agent handshake and file/Memory suites |
+| Workspace Memory fail-soft classification | `daytona/memory_diagnostics.py` | Memory diagnostics and observability sanitation suites |
+| Configuration field metadata and editor inventory | `config.py`, `config_policy.py` | configuration policy and settings API suites |
+| Canonical live/durable TUI projection | `tools/fleet-tui/src/tui/canonical.ts`, `live-adapter.ts`, `durable-adapter.ts`, `turn-reducer.ts` | `turn-reducer-invariants.test.ts` |
+
+Each row has one transformation owner at its seam. Adapters may translate a
+wire representation into the canonical representation, but downstream code
+must not repeat that conversion. Private modules may remain separate when they
+keep ownership local; file-count reduction is not a freeze objective.
+
+## Freeze constraints
+
+The P34 baseline does not include:
+
+- model routing, LM selection, recursion width/depth, latency, throughput,
+  batching, or Sandbox pooling changes;
+- public FastAPI, OpenAPI, SSE, or generated-client changes;
+- SQLite schema/state-machine or Workspace Memory format changes;
+- new DSPy private-API dependencies or weakened provider cleanup guarantees;
+- deletion of a compatibility path that still has a supported consumer.
+
+Superseded private helpers may be deleted only after the deterministic matrix
+is green and their consumers have been checked. Legacy Memory migration,
+wire-format adapters, test/live monkeypatch seams, and explicit process-only
+Workspace-agent compatibility remain supported behavior where their owning
+tests require them.
+
+## Certification matrix
+
+Run the deterministic gates from the exact delivery tip and retain the command
+and pass/fail result in the delivery record:
+
+```bash
+make check
+make check-security
+make build-release
+make check-release
+git diff --check
+```
+
+`make check` covers the non-live Python, contract, generated-artifact, TUI,
+codebase-boundary, and documentation lanes. The credentialed Daytona lane is
+explicit and must be run separately with `FLEET_LIVE=1` using the maintained
+live-proof scripts/tests. Record only the commit SHA, safe test/profile or
+snapshot identifiers, command, and pass/fail summary; never retain credentials,
+provider tokens, or Workspace Memory contents.
+
+The live gate must cover native root execution, recursive child acquisition and
+confirmed cleanup, shared-Volume Workspace operations, the installed agent
+handshake, and absence of provider resources after terminal Run paths. A live
+proof that was not run remains unverified; deterministic green is not a
+substitute for that evidence.
+
+## Drift response
+
+When a guardrail fails, repair the owning P26–P33 seam or update this guide and
+its matching contract check in the same change. Do not hide a failed gate by
+loosening a public assertion, adding a second transformation pipeline, or
+reintroducing a deleted alias. Update [the codebase map](../reference/codebase-map.md)
+and [architecture invariants](../agent-harness/architecture-invariants.md) when
+module ownership changes.

--- a/docs/how-to-guides/workspace-memory-degradation.md
+++ b/docs/how-to-guides/workspace-memory-degradation.md
@@ -1,0 +1,48 @@
+# Workspace Memory degradation diagnostics
+
+Workspace Memory preparation is intentionally fail-soft: a Turn proceeds even
+when Storage, the mounted Workspace agent, or Memory search degrades, because
+Memory context is optional. Fail-soft must not mean invisible. Every degraded
+preparation operation records exactly one bounded, sanitized diagnostic so
+operators can tell *why* Memory context fell back.
+
+## Where diagnostics appear
+
+- **Logs**: `WARNING` records from `fleet_rlm.daytona.memory_diagnostics`
+  with the pattern
+  `Workspace Memory degraded: category=… operation=… runtime=… cause_type=… outcome=…`.
+- **MLflow Turn traces** (when tracing is enabled by the selected TOML
+  profile): the same five fields are attached to the active `fleet_turn` span
+  as `fleet.memory_degradation.*` attributes.
+
+Diagnostics are bounded: they contain only the fields above. Memory contents,
+search queries, file paths, exception messages, environment values, and other
+high-cardinality or sensitive payloads are never attached, and emission is one
+record per degraded operation, never per record or token. When tracing is
+disabled or MLflow is unavailable, the structured log still appears and the
+Turn result is unaffected.
+
+## Categories
+
+| `category` | Likely area |
+| --- | --- |
+| `normalization` | Turn request could not be normalized into a search query (input preparation). Memory falls back to the recency-only digest. |
+| `provider_unavailable` | The mounted Workspace agent / Volume storage failed or is unreachable (Daytona Sandbox, Volume mount, agent process). Memory falls back to recency-only or no injection. |
+| `corrupt_record_set` | A mounted-agent Memory payload violated its checked response shape (store corruption or provider-side tampering). |
+| `invariant_violation` | The durable store contains duplicate/stable-id rows that fail closed. Repair or dedupe `memory/MEMORIES.md` in the Workspace Volume. |
+| `search_failure` | The lexical relevance-search machinery failed after normalization succeeded. Memory falls back to the recency-only digest. |
+| `legacy_migration` | The legacy root `MEMORIES.md` → `memory/MEMORIES.md` migration/read sequence failed (for example a non-regular file at the legacy path). |
+| `unexpected_internal` | None of the above matched: a programming defect or broken invariant. File a bug; the `cause_type` field names the exception class. |
+
+`operation` identifies the fail-soft seam: `normalize_query`,
+`relevance_search` (falls back to the recency-only digest), or
+`injection_digest` (falls back to no Memory injection).
+`fallback_outcome` is `recency_only_digest` or `no_memory_injection`.
+
+## What stays strict
+
+Degradation observability never loosens existing guarantees: Memory mutations
+(`remember`, `edit_memory`, `forget`) and `list_memories` still fail closed on
+duplicate ids, invalid records, or unavailable storage, and surface through
+the normal Tool error path (`unavailable`/`full`/`invalid_*` codes). Only the
+optional read-side Turn preparation is fail-soft.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ FastAPI/SSE contract backed by DSPy, Daytona, and SQLAlchemy/Alembic.
 10. [Official Oolong benchmark](how-to-guides/official-oolong.md)
 11. [Evaluation and monitoring](how-to-guides/evaluation-optimization.md)
 12. [Agent harness](agent-harness/README.md)
+13. [Maintainability freeze](how-to-guides/maintainability-freeze.md)
 
 ## Reference
 

--- a/docs/reference/codebase-map.md
+++ b/docs/reference/codebase-map.md
@@ -48,6 +48,15 @@ compatibility runtime and parallel foundation package no longer exist.
   Run lifecycle, RLM worker, and equivalent provider waits use it; recursive
   batch futures and Daytona lease/quarantine state retain their specialized
   ownership and cleanup policies.
+- `daytona/memory_diagnostics.py` owns the bounded P31 degradation taxonomy:
+  normalization, provider unavailability, corrupt records, invariant
+  violations, search failure, legacy migration, and unexpected internal
+  failures. The optional read-side Memory path stays fail-soft; mutations and
+  list operations remain fail-closed.
+- `tools/fleet-tui/src/tui/tests/turn-reducer-invariants.test.ts` is the P32
+  deterministic convergence proof. Live and durable adapters may differ in
+  framing, but both reduce through the same canonical event vocabulary and
+  source-agnostic reducer.
 - `RunLifecycleService` maps outcomes to typed Claim commands, and both Run
   repositories apply them through one `transition_claim()` seam under their
   existing lock/transaction boundaries.
@@ -90,6 +99,9 @@ compatibility runtime and parallel foundation package no longer exist.
 
 The authoritative route inventory and shapes are in
 [HTTP API](http-api.md) and `openapi.yaml`.
+
+The final P34 ownership matrix, freeze constraints, and certification commands
+are maintained in [Maintainability freeze](../how-to-guides/maintainability-freeze.md).
 
 ## Maintained terminal client
 

--- a/src/fleet_rlm/AGENTS.md
+++ b/src/fleet_rlm/AGENTS.md
@@ -18,6 +18,13 @@ contracts, and tracked docs remain authoritative.
   `config.py` owns strict runtime resolution; `config_policy.py` and the
   loopback-only `/api/settings` routes edit only non-secret policy for restart.
   Do not restore ambient environment aliases or expose referenced secret values.
+  Every `Settings` field carries one authoritative `FleetFieldPolicy`
+  declaration; `_TABLE_KEYS`, policy flattening, and the editor inventory
+  derive from those declarations, so adding or renaming a supported setting
+  means editing that declaration (plus one `*_env` spec for
+  environment-resolved keys) rather than mirroring names across modules.
+  Direct `Settings(...)` construction rejects unknown keys without echoing
+  their values.
 - Keep Daytona SDK imports inside `daytona/`.
 - Create a fresh native DSPy RLM per Turn through `rlm.dspy_contract`. Native
   `RLMOptions` mirrors DSPy 3.3.x exactly: `max_iters` bounds action/REPL

--- a/src/fleet_rlm/AGENTS.md
+++ b/src/fleet_rlm/AGENTS.md
@@ -74,7 +74,11 @@ contracts, and tracked docs remain authoritative.
   idempotent for the same record, and edit/forget perform one mounted-agent
   read-modify-publish operation. Each Turn additionally receives its bounded
   4 KiB relevant+recent `workspace_memory tail` digest inside
-  `session_context`.
+  `session_context`. Memory preparation stays fail-soft, but every degraded
+  operation records one bounded, sanitized diagnostic (category, operation,
+  runtime, cause type, fallback outcome) through `daytona/memory_diagnostics.py`
+  at the adapter seam; strict mutation/list failures (including duplicate
+  stable ids) keep failing closed.
 - Resolve zero to four exact Skill selections against the immutable bundled
   catalog. Skill instructions and resources load progressively; bundled Skills
   never register executable tools. Runtime execution uses a typed

--- a/src/fleet_rlm/CONTEXT.md
+++ b/src/fleet_rlm/CONTEXT.md
@@ -217,6 +217,10 @@ Each Turn's `session_context` also carries a bounded <= 4 KiB
 `workspace_memory tail` digest so relevant and recent
 learnings are visible without a Tool call. Records are durable independently
 of Turn Commit and survive failed or cancelled Runs and Sandbox replacement.
+Optional read-side degradation is classified once by
+`daytona/memory_diagnostics.py` into a bounded sanitized category; mutation and
+list operations remain strict. Do not add a second Memory warning taxonomy or
+leak raw provider, path, query, or record content through diagnostics.
 _Avoid_: Session History, unbounded learned state
 
 **Workspace Volume Tree**:
@@ -373,6 +377,13 @@ delegation uses ordered, bounded sibling execution.
 - `workspace_fs.py` — Session Workspace FS implementation (see disambiguation above).
 - `workspace_gateway.py` — ephemeral mounted-Sandbox gateway (see disambiguation above).
 - `workspace_memory.py` — Workspace Memory store implementation (see disambiguation above).
+
+The post-P25 maintainability baseline keeps one canonical transformation at
+each seam: `RunLifecycle.finish()` commits, `TurnCoordinator` settles the
+stream, `OwnedEffect` supplies the provider-neutral wait vocabulary, and the
+TUI adapters feed one canonical reducer. See the [P34 maintainability freeze
+guide](../../docs/how-to-guides/maintainability-freeze.md) for the certification
+matrix and cleanup guardrails.
 
 ## Out of this context (for now)
 

--- a/src/fleet_rlm/chat/post_commit_memory.py
+++ b/src/fleet_rlm/chat/post_commit_memory.py
@@ -28,10 +28,6 @@ class OwnedPostCommitMemoryPromotion:
         self._action = action
         self._task: asyncio.Task[Any] | None = None
 
-    def __call__(self, candidates: tuple[Any, ...]) -> Any:
-        """Retain compatibility with simple lifecycle adapters and tests."""
-        return self._action(candidates)
-
     async def promote(
         self,
         candidates: tuple[Any, ...],

--- a/src/fleet_rlm/chat/preparation_attempt.py
+++ b/src/fleet_rlm/chat/preparation_attempt.py
@@ -6,7 +6,8 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import Any, Literal, Protocol
+from enum import StrEnum
+from typing import Any, Protocol
 
 from fleet_rlm.chat.run_cleanup import RunCleanupSupervisor
 from fleet_rlm.chat.run_lifecycle import ClaimedRun, RunFailure, RunLifecycle, RunLifecycleUnavailableError
@@ -16,6 +17,13 @@ from fleet_rlm.chat.run_preparation import PreparedRun
 logger = logging.getLogger(__name__)
 
 _PREPARATION_CLEANUP_TIMEOUT_S = 1.0
+
+
+class PreparationSettlement(StrEnum):
+    """Terminal outcome of one owned preparation settlement (typed, no string sentinels)."""
+
+    CLAIM_LOST = "claim_lost"
+    SETTLED = "settled"
 
 
 class _SubmitClaimLoss(Protocol):
@@ -124,7 +132,7 @@ class PreparationAttempt:
                     )
         return bool(pending) or self._preparation_cleanup_error is not None
 
-    async def cancel_and_settle(self, failure: RunFailure) -> Literal["claim_lost", "settled"]:
+    async def cancel_and_settle(self, failure: RunFailure) -> PreparationSettlement:
         """Cancel/timeout path: sample claim loss before and after cancel; revoke after finish."""
         claim_was_lost = self._heartbeat is not None and (self._heartbeat.lost.is_set() or self._run.authority.revoked)
         preparation_pending = await shield_cleanup(self.cancel())
@@ -132,21 +140,21 @@ class PreparationAttempt:
         if claim_was_lost:
             assert self._heartbeat is not None
             await self._submit_claim_loss_with_cleanup(preparation_pending)
-            return "claim_lost"
+            return PreparationSettlement.CLAIM_LOST
         await stop_heartbeat(self._heartbeat)
         await self._settle_failure(failure, preparation_pending, revoke_after_finish=True)
-        return "settled"
+        return PreparationSettlement.SETTLED
 
-    async def settle_failure(self, failure: RunFailure) -> Literal["claim_lost", "settled"]:
+    async def settle_failure(self, failure: RunFailure) -> PreparationSettlement:
         """Generic Exception path: claim_lost() only; finish without finally-revoke when not pending."""
         preparation_pending = await shield_cleanup(self.cancel())
         if self.claim_lost():
             assert self._heartbeat is not None
             await self._submit_claim_loss_with_cleanup(preparation_pending)
-            return "claim_lost"
+            return PreparationSettlement.CLAIM_LOST
         await stop_heartbeat(self._heartbeat)
         await self._settle_failure(failure, preparation_pending, revoke_after_finish=False)
-        return "settled"
+        return PreparationSettlement.SETTLED
 
     def _record_preparation_cleanup_error(self, exc: BaseException) -> None:
         if self._preparation_cleanup_error is None:

--- a/src/fleet_rlm/chat/run_claim.py
+++ b/src/fleet_rlm/chat/run_claim.py
@@ -173,15 +173,20 @@ def _terminal_status(status: ClaimStatus) -> ClaimTerminalStatus:
     return status
 
 
-def _failure_code(state: ClaimState) -> ClaimFailureCode:
-    if state.failure_code is not None:
-        return state.failure_code
+def failure_code_for_terminal_status(status: ClaimTerminalStatus) -> ClaimFailureCode:
+    """Derive the canonical failure code for one terminal status without intent state."""
     codes: dict[ClaimTerminalStatus, ClaimFailureCode] = {
         "failed": "execution_failed",
         "cancelled": "cancelled",
         "timeout": "timeout",
     }
-    return codes[_terminal_status(state.status)]
+    return codes[status]
+
+
+def _failure_code(state: ClaimState) -> ClaimFailureCode:
+    if state.failure_code is not None:
+        return state.failure_code
+    return failure_code_for_terminal_status(_terminal_status(state.status))
 
 
 __all__ = [
@@ -199,4 +204,5 @@ __all__ = [
     "InvalidClaimTransitionError",
     "RevokeClaim",
     "decide_claim_transition",
+    "failure_code_for_terminal_status",
 ]

--- a/src/fleet_rlm/chat/run_execution.py
+++ b/src/fleet_rlm/chat/run_execution.py
@@ -100,6 +100,20 @@ async def _wait_stream_owned(stream: RunEventStream) -> None:
         await wait_owned()
 
 
+async def _close_stream_owned(stream: RunEventStream | None, remember: Callable[[BaseException], None]) -> None:
+    """Close + owned-wait one event stream, remembering the first failure."""
+    if stream is None:
+        return
+    try:
+        await stream.aclose()
+    except BaseException as exc:
+        remember(exc)
+    try:
+        await _wait_stream_owned(stream)
+    except BaseException as exc:
+        remember(exc)
+
+
 def _heartbeat_claim_lost(state: _ExecutionState) -> bool:
     return state.heartbeat is not None and state.heartbeat.lost.is_set()
 
@@ -571,49 +585,24 @@ class RunExecutionDriver:
             state.cleanup_handed_off = True
 
             async def inline_cleanup() -> None:
-                cleanup_error = False
-                claim_cleanup_settled = not claim_lost
                 try:
                     with contextlib.suppress(BaseException):
                         await self._stop_claim_waiter(state)
+                    # Heartbeat stops before claim settlement, closing the
+                    # liveness window before the revoke like the queued path.
                     with contextlib.suppress(BaseException):
                         await stop_heartbeat(state.heartbeat)
                     state.heartbeat = None
-                    if claim_lost:
-                        try:
-                            receipt = await self._revoke_claim(run, claim_loss_usage or empty_rlm_usage())
-                        except BaseException:
-                            receipt = None
-                            cleanup_error = True
-                        claim_cleanup_settled = receipt is not None
-                        if receipt is not None and self._claim_loss_fence is not None:
-                            try:
-                                await self._claim_loss_fence(run.session_id)
-                            except BaseException:
-                                cleanup_error = True
-                                claim_cleanup_settled = False
-                    stream = state.stream
-                    if stream is not None:
-                        try:
-                            await stream.aclose()
-                        except BaseException:
-                            cleanup_error = True
-                        try:
-                            await _wait_stream_owned(stream)
-                        except BaseException:
-                            cleanup_error = True
-                    if finalization_task is not None:
-                        # The finalization task is owned until it settles; a
-                        # post-revocation lifecycle error is expected here.
-                        with contextlib.suppress(BaseException):
-                            await shield_cleanup(finalization_task)
-                    try:
-                        await prepared.aclose()
-                    except BaseException:
-                        cleanup_error = True
-                    if not cleanup_error and claim_cleanup_settled:
-                        with contextlib.suppress(BaseException):
-                            await self._lifecycle.complete_settling(run)
+                    await self._drain_owned_execution(
+                        run,
+                        prepared,
+                        state.stream,
+                        None,
+                        finalization_task,
+                        claim_lost=claim_lost,
+                        claim_loss_usage=claim_loss_usage,
+                        late_claim_loss_window=False,
+                    )
                 finally:
                     with contextlib.suppress(BaseException):
                         await self._stop_claim_waiter(state)
@@ -630,20 +619,17 @@ class RunExecutionDriver:
             await stop_heartbeat(state.heartbeat)
             if not state.cleanup_handed_off:
                 cleanup_error: BaseException | None = None
-                stream = state.stream
-                if stream is not None:
-                    try:
-                        await stream.aclose()
-                    except BaseException as exc:
+
+                def remember(exc: BaseException) -> None:
+                    nonlocal cleanup_error
+                    if cleanup_error is None:
                         cleanup_error = exc
-                    try:
-                        await _wait_stream_owned(stream)
-                    except BaseException as exc:
-                        cleanup_error = cleanup_error or exc
+
+                await _close_stream_owned(state.stream, remember)
                 try:
                     await shield_cleanup(prepared.aclose())
                 except BaseException as exc:
-                    cleanup_error = cleanup_error or exc
+                    remember(exc)
                 if cleanup_error is not None:
                     raise cleanup_error
 
@@ -677,83 +663,107 @@ class RunExecutionDriver:
         claim_loss_usage: RLMUsage | None = None,
     ) -> asyncio.Task[None]:
         async def cleanup() -> None:
-            committed = False
-            cleanup_error: BaseException | None = None
-            effective_claim_lost = claim_lost
-            claim_cleanup_attempted = False
-
-            async def apply_claim_loss() -> None:
-                nonlocal committed, claim_cleanup_attempted, effective_claim_lost
-                if claim_cleanup_attempted:
-                    return
-                claim_cleanup_attempted = True
-                effective_claim_lost = True
-                try:
-                    receipt = await self._revoke_claim(run, claim_loss_usage or empty_rlm_usage())
-                except BaseException as exc:
-                    remember(exc)
-                    return
-                # A racing commit wins: no fence and no settlement release
-                # against a committed Run.
-                committed = receipt is None
-                if receipt is not None and self._claim_loss_fence is not None:
-                    try:
-                        await self._claim_loss_fence(run.session_id)
-                    except BaseException as exc:
-                        remember(exc)
-
-            def remember(exc: BaseException) -> None:
-                nonlocal cleanup_error
-                if cleanup_error is None:
-                    cleanup_error = exc
-
-            try:
-                # Stop the heartbeat before the final durable transition. This
-                # closes the window in which claim loss can be observed after a
-                # local settlement decision but before complete_settling.
-                await stop_heartbeat(heartbeat)
-                if heartbeat is not None:
-                    effective_claim_lost = effective_claim_lost or heartbeat.lost.is_set()
-                if effective_claim_lost:
-                    await apply_claim_loss()
-                if stream is not None:
-                    try:
-                        await stream.aclose()
-                    except BaseException as exc:
-                        remember(exc)
-                    try:
-                        await _wait_stream_owned(stream)
-                    except BaseException as exc:
-                        remember(exc)
-                if finalization_task is not None:
-                    # A timeout/cancellation revokes authority before this
-                    # task settles; its expected RunLifecycleUnavailableError
-                    # is not a child-ownership failure. Waiting for the task
-                    # is the ownership proof, regardless of its result.
-                    with contextlib.suppress(BaseException):
-                        await shield_cleanup(finalization_task)
-                try:
-                    await prepared.aclose()
-                except BaseException as exc:
-                    remember(exc)
-                if heartbeat is not None and heartbeat.lost.is_set() and not effective_claim_lost:
-                    await apply_claim_loss()
-                if cleanup_error is None and not committed:
-                    try:
-                        await self._lifecycle.complete_settling(run)
-                    except BaseException as exc:
-                        remember(exc)
-            finally:
-                await stop_heartbeat(heartbeat)
+            cleanup_error = await self._drain_owned_execution(
+                run,
+                prepared,
+                stream,
+                heartbeat,
+                finalization_task,
+                claim_lost=claim_lost,
+                claim_loss_usage=claim_loss_usage,
+                late_claim_loss_window=True,
+            )
             if cleanup_error is not None:
                 raise cleanup_error
 
-        cleanup_awaitable = cleanup()
+        awaitable = cleanup()
         try:
-            return self._cleanup.submit(cleanup_awaitable)
+            return self._cleanup.submit(awaitable)
         except BaseException:
-            cleanup_awaitable.close()
+            awaitable.close()
             raise
+
+    async def _drain_owned_execution(
+        self,
+        run: ClaimedRun,
+        prepared: PreparedRun,
+        stream: RunEventStream | None,
+        heartbeat: ClaimHeartbeat | None,
+        finalization_task: asyncio.Task[RunSettlement] | None,
+        *,
+        claim_lost: bool,
+        claim_loss_usage: RLMUsage | None,
+        late_claim_loss_window: bool,
+    ) -> BaseException | None:
+        """One owned teardown order for detached cleanup paths (first failure, or None).
+
+        Heartbeat stops before the final durable transition; claim loss is
+        settled before resources close; finalization settlement is awaited as
+        ownership proof; ``complete_settling`` runs only when the teardown was
+        clean and no racing commit already settled the Run.
+        """
+        cleanup_error: BaseException | None = None
+        committed = False
+        claim_cleanup_attempted = False
+        effective_claim_lost = claim_lost
+
+        def remember(exc: BaseException) -> None:
+            nonlocal cleanup_error
+            if cleanup_error is None:
+                cleanup_error = exc
+
+        async def apply_claim_loss() -> None:
+            nonlocal committed, claim_cleanup_attempted, effective_claim_lost
+            if claim_cleanup_attempted:
+                return
+            claim_cleanup_attempted = True
+            effective_claim_lost = True
+            try:
+                receipt = await self._revoke_claim(run, claim_loss_usage or empty_rlm_usage())
+            except BaseException as exc:
+                remember(exc)
+                return
+            # A racing commit wins: no fence and no settlement release
+            # against a committed Run.
+            committed = receipt is None
+            if receipt is not None and self._claim_loss_fence is not None:
+                try:
+                    await self._claim_loss_fence(run.session_id)
+                except BaseException as exc:
+                    remember(exc)
+
+        try:
+            await stop_heartbeat(heartbeat)
+            if heartbeat is not None and heartbeat.lost.is_set():
+                effective_claim_lost = True
+            if effective_claim_lost:
+                await apply_claim_loss()
+            await _close_stream_owned(stream, remember)
+            if finalization_task is not None:
+                # A timeout/cancellation revokes authority before this task
+                # settles; waiting for it is the ownership proof regardless of
+                # its result.
+                with contextlib.suppress(BaseException):
+                    await shield_cleanup(finalization_task)
+            try:
+                await prepared.aclose()
+            except BaseException as exc:
+                remember(exc)
+            if (
+                late_claim_loss_window
+                and heartbeat is not None
+                and heartbeat.lost.is_set()
+                and not effective_claim_lost
+            ):
+                await apply_claim_loss()
+            if cleanup_error is None and not committed:
+                try:
+                    await self._lifecycle.complete_settling(run)
+                except BaseException as exc:
+                    remember(exc)
+        finally:
+            await stop_heartbeat(heartbeat)
+        return cleanup_error
 
     def _execution_deadline(self, prepared: PreparedRun) -> float:
         """Shared Turn deadline from the deep execution context (P25)."""

--- a/src/fleet_rlm/chat/run_execution.py
+++ b/src/fleet_rlm/chat/run_execution.py
@@ -106,11 +106,11 @@ async def _close_stream_owned(stream: RunEventStream | None, remember: Callable[
         return
     try:
         await stream.aclose()
-    except BaseException as exc:
+    except (Exception, asyncio.CancelledError) as exc:
         remember(exc)
     try:
         await _wait_stream_owned(stream)
-    except BaseException as exc:
+    except (Exception, asyncio.CancelledError) as exc:
         remember(exc)
 
 
@@ -720,7 +720,7 @@ class RunExecutionDriver:
             effective_claim_lost = True
             try:
                 receipt = await self._revoke_claim(run, claim_loss_usage or empty_rlm_usage())
-            except BaseException as exc:
+            except (Exception, asyncio.CancelledError) as exc:
                 remember(exc)
                 return
             # A racing commit wins: no fence and no settlement release
@@ -729,7 +729,7 @@ class RunExecutionDriver:
             if receipt is not None and self._claim_loss_fence is not None:
                 try:
                     await self._claim_loss_fence(run.session_id)
-                except BaseException as exc:
+                except (Exception, asyncio.CancelledError) as exc:
                     remember(exc)
 
         try:
@@ -747,7 +747,7 @@ class RunExecutionDriver:
                     await shield_cleanup(finalization_task)
             try:
                 await prepared.aclose()
-            except BaseException as exc:
+            except (Exception, asyncio.CancelledError) as exc:
                 remember(exc)
             if (
                 late_claim_loss_window

--- a/src/fleet_rlm/chat/run_lifecycle.py
+++ b/src/fleet_rlm/chat/run_lifecycle.py
@@ -19,10 +19,12 @@ from fleet_rlm.chat.run_claim import (
     BeginSettlement,
     ClaimCommand,
     ClaimFailure,
+    ClaimFailureCode,
     CompleteSettlement,
     FailClaim,
     HeartbeatClaim,
     RevokeClaim,
+    failure_code_for_terminal_status,
 )
 from fleet_rlm.chat.run_cleanup import RunCleanupSupervisor, RunCleanupUnavailableError
 from fleet_rlm.chat.turn_detail_policy import commit_success
@@ -126,24 +128,8 @@ class CommittedRunReplay:
 
 
 RunStart: TypeAlias = ClaimedRun | CommittedRunReplay
-RunFailureCode: TypeAlias = Literal[
-    "preparation_failed",
-    "execution_failed",
-    "commit_failed",
-    "cancelled",
-    "timeout",
-    "stale_claim",
-]
-
-
-def failure_code_for_terminal_status(
-    status: Literal["failed", "cancelled", "timeout"],
-) -> RunFailureCode:
-    if status == "cancelled":
-        return "cancelled"
-    if status == "timeout":
-        return "timeout"
-    return "execution_failed"
+# The failure-code vocabulary is owned once by run_claim; lifecycle aliases it.
+RunFailureCode: TypeAlias = ClaimFailureCode
 
 
 @dataclass(frozen=True, slots=True)
@@ -740,5 +726,4 @@ __all__ = [
     "RunStart",
     "RunStateError",
     "RunValidationError",
-    "failure_code_for_terminal_status",
 ]

--- a/src/fleet_rlm/chat/run_ownership.py
+++ b/src/fleet_rlm/chat/run_ownership.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from fleet_rlm.runtime.owned_effect import OwnedEffect
 
@@ -36,18 +35,6 @@ async def shield_cleanup(awaitable: Awaitable[T]) -> T:
     return settled.result()
 
 
-def consume_task_exception(task: asyncio.Task[Any]) -> None:
-    """
-    Consume a task's exception without propagating it.
-
-    Parameters:
-        task (asyncio.Task[Any]): The task whose exception should be retrieved.
-    """
-    if not task.cancelled():
-        with contextlib.suppress(BaseException):
-            task.exception()
-
-
 async def stop_heartbeat(heartbeat: ClaimHeartbeat | None) -> None:
     if heartbeat is None:
         return
@@ -57,7 +44,6 @@ async def stop_heartbeat(heartbeat: ClaimHeartbeat | None) -> None:
 
 __all__ = [
     "ClaimHeartbeat",
-    "consume_task_exception",
     "shield_cleanup",
     "stop_heartbeat",
 ]

--- a/src/fleet_rlm/chat/run_preparation.py
+++ b/src/fleet_rlm/chat/run_preparation.py
@@ -55,14 +55,6 @@ class RunPreparationTimeoutError(RunPreparationError):
     pass
 
 
-class RunPreparationValidationError(RunPreparationError):
-    pass
-
-
-class RunPreparationIntegrityError(RunPreparationError):
-    pass
-
-
 class RunPreparationUnavailableError(RunPreparationError):
     pass
 
@@ -418,8 +410,6 @@ __all__ = [
     "RunPreparation",
     "RunPreparationCancelledError",
     "RunPreparationError",
-    "RunPreparationIntegrityError",
     "RunPreparationTimeoutError",
     "RunPreparationUnavailableError",
-    "RunPreparationValidationError",
 ]

--- a/src/fleet_rlm/chat/session_context.py
+++ b/src/fleet_rlm/chat/session_context.py
@@ -18,13 +18,6 @@ class TurnPreview:
     role: Literal["user", "assistant"]
     preview: str
 
-    def to_input(self) -> dict[str, object]:
-        return {
-            "ordinal": self.ordinal,
-            "role": self.role,
-            "preview": self.preview,
-        }
-
 
 @dataclass(frozen=True, slots=True)
 class SessionContextManifest:
@@ -32,14 +25,6 @@ class SessionContextManifest:
     checkpoint_version: int
     message_count: int
     recent: tuple[TurnPreview, ...]
-
-    def to_input(self) -> dict[str, object]:
-        return {
-            "session_id": str(self.session_id),
-            "checkpoint_version": self.checkpoint_version,
-            "message_count": self.message_count,
-            "recent": [item.to_input() for item in self.recent],
-        }
 
 
 def build_session_context_manifest(

--- a/src/fleet_rlm/chat/turn_coordinator.py
+++ b/src/fleet_rlm/chat/turn_coordinator.py
@@ -27,7 +27,6 @@ from fleet_rlm.chat.run_lifecycle import (
 )
 from fleet_rlm.chat.run_ownership import (
     ClaimHeartbeat,
-    consume_task_exception,
     shield_cleanup,
     stop_heartbeat,
 )
@@ -329,16 +328,6 @@ class TurnCoordinator:
             await self._lifecycle.complete_settling(run)
         finally:
             await stop_heartbeat(heartbeat)
-
-    def _submit_claim_loss_cleanup(self, run: ClaimedRun, heartbeat: ClaimHeartbeat) -> None:
-        """Submit claim-loss cleanup for compatibility with synchronous callers."""
-        cleanup_awaitable = self._claim_loss_cleanup(run, heartbeat)
-        try:
-            self._cleanup.submit(cleanup_awaitable)
-        except BaseException:
-            cleanup_awaitable.close()
-            task = asyncio.create_task(self._claim_loss_cleanup(run, heartbeat), name="fleet-claim-loss-cleanup")
-            task.add_done_callback(consume_task_exception)
 
     async def _submit_claim_loss_cleanup_or_drain(
         self,

--- a/src/fleet_rlm/chat/turn_coordinator.py
+++ b/src/fleet_rlm/chat/turn_coordinator.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from fleet_rlm.chat.commands import OpenTurnCommand
 from fleet_rlm.chat.committed_turn_events import CommittedTurnEventProjector
-from fleet_rlm.chat.preparation_attempt import PreparationAttempt
+from fleet_rlm.chat.preparation_attempt import PreparationAttempt, PreparationSettlement
 from fleet_rlm.chat.run_cleanup import RunCleanupSupervisor, RunCleanupUnavailableError
 from fleet_rlm.chat.run_execution import RunExecutionDriver, RunRunner
 from fleet_rlm.chat.run_lifecycle import (
@@ -72,6 +72,12 @@ class OpenedTurnStream:
         close = getattr(self._events, "aclose", None)
         if close is not None:
             await shield_cleanup(close())
+
+
+def _settled_or_unavailable(result: PreparationSettlement) -> None:
+    """Translate the attempt's typed settlement into the coordinator's claim-loss error."""
+    if result is PreparationSettlement.CLAIM_LOST:
+        raise RunLifecycleUnavailableError("Turn claim is no longer available")
 
 
 class TurnCoordinator:
@@ -190,32 +196,32 @@ class TurnCoordinator:
         try:
             prepared = await attempt.wait()
         except (RunPreparationCancelledError, asyncio.CancelledError):
-            result = await attempt.cancel_and_settle(
-                RunFailure("cancelled", "cancelled", "Turn cancelled", empty_rlm_usage())
+            _settled_or_unavailable(
+                await attempt.cancel_and_settle(
+                    RunFailure("cancelled", "cancelled", "Turn cancelled", empty_rlm_usage())
+                )
             )
-            if result == "claim_lost":
-                raise RunLifecycleUnavailableError("Turn claim is no longer available") from None
             raise
         except (RunPreparationTimeoutError, TimeoutError) as exc:
-            result = await attempt.cancel_and_settle(
-                RunFailure("timeout", "timeout", "Turn preparation timed out", empty_rlm_usage())
+            _settled_or_unavailable(
+                await attempt.cancel_and_settle(
+                    RunFailure("timeout", "timeout", "Turn preparation timed out", empty_rlm_usage())
+                )
             )
-            if result == "claim_lost":
-                raise RunLifecycleUnavailableError("Turn claim is no longer available") from None
             if isinstance(exc, RunPreparationTimeoutError):
                 raise
             raise RunPreparationTimeoutError("Turn preparation timed out") from None
         except Exception:
-            result = await attempt.settle_failure(
-                RunFailure(
-                    "failed",
-                    "preparation_failed",
-                    "Turn could not be prepared",
-                    empty_rlm_usage(),
+            _settled_or_unavailable(
+                await attempt.settle_failure(
+                    RunFailure(
+                        "failed",
+                        "preparation_failed",
+                        "Turn could not be prepared",
+                        empty_rlm_usage(),
+                    )
                 )
             )
-            if result == "claim_lost":
-                raise RunLifecycleUnavailableError("Turn claim is no longer available") from None
             raise
         return OpenedTurnStream(
             start.run_id,

--- a/src/fleet_rlm/composition/testing.py
+++ b/src/fleet_rlm/composition/testing.py
@@ -343,7 +343,7 @@ def create_testing_app(*, settings: Settings | None = None) -> FastAPI:
 
     if settings is None:
         settings_factory: Any = Settings
-        resolved = settings_factory(_env_file=None, run_environment="daytona")
+        resolved = settings_factory(run_environment="daytona")
     else:
         resolved = settings
     return create_app(settings=resolved, _composition_installer=install_testing_composition)

--- a/src/fleet_rlm/config.py
+++ b/src/fleet_rlm/config.py
@@ -241,25 +241,6 @@ class Settings(BaseModel):
             doc="Legacy programmatic fallback key for roles naming FLEET_OPENAI_API_KEY; never settable via TOML",
         ),
     ] = Field(default=None)
-    llm_base_url: Annotated[
-        str | None,
-        FleetFieldPolicy(
-            toml_path=None, compatibility=True, doc="Programmatic-only compatibility input; no TOML mapping"
-        ),
-    ] = Field(
-        default=None,
-        description="Optional OpenAI-compatible base URL for dspy.LM",
-    )
-    llm_max_tokens: Annotated[
-        int | None,
-        FleetFieldPolicy(
-            toml_path=None, compatibility=True, doc="Programmatic-only compatibility input; no TOML mapping"
-        ),
-    ] = Field(
-        default=None,
-        ge=1,
-        description="Optional output-token limit passed to both DSPy model roles",
-    )
     root_model: Annotated[
         str,
         FleetFieldPolicy(
@@ -863,27 +844,6 @@ class Settings(BaseModel):
             return normalize_memory_candidate_categories(value)
         except ValueError as exc:
             raise ValueError("rlm_autonomous_memory_categories contains an invalid Workspace Memory category") from exc
-
-    @field_validator("llm_base_url", mode="before")
-    @classmethod
-    def _sanitize_llm_base_url(cls, value: object) -> str | None:
-        """
-        Normalize an optional LLM service base URL.
-
-        Parameters:
-            value (object): Candidate URL value to sanitize.
-
-        Returns:
-            str | None: The normalized HTTP(S) URL without trailing slashes, or `None` for empty or invalid values.
-        """
-        if value is None or value == "":
-            return None
-        text = str(value).strip().strip("'\"")
-        if " #" in text:
-            text = text.split(" #", 1)[0].rstrip().strip("'\"")
-        if not (text.startswith("http://") or text.startswith("https://")):
-            return None
-        return text.rstrip("/")
 
     @field_validator("posthog_host")
     @classmethod

--- a/src/fleet_rlm/config.py
+++ b/src/fleet_rlm/config.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
 from dotenv import dotenv_values
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, SecretStr, field_validator, model_validator
@@ -28,6 +28,37 @@ _ENVIRONMENT_NAME = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
 class FleetConfigurationError(ValueError):
     """Raised when the required Fleet runtime policy is invalid."""
+
+
+EditorKind = Literal["text", "number", "boolean", "single_choice", "multi_choice", "string_list"]
+
+
+@dataclass(frozen=True, slots=True)
+class FleetFieldPolicy:
+    """Authoritative policy declaration for one ``Settings`` field.
+
+    Every ``Settings`` field carries exactly one declaration so the supported
+    TOML location, operator grouping, editor affordances, and compatibility
+    disposition live next to the field itself.  ``_TABLE_KEYS``, policy
+    flattening, and the ``config_policy`` editor inventory derive from these
+    declarations instead of mirroring field names by hand.
+
+    ``toml_path=None`` marks fields that TOML cannot set: secrets resolved at
+    the runtime seam and programmatic-only compatibility inputs.  Operator-
+    editable fields must declare complete editor metadata plus a unique
+    ``rank`` that pins the policy inventory ordering.
+    """
+
+    toml_path: str | None
+    group: str | None = None
+    label: str | None = None
+    editor: EditorKind | None = None
+    choices: tuple[str, ...] = ()
+    rank: int | None = None
+    required_in_policy: bool = False
+    secret: bool = False
+    compatibility: bool = False
+    doc: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,158 +154,695 @@ class Settings(BaseModel):
     Production callers must use :func:`load_runtime_settings`, which derives
     these values from the selected TOML policy and its explicit environment
     references. Direct ``Settings(...)`` construction is for tests and
-    injected inventories: it accepts constructor values only.
+    injected inventories: it accepts constructor values only and rejects
+    unknown or retired keyword arguments rather than ignoring them silently.
 
     This model never scans ambient environment variables, ``.env``, or secret
     files for field names. That would let stale ``FLEET_*`` or unprefixed
     values such as ``DATABASE_URL`` override the selected TOML policy.
+
+    Each field owns one authoritative :class:`FleetFieldPolicy` policy
+    declaration. Unknown constructor/validation keys fail with a
+    :class:`FleetConfigurationError` naming the unsupported keys only —
+    values are never echoed, so a misspelled secret cannot leak.
     """
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="forbid")
 
-    app_name: str = Field(default="fleet-rlm")
-    daytona_api_key: SecretStr | None = Field(default=None)
-    daytona_snapshot: str | None = Field(default=None)
-    daytona_org_id: str | None = Field(default=None)
-    llm_api_key: SecretStr | None = Field(default=None)
-    llm_base_url: str | None = Field(
+    def __init__(self, /, **data: Any) -> None:
+        """Reject unknown keyword arguments without echoing their values."""
+        self._reject_unknown_fields(data)
+        super().__init__(**data)
+
+    @classmethod
+    def model_validate(
+        cls,
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        extra: Any = None,
+        from_attributes: bool | None = None,
+        context: Any | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
+    ) -> Settings:
+        """Reject unknown field names without echoing their values."""
+        if extra not in (None, "forbid"):
+            raise FleetConfigurationError("Settings does not permit relaxed extra-field handling")
+        if isinstance(obj, Mapping):
+            cls._reject_unknown_fields(obj)
+        return super().model_validate(
+            obj,
+            strict=strict,
+            from_attributes=from_attributes,
+            context=context,
+            by_alias=by_alias,
+            by_name=by_name,
+        )
+
+    @classmethod
+    def _reject_unknown_fields(cls, data: Mapping[Any, Any]) -> None:
+        """Fail on unsupported keys, naming keys only to protect secret values."""
+        unknown = sorted(key for key in data if key not in cls.model_fields)
+        if unknown:
+            raise FleetConfigurationError(f"unsupported Settings field(s): {', '.join(map(str, unknown))}")
+
+    app_name: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="application.name",
+            group="Application",
+            label="Name",
+            editor="text",
+            rank=0,
+            required_in_policy=True,
+        ),
+    ] = Field(default="fleet-rlm")
+    daytona_api_key: Annotated[
+        SecretStr | None,
+        FleetFieldPolicy(
+            toml_path=None, secret=True, doc="Provider credential resolved at runtime from daytona.api_key_env"
+        ),
+    ] = Field(default=None)
+    daytona_snapshot: Annotated[
+        str | None,
+        FleetFieldPolicy(toml_path="daytona.snapshot", group="Daytona", label="Snapshot", editor="text", rank=45),
+    ] = Field(default=None)
+    daytona_org_id: Annotated[
+        str | None,
+        FleetFieldPolicy(toml_path="daytona.org_id", group="Daytona", label="Organization ID", editor="text", rank=46),
+    ] = Field(default=None)
+    llm_api_key: Annotated[
+        SecretStr | None,
+        FleetFieldPolicy(
+            toml_path=None,
+            secret=True,
+            compatibility=True,
+            doc="Legacy programmatic fallback key for roles naming FLEET_OPENAI_API_KEY; never settable via TOML",
+        ),
+    ] = Field(default=None)
+    llm_base_url: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path=None, compatibility=True, doc="Programmatic-only compatibility input; no TOML mapping"
+        ),
+    ] = Field(
         default=None,
         description="Optional OpenAI-compatible base URL for dspy.LM",
     )
-    llm_max_tokens: int | None = Field(
+    llm_max_tokens: Annotated[
+        int | None,
+        FleetFieldPolicy(
+            toml_path=None, compatibility=True, doc="Programmatic-only compatibility input; no TOML mapping"
+        ),
+    ] = Field(
         default=None,
         ge=1,
         description="Optional output-token limit passed to both DSPy model roles",
     )
-    root_model: str = Field(
+    root_model: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="llm.root.model",
+            group="Root LLM",
+            label="Model id",
+            editor="text",
+            rank=7,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default="openai/gpt-4o-mini",
         description="Root model id sent through the OpenAI-compatible Chat Completion provider",
     )
-    sub_model: str = Field(
+    sub_model: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="llm.sub.model",
+            group="Sub LLM",
+            label="Model id",
+            editor="text",
+            rank=16,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default="openai/gpt-4o-mini",
         description="Sub model id sent through the OpenAI-compatible Chat Completion provider",
     )
-    database_url: str | None = Field(
+    database_url: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path=None, doc="Resolved at runtime from the environment named by storage.database_url_env"
+        ),
+    ] = Field(
         default=None,
         description="Async SQLAlchemy URL (e.g. sqlite+aiosqlite:///:memory: or postgresql+asyncpg://...)",
     )
-    volume_name: str = Field(
+    volume_name: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="daytona.volume_name",
+            group="Daytona",
+            label="Volume name",
+            editor="text",
+            rank=47,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default="rlm-volume-dspy",
         description="Daytona Volume name for workspace durable files",
     )
-    volume_mount_path: str = Field(
+    volume_mount_path: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="daytona.volume_mount_path",
+            group="Daytona",
+            label="Volume mount path",
+            editor="text",
+            rank=48,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default="/home/daytona/fleet",
         description="Absolute Sandbox mount path for the workspace Volume",
     )
-    run_environment: Literal["daytona"] = Field(default="daytona")
-    live_enabled: bool = Field(
+    run_environment: Annotated[
+        Literal["daytona"],
+        FleetFieldPolicy(
+            toml_path="runtime.environment",
+            group="Runtime",
+            label="Environment",
+            editor="single_choice",
+            choices=("daytona",),
+            rank=1,
+            required_in_policy=True,
+        ),
+    ] = Field(default="daytona")
+    live_enabled: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="runtime.live_enabled", group="Runtime", label="Live execution", editor="boolean", rank=2
+        ),
+    ] = Field(
         default=True,
         description="Allow explicitly invoked credentialed provider and benchmark commands",
     )
-    data_root: str = Field(default=".fleet_rlm")
-    max_upload_bytes: int = Field(
+    data_root: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="storage.data_root",
+            group="Storage",
+            label="Data root",
+            editor="text",
+            rank=39,
+            required_in_policy=True,
+        ),
+    ] = Field(default=".fleet_rlm")
+    max_upload_bytes: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="storage.max_upload_bytes",
+            group="Storage",
+            label="Maximum upload bytes",
+            editor="number",
+            rank=40,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default=10 * 1024 * 1024,
         description="Maximum upload size in bytes",
     )
-    max_url_bytes: int = Field(
+    max_url_bytes: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="storage.max_url_bytes",
+            group="Storage",
+            label="Maximum URL source bytes",
+            editor="number",
+            rank=41,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default=10 * 1024 * 1024,
         description="Maximum public URL source size in bytes",
     )
-    max_artifact_bytes: int = Field(
+    max_artifact_bytes: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="storage.max_artifact_bytes",
+            group="Storage",
+            label="Maximum artifact bytes",
+            editor="number",
+            rank=42,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default=10 * 1024 * 1024,
         description="Maximum artifact body size in bytes",
     )
-    turn_timeout_seconds: int = Field(
+    turn_timeout_seconds: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="runtime.turn_timeout_seconds",
+            group="Runtime",
+            label="Turn timeout seconds",
+            editor="number",
+            rank=3,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default=1800,
         gt=0,
         description="Turn Timeout in wall-clock seconds for one RLM Turn",
     )
-    max_active_daytona_leases: int = Field(
+    max_active_daytona_leases: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="runtime.max_active_daytona_leases",
+            group="Runtime",
+            label="Maximum Daytona leases",
+            editor="number",
+            rank=4,
+            required_in_policy=True,
+        ),
+    ] = Field(
         default=8,
         gt=0,
         le=8,
         description="Daytona Admission bound for process-wide acquiring or active Interpreter Leases",
     )
-    rlm_max_iters: int = Field(default=20, gt=0)
-    rlm_max_llm_calls: int = Field(default=50, gt=0)
-    rlm_max_output_chars: int = Field(default=10_000, gt=0)
-    rlm_max_execution_output_chars: int = Field(default=4_000, gt=0)
-    rlm_execution_timeout_s: int = Field(default=120, gt=0)
-    rlm_recursion_enabled: bool = False
-    rlm_recursion_max_calls: int = Field(default=4, gt=0)
-    rlm_recursion_max_prompt_chars: int = Field(default=50_000, gt=0)
-    rlm_recursion_child_max_iters: int = Field(default=8, gt=0)
-    rlm_recursion_child_max_llm_calls: int = Field(default=12, gt=0)
-    rlm_recursion_child_max_output_chars: int = Field(default=4_000, gt=0)
-    rlm_recursion_max_parallel_children: int = Field(default=2, gt=0, le=8)
-    rlm_autonomous_memory_categories: tuple[str, ...] = Field(default=())
-    run_heartbeat_seconds: int = Field(default=10, gt=0)
-    run_stale_after_seconds: int = Field(default=60, gt=0)
-    rlm_verbose: bool = True
-    log_level: Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"] = "INFO"
-    root_llm_api_key_env: str = "FLEET_OPENAI_API_KEY"
-    root_llm_base_url: str | None = None
-    root_llm_max_tokens: int | None = Field(default=None, ge=1)
-    root_llm_temperature: float | None = None
-    root_llm_reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
-    root_llm_cache: bool = True
-    root_llm_num_retries: int = Field(default=3, ge=0)
-    sub_llm_api_key_env: str = "FLEET_OPENAI_API_KEY"
-    sub_llm_base_url: str | None = None
-    sub_llm_max_tokens: int | None = Field(default=None, ge=1)
-    sub_llm_temperature: float | None = None
-    sub_llm_reasoning_effort: Literal["none", "low", "medium", "high"] | None = None
-    sub_llm_cache: bool = True
-    sub_llm_num_retries: int = Field(default=3, ge=0)
-
-    mlflow_tracing_enabled: bool = Field(
+    rlm_max_iters: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_iters",
+            group="RLM",
+            label="Maximum iterations",
+            editor="number",
+            rank=25,
+            required_in_policy=True,
+        ),
+    ] = Field(default=20, gt=0)
+    rlm_max_llm_calls: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_llm_calls",
+            group="RLM",
+            label="Maximum LLM calls",
+            editor="number",
+            rank=26,
+            required_in_policy=True,
+        ),
+    ] = Field(default=50, gt=0)
+    rlm_max_output_chars: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_output_chars",
+            group="RLM",
+            label="Maximum output characters",
+            editor="number",
+            rank=27,
+            required_in_policy=True,
+        ),
+    ] = Field(default=10_000, gt=0)
+    rlm_max_execution_output_chars: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_execution_output_chars",
+            group="RLM",
+            label="Maximum execution output characters",
+            editor="number",
+            rank=28,
+            required_in_policy=True,
+        ),
+    ] = Field(default=4_000, gt=0)
+    rlm_execution_timeout_s: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.execution_timeout_s",
+            group="RLM",
+            label="Sandbox execution timeout (seconds)",
+            editor="number",
+            rank=29,
+            required_in_policy=True,
+        ),
+    ] = Field(default=120, gt=0)
+    rlm_recursion_enabled: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_enabled",
+            group="RLM",
+            label="Enable recursive child RLMs",
+            editor="boolean",
+            rank=30,
+        ),
+    ] = False
+    rlm_recursion_max_calls: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_max_calls", group="RLM", label="Recursive maximum calls", editor="number", rank=31
+        ),
+    ] = Field(default=4, gt=0)
+    rlm_recursion_max_prompt_chars: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_max_prompt_chars",
+            group="RLM",
+            label="Recursive prompt character bound",
+            editor="number",
+            rank=32,
+        ),
+    ] = Field(default=50_000, gt=0)
+    rlm_recursion_child_max_iters: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_child_max_iters",
+            group="RLM",
+            label="Child maximum iterations",
+            editor="number",
+            rank=33,
+        ),
+    ] = Field(default=8, gt=0)
+    rlm_recursion_child_max_llm_calls: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_child_max_llm_calls",
+            group="RLM",
+            label="Child maximum LLM calls",
+            editor="number",
+            rank=34,
+        ),
+    ] = Field(default=12, gt=0)
+    rlm_recursion_child_max_output_chars: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_child_max_output_chars",
+            group="RLM",
+            label="Child maximum output characters",
+            editor="number",
+            rank=35,
+        ),
+    ] = Field(default=4_000, gt=0)
+    rlm_recursion_max_parallel_children: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.recursion_max_parallel_children",
+            group="RLM",
+            label="Maximum parallel child RLMs",
+            editor="number",
+            rank=36,
+        ),
+    ] = Field(default=2, gt=0, le=8)
+    rlm_autonomous_memory_categories: Annotated[
+        tuple[str, ...],
+        FleetFieldPolicy(
+            toml_path="rlm.autonomous_memory_categories",
+            group="RLM",
+            label="Autonomous Memory categories",
+            editor="string_list",
+            rank=37,
+        ),
+    ] = Field(default=())
+    run_heartbeat_seconds: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="runtime.heartbeat_seconds",
+            group="Runtime",
+            label="Heartbeat seconds",
+            editor="number",
+            rank=5,
+            required_in_policy=True,
+        ),
+    ] = Field(default=10, gt=0)
+    run_stale_after_seconds: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="runtime.stale_after_seconds",
+            group="Runtime",
+            label="Stale after seconds",
+            editor="number",
+            rank=6,
+            required_in_policy=True,
+        ),
+    ] = Field(default=60, gt=0)
+    rlm_verbose: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="rlm.verbose",
+            group="RLM",
+            label="DSPy host verbose logging",
+            editor="boolean",
+            rank=38,
+            required_in_policy=True,
+        ),
+    ] = True
+    log_level: Annotated[
+        Literal["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        FleetFieldPolicy(
+            toml_path="logging.level",
+            group="Logging",
+            label="Level",
+            editor="single_choice",
+            choices=(
+                "CRITICAL",
+                "ERROR",
+                "WARNING",
+                "INFO",
+                "DEBUG",
+            ),
+            rank=49,
+            required_in_policy=True,
+        ),
+    ] = "INFO"
+    root_llm_api_key_env: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="llm.root.api_key_env",
+            group="Root LLM",
+            label="Provider API key environment variable",
+            editor="text",
+            rank=8,
+            required_in_policy=True,
+        ),
+    ] = "FLEET_OPENAI_API_KEY"
+    root_llm_base_url: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path="llm.root.base_url", group="Root LLM", label="Provider base URL", editor="text", rank=9
+        ),
+    ] = None
+    root_llm_max_tokens: Annotated[
+        int | None,
+        FleetFieldPolicy(
+            toml_path="llm.root.max_tokens", group="Root LLM", label="Maximum tokens", editor="number", rank=11
+        ),
+    ] = Field(default=None, ge=1)
+    root_llm_temperature: Annotated[
+        float | None,
+        FleetFieldPolicy(
+            toml_path="llm.root.temperature", group="Root LLM", label="Temperature", editor="number", rank=12
+        ),
+    ] = None
+    root_llm_reasoning_effort: Annotated[
+        Literal["none", "low", "medium", "high"] | None,
+        FleetFieldPolicy(
+            toml_path="llm.root.reasoning_effort",
+            group="Root LLM",
+            label="Reasoning effort",
+            editor="single_choice",
+            choices=(
+                "none",
+                "low",
+                "medium",
+                "high",
+            ),
+            rank=15,
+        ),
+    ] = None
+    root_llm_cache: Annotated[
+        bool, FleetFieldPolicy(toml_path="llm.root.cache", group="Root LLM", label="Cache", editor="boolean", rank=13)
+    ] = True
+    root_llm_num_retries: Annotated[
+        int,
+        FleetFieldPolicy(toml_path="llm.root.num_retries", group="Root LLM", label="Retries", editor="number", rank=14),
+    ] = Field(default=3, ge=0)
+    sub_llm_api_key_env: Annotated[
+        str,
+        FleetFieldPolicy(
+            toml_path="llm.sub.api_key_env",
+            group="Sub LLM",
+            label="Provider API key environment variable",
+            editor="text",
+            rank=17,
+            required_in_policy=True,
+        ),
+    ] = "FLEET_OPENAI_API_KEY"
+    sub_llm_base_url: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path="llm.sub.base_url", group="Sub LLM", label="Provider base URL", editor="text", rank=18
+        ),
+    ] = None
+    sub_llm_max_tokens: Annotated[
+        int | None,
+        FleetFieldPolicy(
+            toml_path="llm.sub.max_tokens", group="Sub LLM", label="Maximum tokens", editor="number", rank=20
+        ),
+    ] = Field(default=None, ge=1)
+    sub_llm_temperature: Annotated[
+        float | None,
+        FleetFieldPolicy(
+            toml_path="llm.sub.temperature", group="Sub LLM", label="Temperature", editor="number", rank=21
+        ),
+    ] = None
+    sub_llm_reasoning_effort: Annotated[
+        Literal["none", "low", "medium", "high"] | None,
+        FleetFieldPolicy(
+            toml_path="llm.sub.reasoning_effort",
+            group="Sub LLM",
+            label="Reasoning effort",
+            editor="single_choice",
+            choices=(
+                "none",
+                "low",
+                "medium",
+                "high",
+            ),
+            rank=24,
+        ),
+    ] = None
+    sub_llm_cache: Annotated[
+        bool, FleetFieldPolicy(toml_path="llm.sub.cache", group="Sub LLM", label="Cache", editor="boolean", rank=22)
+    ] = True
+    sub_llm_num_retries: Annotated[
+        int,
+        FleetFieldPolicy(toml_path="llm.sub.num_retries", group="Sub LLM", label="Retries", editor="number", rank=23),
+    ] = Field(default=3, ge=0)
+    mlflow_tracing_enabled: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="mlflow.tracing_enabled", group="MLflow", label="Tracing enabled", editor="boolean", rank=50
+        ),
+    ] = Field(
         default=False,
         description="Enable Databricks-backed MLflow DSPy autolog (engineering observability)",
     )
-    mlflow_experiment_name: str | None = Field(
+    mlflow_experiment_name: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path="mlflow.experiment_name", group="MLflow", label="Experiment name", editor="text", rank=54
+        ),
+    ] = Field(
         default=None,
         description="MLflow experiment name when tracing is enabled",
     )
-    mlflow_tracking_uri: str = Field(
+    mlflow_tracking_uri: Annotated[
+        str,
+        FleetFieldPolicy(toml_path="mlflow.tracking_uri", group="MLflow", label="Tracking URI", editor="text", rank=56),
+    ] = Field(
         default="databricks",
         description="MLflow tracking URI selected by the Fleet policy",
     )
-    mlflow_expose_trace_id: bool = Field(
+    mlflow_expose_trace_id: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="mlflow.expose_trace_id", group="MLflow", label="Expose trace ID", editor="boolean", rank=57
+        ),
+    ] = Field(
         default=True,
         description="When tracing is enabled, surface trace ids on Turn SSE metadata",
     )
-    mlflow_async_logging: bool = Field(
+    mlflow_async_logging: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="mlflow.async_logging", group="MLflow", label="Async trace logging", editor="boolean", rank=51
+        ),
+    ] = Field(
         default=True,
         description="Upload MLflow trace data asynchronously when tracing is enabled",
     )
-    mlflow_trace_sampling_ratio: float = Field(
+    mlflow_trace_sampling_ratio: Annotated[
+        float,
+        FleetFieldPolicy(
+            toml_path="mlflow.trace_sampling_ratio",
+            group="MLflow",
+            label="Trace sampling ratio",
+            editor="number",
+            rank=52,
+        ),
+    ] = Field(
         default=1.0,
         ge=0.0,
         le=1.0,
         description="Fraction of Turn traces to sample for MLflow",
     )
-    mlflow_trace_content_max_chars: int = Field(
+    mlflow_trace_content_max_chars: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="mlflow.trace_content_max_chars",
+            group="MLflow",
+            label="Trace payload character limit",
+            editor="number",
+            rank=53,
+        ),
+    ] = Field(
         default=10_000,
         ge=256,
         le=50_000,
         description="Maximum characters retained in one readable MLflow trace payload field",
     )
-    mlflow_trace_catalog: str | None = Field(default=None)
-    mlflow_trace_schema: str | None = Field(default=None)
-    mlflow_trace_table_prefix: str | None = Field(default=None)
-    mlflow_tracing_sql_warehouse_id: str | None = Field(default=None)
-    posthog_enabled: bool = Field(
+    mlflow_trace_catalog: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path="mlflow.trace_catalog", group="MLflow", label="Trace catalog", editor="text", rank=58
+        ),
+    ] = Field(default=None)
+    mlflow_trace_schema: Annotated[
+        str | None,
+        FleetFieldPolicy(toml_path="mlflow.trace_schema", group="MLflow", label="Trace schema", editor="text", rank=60),
+    ] = Field(default=None)
+    mlflow_trace_table_prefix: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path="mlflow.trace_table_prefix", group="MLflow", label="Trace table prefix", editor="text", rank=62
+        ),
+    ] = Field(default=None)
+    mlflow_tracing_sql_warehouse_id: Annotated[
+        str | None,
+        FleetFieldPolicy(
+            toml_path="mlflow.tracing_sql_warehouse_id",
+            group="MLflow",
+            label="Tracing SQL warehouse ID",
+            editor="text",
+            rank=64,
+        ),
+    ] = Field(default=None)
+    posthog_enabled: Annotated[
+        bool,
+        FleetFieldPolicy(
+            toml_path="posthog.enabled", group="PostHog", label="Analytics enabled", editor="boolean", rank=66
+        ),
+    ] = Field(
         default=False,
         description="Enable PostHog product analytics selected by the Fleet policy",
     )
-    posthog_project_token: SecretStr | None = Field(
+    posthog_project_token: Annotated[
+        SecretStr | None,
+        FleetFieldPolicy(
+            toml_path=None,
+            secret=True,
+            doc="Resolved at runtime from the environment named by posthog.project_token_env",
+        ),
+    ] = Field(
         default=None,
         description="PostHog project token resolved from posthog.project_token_env",
     )
-    posthog_host: str | None = Field(
+    posthog_host: Annotated[
+        str | None,
+        FleetFieldPolicy(toml_path="posthog.host", group="PostHog", label="Ingestion host", editor="text", rank=68),
+    ] = Field(
         default=None,
         description="PostHog ingestion host selected by the Fleet policy",
     )
+
     _dotenv_values: dict[str, str] = PrivateAttr(default_factory=dict)
     _active_profile: str | None = PrivateAttr(default=None)
 
@@ -403,74 +971,305 @@ class Settings(BaseModel):
         return LLMRoleBundle(root=self.root_lm, sub=self.sub_lm)
 
 
-_TABLE_KEYS: dict[str, frozenset[str]] = {
-    "application": frozenset({"name"}),
-    "runtime": frozenset(
-        {
-            "environment",
-            "live_enabled",
-            "turn_timeout_seconds",
-            "max_active_daytona_leases",
-            "heartbeat_seconds",
-            "stale_after_seconds",
-        }
+@dataclass(frozen=True, slots=True)
+class EnvironmentReferenceSpec:
+    """A TOML ``*_env`` key resolving one Settings field from the process environment.
+
+    Environment-reference keys are operator-editable policy surface but do not
+    bind a ``Settings`` field directly: ``load_runtime_settings`` resolves the
+    named variable via the environment/``.env`` seam only.  ``resolves_to``
+    names the owning Settings field so inventory generation cannot drift from
+    the schema.
+    """
+
+    toml_path: str
+    group: str
+    label: str
+    rank: int
+    resolves_to: str
+
+
+# Operator-editable ``*_env`` TOML keys. TOML *paths* are declared once here
+# because no Settings field can own them; the *resolved field identity* is
+# referenced, never duplicated. Ranks pin positions in the policy inventory.
+_ENVIRONMENT_REFERENCE_SPECS: tuple[EnvironmentReferenceSpec, ...] = (
+    EnvironmentReferenceSpec(
+        toml_path="llm.root.base_url_env",
+        group="Root LLM",
+        label="Provider base URL environment variable",
+        rank=10,
+        resolves_to="root_llm_base_url",
     ),
-    "llm": frozenset({"root", "sub"}),
-    "rlm": frozenset(
-        {
-            "max_iters",
-            "max_llm_calls",
-            "max_output_chars",
-            "max_execution_output_chars",
-            "execution_timeout_s",
-            "recursion_enabled",
-            "recursion_max_calls",
-            "recursion_max_prompt_chars",
-            "recursion_child_max_iters",
-            "recursion_child_max_llm_calls",
-            "recursion_child_max_output_chars",
-            "recursion_max_parallel_children",
-            "autonomous_memory_categories",
-            "verbose",
-        }
+    EnvironmentReferenceSpec(
+        toml_path="llm.sub.base_url_env",
+        group="Sub LLM",
+        label="Provider base URL environment variable",
+        rank=19,
+        resolves_to="sub_llm_base_url",
     ),
-    "storage": frozenset({"data_root", "max_upload_bytes", "max_url_bytes", "max_artifact_bytes", "database_url_env"}),
-    "daytona": frozenset({"api_key_env", "snapshot", "org_id", "volume_name", "volume_mount_path"}),
-    "logging": frozenset({"level"}),
-    "mlflow": frozenset(
-        {
-            "tracing_enabled",
-            "experiment_name",
-            "experiment_name_env",
-            "tracking_uri",
-            "expose_trace_id",
-            "async_logging",
-            "trace_sampling_ratio",
-            "trace_content_max_chars",
-            "trace_catalog",
-            "trace_catalog_env",
-            "trace_schema",
-            "trace_schema_env",
-            "trace_table_prefix",
-            "trace_table_prefix_env",
-            "tracing_sql_warehouse_id",
-            "tracing_sql_warehouse_id_env",
-        }
+    EnvironmentReferenceSpec(
+        toml_path="storage.database_url_env",
+        group="Storage",
+        label="Database URL environment variable",
+        rank=43,
+        resolves_to="database_url",
     ),
-    "posthog": frozenset({"enabled", "project_token_env", "host"}),
+    EnvironmentReferenceSpec(
+        toml_path="daytona.api_key_env",
+        group="Daytona",
+        label="API key environment variable",
+        rank=44,
+        resolves_to="daytona_api_key",
+    ),
+    EnvironmentReferenceSpec(
+        toml_path="mlflow.experiment_name_env",
+        group="MLflow",
+        label="Experiment environment variable",
+        rank=55,
+        resolves_to="mlflow_experiment_name",
+    ),
+    EnvironmentReferenceSpec(
+        toml_path="mlflow.trace_catalog_env",
+        group="MLflow",
+        label="Trace catalog environment variable",
+        rank=59,
+        resolves_to="mlflow_trace_catalog",
+    ),
+    EnvironmentReferenceSpec(
+        toml_path="mlflow.trace_schema_env",
+        group="MLflow",
+        label="Trace schema environment variable",
+        rank=61,
+        resolves_to="mlflow_trace_schema",
+    ),
+    EnvironmentReferenceSpec(
+        toml_path="mlflow.trace_table_prefix_env",
+        group="MLflow",
+        label="Trace table prefix environment variable",
+        rank=63,
+        resolves_to="mlflow_trace_table_prefix",
+    ),
+    EnvironmentReferenceSpec(
+        toml_path="mlflow.tracing_sql_warehouse_id_env",
+        group="MLflow",
+        label="Tracing SQL warehouse environment variable",
+        rank=65,
+        resolves_to="mlflow_tracing_sql_warehouse_id",
+    ),
+    EnvironmentReferenceSpec(
+        toml_path="posthog.project_token_env",
+        group="PostHog",
+        label="Project token environment variable",
+        rank=67,
+        resolves_to="posthog_project_token",
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigFieldSpec:
+    """Resolved authoritative descriptor for one supported TOML policy key."""
+
+    toml_path: str
+    section: str
+    key: str
+    group: str
+    label: str
+    editor: EditorKind
+    choices: tuple[str, ...]
+    rank: int
+    settings_field: str | None
+    environment_reference_for: str | None
+    required_in_policy: bool
+
+
+@dataclass(frozen=True, slots=True)
+class FlattenedPolicy:
+    """TOML-derived ``Settings`` constructor input, split by resolution seam.
+
+    ``settings`` carries TOML-bound values keyed by Settings field name.
+    ``environment_references`` maps Settings field names to the environment
+    variables named by ``*_env`` TOML keys; only the runtime load seam
+    resolves those variables into values.
+    """
+
+    settings: Mapping[str, Any]
+    environment_references: Mapping[str, str]
+
+
+_EDITOR_KINDS: frozenset[str] = frozenset(getattr(EditorKind, "__args__", ()))
+_MISSING: Any = object()
+
+
+def _field_policies() -> dict[str, FleetFieldPolicy]:
+    """Return each Settings field's authoritative policy declaration."""
+
+    policies: dict[str, FleetFieldPolicy] = {}
+    for name, field_info in Settings.model_fields.items():
+        meta = next((item for item in field_info.metadata if isinstance(item, FleetFieldPolicy)), None)
+        if meta is None:
+            raise FleetConfigurationError(f"Settings.{name} is missing its authoritative FleetFieldPolicy declaration")
+        policies[name] = meta
+    return policies
+
+
+def _lookup_toml(mapping: Mapping[str, Any], toml_path: str) -> Any:
+    """Return the value at ``toml_path`` or the ``_MISSING`` sentinel."""
+
+    current: Any = mapping
+    for part in toml_path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return _MISSING
+        current = current[part]
+    return current
+
+
+def _build_field_specs() -> tuple[ConfigFieldSpec, ...]:
+    """Build the canonical policy inventory and prove it cannot drift from ``Settings``.
+
+    Raises:
+        FleetConfigurationError: If a Settings field lacks a declaration, a declaration is
+            incomplete, paths/ranks collide, environment references resolve unknown fields,
+            or the Root/Sub LLM key surfaces diverge.
+    """
+
+    policies = _field_policies()
+    specs: list[ConfigFieldSpec] = []
+    env_targets: set[str] = set()
+    for env in _ENVIRONMENT_REFERENCE_SPECS:
+        if not env.toml_path.endswith("_env"):
+            raise FleetConfigurationError(f"environment reference path must end with _env: {env.toml_path}")
+        if env.resolves_to not in policies:
+            raise FleetConfigurationError(
+                f"environment reference {env.toml_path} resolves unknown Settings field: {env.resolves_to}"
+            )
+        env_targets.add(env.resolves_to)
+        section = env.toml_path.split(".", 1)[0]
+        specs.append(
+            ConfigFieldSpec(
+                toml_path=env.toml_path,
+                section=section,
+                key=env.toml_path.rsplit(".", 1)[-1],
+                group=env.group,
+                label=env.label,
+                editor="text",
+                choices=(),
+                rank=env.rank,
+                settings_field=None,
+                environment_reference_for=env.resolves_to,
+                required_in_policy=False,
+            )
+        )
+    for name, meta in policies.items():
+        if meta.toml_path is None:
+            if meta.group is not None or meta.label is not None or meta.editor is not None or meta.rank is not None:
+                raise FleetConfigurationError(f"Settings.{name} declares editor metadata without a TOML mapping")
+            if not (meta.secret or meta.compatibility or name in env_targets):
+                raise FleetConfigurationError(
+                    f"Settings.{name} has no TOML mapping and is neither secret, "
+                    "compatibility, nor environment-resolved"
+                )
+            continue
+        if meta.secret:
+            raise FleetConfigurationError(f"Settings.{name} is secret and must not be TOML-settable")
+        if meta.group is None or meta.label is None or meta.editor is None or meta.rank is None:
+            raise FleetConfigurationError(
+                f"Settings.{name} TOML mapping requires complete editor metadata (group, label, editor, rank)"
+            )
+        if meta.editor not in _EDITOR_KINDS:
+            raise FleetConfigurationError(f"Settings.{name} declares unsupported editor kind: {meta.editor}")
+        expects_choices = meta.editor in ("single_choice", "multi_choice")
+        if bool(meta.choices) != expects_choices:
+            raise FleetConfigurationError(
+                f"Settings.{name} choice metadata does not match its editor kind: {meta.editor}"
+            )
+        section = meta.toml_path.split(".", 1)[0]
+        specs.append(
+            ConfigFieldSpec(
+                toml_path=meta.toml_path,
+                section=section,
+                key=meta.toml_path.rsplit(".", 1)[-1],
+                group=meta.group,
+                label=meta.label,
+                editor=meta.editor,
+                choices=meta.choices,
+                rank=meta.rank,
+                settings_field=name,
+                environment_reference_for=None,
+                required_in_policy=meta.required_in_policy,
+            )
+        )
+    seen_paths: set[str] = set()
+    seen_ranks: set[int] = set()
+    for spec in specs:
+        if spec.toml_path in seen_paths:
+            raise FleetConfigurationError(f"duplicate supported TOML path: {spec.toml_path}")
+        if spec.rank in seen_ranks:
+            raise FleetConfigurationError(f"duplicate policy inventory rank: {spec.rank}")
+        seen_paths.add(spec.toml_path)
+        seen_ranks.add(spec.rank)
+    root_keys = {spec.key for spec in specs if spec.toml_path.startswith("llm.root.")}
+    sub_keys = {spec.key for spec in specs if spec.toml_path.startswith("llm.sub.")}
+    if root_keys != sub_keys:
+        raise FleetConfigurationError(
+            "Root/Sub LLM policy keys diverge: "
+            f"root-only={sorted(root_keys - sub_keys)} sub-only={sorted(sub_keys - root_keys)}"
+        )
+    return tuple(sorted(specs, key=lambda spec: spec.rank))
+
+
+_FIELD_SPECS: tuple[ConfigFieldSpec, ...] = _build_field_specs()
+
+
+def config_field_specs() -> tuple[ConfigFieldSpec, ...]:
+    """Return the authoritative supported-key inventory derived from ``Settings``."""
+
+    return _FIELD_SPECS
+
+
+def _derive_table_keys(specs: tuple[ConfigFieldSpec, ...]) -> tuple[dict[str, frozenset[str]], frozenset[str]]:
+    """Derive the supported TOML key surfaces from the authoritative inventory."""
+
+    tables: dict[str, set[str]] = {}
+    role_keys: set[str] = set()
+    for spec in specs:
+        if spec.section == "llm":
+            tables.setdefault("llm", set()).add(spec.toml_path.split(".")[1])
+            role_keys.add(spec.key)
+        else:
+            tables.setdefault(spec.section, set()).add(spec.key)
+    return {name: frozenset(keys) for name, keys in tables.items()}, frozenset(role_keys)
+
+
+_TABLE_KEYS, _ROLE_KEYS = _derive_table_keys(_FIELD_SPECS)
+
+# Non-LLM sections: supported ``*_env`` keys and (direct, env) pairs that may
+# not be declared together; both derive from the authoritative inventory.
+_ENV_REFERENCE_KEYS: dict[str, tuple[str, ...]] = {
+    section: tuple(
+        spec.key for spec in _FIELD_SPECS if spec.section == section and spec.environment_reference_for is not None
+    )
+    for section in dict.fromkeys(spec.section for spec in _FIELD_SPECS if spec.section != "llm")
 }
-_ROLE_KEYS = frozenset(
-    {
-        "model",
-        "api_key_env",
-        "base_url",
-        "base_url_env",
-        "max_tokens",
-        "temperature",
-        "reasoning_effort",
-        "cache",
-        "num_retries",
-    }
+_EXCLUSIVE_ENV_PAIRS: dict[str, tuple[tuple[str, str], ...]] = {
+    section: tuple(
+        (direct.key, f"{direct.key}_env")
+        for direct in _FIELD_SPECS
+        if direct.section == section
+        and direct.environment_reference_for is None
+        and any(
+            env.section == section
+            and env.environment_reference_for == direct.settings_field
+            and env.key == f"{direct.key}_env"
+            for env in _FIELD_SPECS
+        )
+    )
+    for section in dict.fromkeys(spec.section for spec in _FIELD_SPECS if spec.section != "llm")
+}
+_SECRET_RESOLVED_FIELDS: frozenset[str] = frozenset(
+    spec.environment_reference_for
+    for spec in _FIELD_SPECS
+    if spec.environment_reference_for is not None and _field_policies()[spec.environment_reference_for].secret
 )
 
 
@@ -542,34 +1341,14 @@ def _validate_policy_table(value: object, location: str, *, allow_partial_llm: b
             )
         continue
     for name, child in table.items():
-        if name == "storage":
-            _validate_optional_environment_reference(
-                _require_mapping(child, f"{location}.storage").get("database_url_env"),
-                f"{location}.storage.database_url_env",
-            )
-        elif name == "daytona":
-            _validate_optional_environment_reference(
-                _require_mapping(child, f"{location}.daytona").get("api_key_env"),
-                f"{location}.daytona.api_key_env",
-            )
-        elif name == "mlflow":
-            mlflow = _require_mapping(child, f"{location}.mlflow")
-            for key in (
-                "experiment_name",
-                "trace_catalog",
-                "trace_schema",
-                "trace_table_prefix",
-                "tracing_sql_warehouse_id",
-            ):
-                reference = f"{key}_env"
-                if key in mlflow and reference in mlflow:
-                    raise FleetConfigurationError(f"{location}.mlflow cannot define both {key} and {reference}")
-                _validate_optional_environment_reference(mlflow.get(reference), f"{location}.mlflow.{reference}")
-        elif name == "posthog":
-            _validate_optional_environment_reference(
-                _require_mapping(child, f"{location}.posthog").get("project_token_env"),
-                f"{location}.posthog.project_token_env",
-            )
+        if name == "llm":
+            continue
+        child_table = _require_mapping(child, f"{location}.{name}")
+        for direct_key, env_key in _EXCLUSIVE_ENV_PAIRS.get(name, ()):
+            if direct_key in child_table and env_key in child_table:
+                raise FleetConfigurationError(f"{location}.{name} cannot define both {direct_key} and {env_key}")
+        for env_key in _ENV_REFERENCE_KEYS.get(name, ()):
+            _validate_optional_environment_reference(child_table.get(env_key), f"{location}.{name}.{env_key}")
 
 
 def _validate_environment_reference(value: object, location: str) -> str:
@@ -607,135 +1386,40 @@ def _deep_merge(base: Mapping[str, Any], override: Mapping[str, Any]) -> dict[st
     return result
 
 
-def _flatten_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
-    """
-    Flatten validated nested policy sections into the field names required by `Settings`.
+def _flatten_policy(policy: Mapping[str, Any]) -> FlattenedPolicy:
+    """Flatten one validated profile table into ``Settings`` constructor input.
+
+    The authoritative field specs own the TOML-path-to-Settings-field mapping;
+    absent optional keys stay absent so ``Settings`` defaults apply, and
+    ``*_env`` keys become pending environment references resolved only by the
+    runtime load seam.
 
     Parameters:
-        policy (Mapping[str, Any]): Validated policy configuration containing application, runtime, RLM,
-            storage, Daytona, logging, LLM, and MLflow sections.
+        policy (Mapping[str, Any]): Validated merged policy table for one profile.
 
     Returns:
-        dict[str, Any]: Settings field values with applicable defaults applied.
+        FlattenedPolicy: Settings values plus pending environment references.
 
     Raises:
-        FleetConfigurationError: If required settings are missing.
+        FleetConfigurationError: If a required policy key is missing.
     """
 
-    def table(name: str) -> Mapping[str, Any]:
-        return _require_mapping(policy.get(name, {}), name)
-
-    application = table("application")
-    runtime = table("runtime")
-    rlm = table("rlm")
-    storage = table("storage")
-    daytona = table("daytona")
-    log = table("logging")
-    llm = table("llm")
-    mlflow = table("mlflow")
-    posthog = table("posthog")
-    values: dict[str, Any] = {
-        "app_name": application.get("name"),
-        "run_environment": runtime.get("environment"),
-        "live_enabled": runtime.get("live_enabled", True),
-        "turn_timeout_seconds": runtime.get("turn_timeout_seconds"),
-        "max_active_daytona_leases": runtime.get("max_active_daytona_leases"),
-        "run_heartbeat_seconds": runtime.get("heartbeat_seconds"),
-        "run_stale_after_seconds": runtime.get("stale_after_seconds"),
-        "rlm_max_iters": rlm.get("max_iters"),
-        "rlm_max_llm_calls": rlm.get("max_llm_calls"),
-        "rlm_max_output_chars": rlm.get("max_output_chars"),
-        "rlm_max_execution_output_chars": rlm.get("max_execution_output_chars"),
-        "rlm_execution_timeout_s": rlm.get("execution_timeout_s"),
-        "rlm_recursion_enabled": rlm.get("recursion_enabled", False),
-        "rlm_recursion_max_calls": rlm.get("recursion_max_calls", 4),
-        "rlm_recursion_max_prompt_chars": rlm.get("recursion_max_prompt_chars", 50_000),
-        "rlm_recursion_child_max_iters": rlm.get("recursion_child_max_iters", 8),
-        "rlm_recursion_child_max_llm_calls": rlm.get("recursion_child_max_llm_calls", 12),
-        "rlm_recursion_child_max_output_chars": rlm.get("recursion_child_max_output_chars", 4_000),
-        "rlm_recursion_max_parallel_children": rlm.get("recursion_max_parallel_children", 2),
-        "rlm_autonomous_memory_categories": rlm.get("autonomous_memory_categories", ()),
-        "rlm_verbose": rlm.get("verbose"),
-        "data_root": storage.get("data_root"),
-        "max_upload_bytes": storage.get("max_upload_bytes"),
-        "max_url_bytes": storage.get("max_url_bytes"),
-        "max_artifact_bytes": storage.get("max_artifact_bytes"),
-        "database_url_env": storage.get("database_url_env"),
-        "daytona_api_key_env": daytona.get("api_key_env"),
-        "daytona_snapshot": daytona.get("snapshot"),
-        "daytona_org_id": daytona.get("org_id"),
-        "volume_name": daytona.get("volume_name"),
-        "volume_mount_path": daytona.get("volume_mount_path"),
-        "log_level": log.get("level"),
-        "posthog_enabled": posthog.get("enabled", False),
-        "posthog_project_token_env": posthog.get("project_token_env"),
-        "posthog_host": posthog.get("host"),
-    }
-    if "tracing_enabled" in mlflow:
-        values["mlflow_tracing_enabled"] = mlflow["tracing_enabled"]
-    for key, settings_field in (
-        ("experiment_name", "mlflow_experiment_name"),
-        ("trace_catalog", "mlflow_trace_catalog"),
-        ("trace_schema", "mlflow_trace_schema"),
-        ("trace_table_prefix", "mlflow_trace_table_prefix"),
-        ("tracing_sql_warehouse_id", "mlflow_tracing_sql_warehouse_id"),
-    ):
-        if key in mlflow:
-            values[settings_field] = mlflow[key]
-        if f"{key}_env" in mlflow:
-            values[f"{settings_field}_env"] = mlflow[f"{key}_env"]
-    if "tracking_uri" in mlflow:
-        values["mlflow_tracking_uri"] = mlflow["tracking_uri"]
-    if "expose_trace_id" in mlflow:
-        values["mlflow_expose_trace_id"] = mlflow["expose_trace_id"]
-    if "async_logging" in mlflow:
-        values["mlflow_async_logging"] = mlflow["async_logging"]
-    if "trace_sampling_ratio" in mlflow:
-        values["mlflow_trace_sampling_ratio"] = mlflow["trace_sampling_ratio"]
-    if "trace_content_max_chars" in mlflow:
-        values["mlflow_trace_content_max_chars"] = mlflow["trace_content_max_chars"]
-    for role in ("root", "sub"):
-        role_values = _require_mapping(llm.get(role, {}), f"llm.{role}")
-        values[f"{role}_model"] = role_values.get("model")
-        values[f"{role}_llm_api_key_env"] = role_values.get("api_key_env")
-        values[f"{role}_llm_base_url"] = role_values.get("base_url")
-        values[f"{role}_llm_base_url_env"] = role_values.get("base_url_env")
-        values[f"{role}_llm_max_tokens"] = role_values.get("max_tokens")
-        values[f"{role}_llm_temperature"] = role_values.get("temperature")
-        values[f"{role}_llm_reasoning_effort"] = role_values.get("reasoning_effort")
-        values[f"{role}_llm_cache"] = role_values.get("cache", True)
-        values[f"{role}_llm_num_retries"] = role_values.get("num_retries", 3)
-    optional = {
-        "database_url_env",
-        "daytona_api_key_env",
-        "posthog_project_token_env",
-        "posthog_host",
-        "daytona_snapshot",
-        "daytona_org_id",
-        "root_llm_base_url",
-        "sub_llm_base_url",
-        "root_llm_base_url_env",
-        "sub_llm_base_url_env",
-        "mlflow_experiment_name_env",
-        "mlflow_trace_catalog_env",
-        "mlflow_trace_schema_env",
-        "mlflow_trace_table_prefix_env",
-        "mlflow_tracing_sql_warehouse_id_env",
-        "root_llm_max_tokens",
-        "sub_llm_max_tokens",
-        "root_llm_temperature",
-        "sub_llm_temperature",
-        "root_llm_reasoning_effort",
-        "sub_llm_reasoning_effort",
-        "root_llm_cache",
-        "sub_llm_cache",
-        "root_llm_num_retries",
-        "sub_llm_num_retries",
-    }
-    missing = sorted(key for key, value in values.items() if value is None and key not in optional)
+    settings: dict[str, Any] = {}
+    environment_references: dict[str, str] = {}
+    missing: list[str] = []
+    for spec in _FIELD_SPECS:
+        value = _lookup_toml(policy, spec.toml_path)
+        if value is _MISSING:
+            if spec.required_in_policy:
+                missing.append(spec.settings_field or spec.toml_path)
+            continue
+        if spec.environment_reference_for is not None:
+            environment_references[spec.environment_reference_for] = value
+        else:
+            settings[spec.settings_field or spec.toml_path] = value
     if missing:
-        raise FleetConfigurationError(f"selected profile is missing required setting(s): {', '.join(missing)}")
-    return values
+        raise FleetConfigurationError(f"selected profile is missing required setting(s): {', '.join(sorted(missing))}")
+    return FlattenedPolicy(settings=settings, environment_references=environment_references)
 
 
 def _unique_environment_names(*values: str | None) -> tuple[str, ...]:
@@ -907,31 +1591,36 @@ def _resolve_environment_value(name: str | None, dotenv: Mapping[str, str | None
 
 def _require_managed_profile_environment_values(
     profile: str,
-    values: Mapping[str, Any],
+    flattened: FlattenedPolicy,
     dotenv: Mapping[str, str | None],
 ) -> None:
     """Fail early when the explicit managed Lakebase/MLflow policy is incomplete."""
     if profile != "daytona-managed":
         return
-    references = (
-        "database_url_env",
-        "daytona_api_key_env",
-        "root_llm_api_key_env",
-        "root_llm_base_url_env",
-        "mlflow_experiment_name_env",
-        "mlflow_trace_catalog_env",
-        "mlflow_trace_schema_env",
-        "mlflow_trace_table_prefix_env",
-        "mlflow_tracing_sql_warehouse_id_env",
+    # Settings field name -> diagnostic label used when no reference is declared.
+    references: tuple[tuple[str, str], ...] = (
+        ("database_url", "database_url_env"),
+        ("daytona_api_key", "daytona_api_key_env"),
+        ("root_llm_api_key_env", "root_llm_api_key_env"),
+        ("root_llm_base_url", "root_llm_base_url_env"),
+        ("mlflow_experiment_name", "mlflow_experiment_name_env"),
+        ("mlflow_trace_catalog", "mlflow_trace_catalog_env"),
+        ("mlflow_trace_schema", "mlflow_trace_schema_env"),
+        ("mlflow_trace_table_prefix", "mlflow_trace_table_prefix_env"),
+        ("mlflow_tracing_sql_warehouse_id", "mlflow_tracing_sql_warehouse_id_env"),
     )
     missing: set[str] = set()
-    for field_name in references:
-        environment_name = values.get(field_name)
+    for field_name, label in references:
+        if field_name == "root_llm_api_key_env":
+            # The role field stores the environment name directly.
+            environment_name: Any = flattened.settings.get(field_name)
+        else:
+            environment_name = flattened.environment_references.get(field_name)
         if not isinstance(environment_name, str) or not _resolve_environment_value(environment_name, dotenv):
-            missing.add(environment_name if isinstance(environment_name, str) else field_name)
+            missing.add(environment_name if isinstance(environment_name, str) else label)
     if missing:
         raise FleetConfigurationError(
-            f"selected profile {profile!r} is missing required environment value(s): {', '.join(missing)}"
+            f"selected profile {profile!r} is missing required environment value(s): {', '.join(sorted(missing))}"
         )
 
 
@@ -958,29 +1647,16 @@ def load_runtime_settings() -> Settings:
             raise FleetConfigurationError("config.default_profile is required when multiple profiles exist")
     selected = _require_mapping(profiles[profile], f"profiles.{profile}")
     _validate_policy_table(selected, f"profiles.{profile}")
-    values = _flatten_policy(_deep_merge(defaults, selected))
-    _require_managed_profile_environment_values(profile, values, dotenv)
+    flattened = _flatten_policy(_deep_merge(defaults, selected))
+    _require_managed_profile_environment_values(profile, flattened, dotenv)
 
-    database_url_env = values.pop("database_url_env", None)
-    daytona_api_key_env = values.pop("daytona_api_key_env", None)
-    values["database_url"] = _resolve_environment_value(database_url_env, dotenv)
-    daytona_api_key = _resolve_environment_value(daytona_api_key_env, dotenv)
-    values["daytona_api_key"] = SecretStr(daytona_api_key) if daytona_api_key is not None else None
-    posthog_project_token_env = values.pop("posthog_project_token_env", None)
-    posthog_project_token = _resolve_environment_value(posthog_project_token_env, dotenv)
-    values["posthog_project_token"] = SecretStr(posthog_project_token) if posthog_project_token is not None else None
-    for settings_field in (
-        "root_llm_base_url",
-        "sub_llm_base_url",
-        "mlflow_experiment_name",
-        "mlflow_trace_catalog",
-        "mlflow_trace_schema",
-        "mlflow_trace_table_prefix",
-        "mlflow_tracing_sql_warehouse_id",
-    ):
-        reference = values.pop(f"{settings_field}_env", None)
-        if reference is not None:
-            values[settings_field] = _resolve_environment_value(reference, dotenv)
+    values: dict[str, Any] = dict(flattened.settings)
+    for field_name, environment_name in flattened.environment_references.items():
+        resolved = _resolve_environment_value(environment_name, dotenv)
+        if field_name in _SECRET_RESOLVED_FIELDS:
+            values[field_name] = SecretStr(resolved) if resolved is not None else None
+        else:
+            values[field_name] = resolved
     settings = Settings(**values)
     settings._dotenv_values = {key: value for key, value in dotenv.items() if value is not None}
     settings._active_profile = profile

--- a/src/fleet_rlm/config_policy.py
+++ b/src/fleet_rlm/config_policy.py
@@ -39,11 +39,8 @@ from fleet_rlm.files.memory_models import WorkspaceMemoryCategoryError
 
 __all__ = [
     "ConfigPolicyService",
-    "EditorKind",
     "PolicyAccessError",
     "PolicyConflictError",
-    "PolicyField",
-    "PolicySnapshot",
 ]
 
 

--- a/src/fleet_rlm/config_policy.py
+++ b/src/fleet_rlm/config_policy.py
@@ -3,6 +3,10 @@
 This module owns the committed policy document only.  It never reads values from
 ``.env`` or process environment variables, so callers cannot use it to recover
 credentials or runtime overrides.
+
+The editable-field inventory derives from the authoritative
+:class:`fleet_rlm.config.FleetFieldPolicy` declarations on ``Settings`` fields
+plus their ``*_env`` reference specs; nothing here mirrors field names by hand.
 """
 
 from __future__ import annotations
@@ -14,12 +18,13 @@ import threading
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import tomlkit
 from tomlkit import TOMLDocument
 
 from fleet_rlm.config import (
+    EditorKind,
     FleetConfigurationError,
     Settings,
     _deep_merge,
@@ -27,11 +32,19 @@ from fleet_rlm.config import (
     _policy_document_from_mapping,
     _require_mapping,
     _validate_policy_table,
+    config_field_specs,
 )
 from fleet_rlm.files.memory_candidates import normalize_memory_candidate_categories
 from fleet_rlm.files.memory_models import WorkspaceMemoryCategoryError
 
-EditorKind = Literal["text", "number", "boolean", "single_choice", "multi_choice", "string_list"]
+__all__ = [
+    "ConfigPolicyService",
+    "EditorKind",
+    "PolicyAccessError",
+    "PolicyConflictError",
+    "PolicyField",
+    "PolicySnapshot",
+]
 
 
 class PolicyConflictError(ValueError):
@@ -52,226 +65,19 @@ class PolicyField:
     settings_field: str | None = None
 
 
-_FIELDS: tuple[PolicyField, ...] = (
-    PolicyField("application.name", "Application", "Name", "text", settings_field="app_name"),
-    PolicyField("runtime.environment", "Runtime", "Environment", "single_choice", ("daytona",), "run_environment"),
-    PolicyField("runtime.live_enabled", "Runtime", "Live execution", "boolean", settings_field="live_enabled"),
+# Derived from the authoritative Settings policy declarations (config.py);
+# no Settings field names or TOML paths are authored here by hand.
+_FIELDS: tuple[PolicyField, ...] = tuple(
     PolicyField(
-        "runtime.turn_timeout_seconds",
-        "Runtime",
-        "Turn timeout seconds",
-        "number",
-        settings_field="turn_timeout_seconds",
-    ),
-    PolicyField(
-        "runtime.max_active_daytona_leases",
-        "Runtime",
-        "Maximum Daytona leases",
-        "number",
-        settings_field="max_active_daytona_leases",
-    ),
-    PolicyField(
-        "runtime.heartbeat_seconds", "Runtime", "Heartbeat seconds", "number", settings_field="run_heartbeat_seconds"
-    ),
-    PolicyField(
-        "runtime.stale_after_seconds",
-        "Runtime",
-        "Stale after seconds",
-        "number",
-        settings_field="run_stale_after_seconds",
-    ),
-    PolicyField("llm.root.model", "Root LLM", "Model id", "text", settings_field="root_model"),
-    PolicyField(
-        "llm.root.api_key_env",
-        "Root LLM",
-        "Provider API key environment variable",
-        "text",
-        settings_field="root_llm_api_key_env",
-    ),
-    PolicyField("llm.root.base_url", "Root LLM", "Provider base URL", "text", settings_field="root_llm_base_url"),
-    PolicyField("llm.root.base_url_env", "Root LLM", "Provider base URL environment variable", "text"),
-    PolicyField("llm.root.max_tokens", "Root LLM", "Maximum tokens", "number", settings_field="root_llm_max_tokens"),
-    PolicyField("llm.root.temperature", "Root LLM", "Temperature", "number", settings_field="root_llm_temperature"),
-    PolicyField("llm.root.cache", "Root LLM", "Cache", "boolean", settings_field="root_llm_cache"),
-    PolicyField("llm.root.num_retries", "Root LLM", "Retries", "number", settings_field="root_llm_num_retries"),
-    PolicyField(
-        "llm.root.reasoning_effort",
-        "Root LLM",
-        "Reasoning effort",
-        "single_choice",
-        ("none", "low", "medium", "high"),
-        settings_field="root_llm_reasoning_effort",
-    ),
-    PolicyField("llm.sub.model", "Sub LLM", "Model id", "text", settings_field="sub_model"),
-    PolicyField(
-        "llm.sub.api_key_env",
-        "Sub LLM",
-        "Provider API key environment variable",
-        "text",
-        settings_field="sub_llm_api_key_env",
-    ),
-    PolicyField("llm.sub.base_url", "Sub LLM", "Provider base URL", "text", settings_field="sub_llm_base_url"),
-    PolicyField("llm.sub.base_url_env", "Sub LLM", "Provider base URL environment variable", "text"),
-    PolicyField("llm.sub.max_tokens", "Sub LLM", "Maximum tokens", "number", settings_field="sub_llm_max_tokens"),
-    PolicyField("llm.sub.temperature", "Sub LLM", "Temperature", "number", settings_field="sub_llm_temperature"),
-    PolicyField("llm.sub.cache", "Sub LLM", "Cache", "boolean", settings_field="sub_llm_cache"),
-    PolicyField("llm.sub.num_retries", "Sub LLM", "Retries", "number", settings_field="sub_llm_num_retries"),
-    PolicyField(
-        "llm.sub.reasoning_effort",
-        "Sub LLM",
-        "Reasoning effort",
-        "single_choice",
-        ("none", "low", "medium", "high"),
-        settings_field="sub_llm_reasoning_effort",
-    ),
-    PolicyField("rlm.max_iters", "RLM", "Maximum iterations", "number", settings_field="rlm_max_iters"),
-    PolicyField("rlm.max_llm_calls", "RLM", "Maximum LLM calls", "number", settings_field="rlm_max_llm_calls"),
-    PolicyField(
-        "rlm.max_output_chars", "RLM", "Maximum output characters", "number", settings_field="rlm_max_output_chars"
-    ),
-    PolicyField(
-        "rlm.max_execution_output_chars",
-        "RLM",
-        "Maximum execution output characters",
-        "number",
-        settings_field="rlm_max_execution_output_chars",
-    ),
-    PolicyField(
-        "rlm.execution_timeout_s",
-        "RLM",
-        "Sandbox execution timeout (seconds)",
-        "number",
-        settings_field="rlm_execution_timeout_s",
-    ),
-    PolicyField(
-        "rlm.recursion_enabled",
-        "RLM",
-        "Enable recursive child RLMs",
-        "boolean",
-        settings_field="rlm_recursion_enabled",
-    ),
-    PolicyField(
-        "rlm.recursion_max_calls", "RLM", "Recursive maximum calls", "number", settings_field="rlm_recursion_max_calls"
-    ),
-    PolicyField(
-        "rlm.recursion_max_prompt_chars",
-        "RLM",
-        "Recursive prompt character bound",
-        "number",
-        settings_field="rlm_recursion_max_prompt_chars",
-    ),
-    PolicyField(
-        "rlm.recursion_child_max_iters",
-        "RLM",
-        "Child maximum iterations",
-        "number",
-        settings_field="rlm_recursion_child_max_iters",
-    ),
-    PolicyField(
-        "rlm.recursion_child_max_llm_calls",
-        "RLM",
-        "Child maximum LLM calls",
-        "number",
-        settings_field="rlm_recursion_child_max_llm_calls",
-    ),
-    PolicyField(
-        "rlm.recursion_child_max_output_chars",
-        "RLM",
-        "Child maximum output characters",
-        "number",
-        settings_field="rlm_recursion_child_max_output_chars",
-    ),
-    PolicyField(
-        "rlm.recursion_max_parallel_children",
-        "RLM",
-        "Maximum parallel child RLMs",
-        "number",
-        settings_field="rlm_recursion_max_parallel_children",
-    ),
-    PolicyField(
-        "rlm.autonomous_memory_categories",
-        "RLM",
-        "Autonomous Memory categories",
-        "string_list",
-        settings_field="rlm_autonomous_memory_categories",
-    ),
-    PolicyField("rlm.verbose", "RLM", "DSPy host verbose logging", "boolean", settings_field="rlm_verbose"),
-    PolicyField("storage.data_root", "Storage", "Data root", "text", settings_field="data_root"),
-    PolicyField(
-        "storage.max_upload_bytes", "Storage", "Maximum upload bytes", "number", settings_field="max_upload_bytes"
-    ),
-    PolicyField(
-        "storage.max_url_bytes", "Storage", "Maximum URL source bytes", "number", settings_field="max_url_bytes"
-    ),
-    PolicyField(
-        "storage.max_artifact_bytes", "Storage", "Maximum artifact bytes", "number", settings_field="max_artifact_bytes"
-    ),
-    PolicyField("storage.database_url_env", "Storage", "Database URL environment variable", "text"),
-    PolicyField("daytona.api_key_env", "Daytona", "API key environment variable", "text"),
-    PolicyField("daytona.snapshot", "Daytona", "Snapshot", "text", settings_field="daytona_snapshot"),
-    PolicyField("daytona.org_id", "Daytona", "Organization ID", "text", settings_field="daytona_org_id"),
-    PolicyField("daytona.volume_name", "Daytona", "Volume name", "text", settings_field="volume_name"),
-    PolicyField(
-        "daytona.volume_mount_path", "Daytona", "Volume mount path", "text", settings_field="volume_mount_path"
-    ),
-    PolicyField(
-        "logging.level",
-        "Logging",
-        "Level",
-        "single_choice",
-        ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
-        "log_level",
-    ),
-    PolicyField(
-        "mlflow.tracing_enabled", "MLflow", "Tracing enabled", "boolean", settings_field="mlflow_tracing_enabled"
-    ),
-    PolicyField(
-        "mlflow.async_logging", "MLflow", "Async trace logging", "boolean", settings_field="mlflow_async_logging"
-    ),
-    PolicyField(
-        "mlflow.trace_sampling_ratio",
-        "MLflow",
-        "Trace sampling ratio",
-        "number",
-        settings_field="mlflow_trace_sampling_ratio",
-    ),
-    PolicyField(
-        "mlflow.trace_content_max_chars",
-        "MLflow",
-        "Trace payload character limit",
-        "number",
-        settings_field="mlflow_trace_content_max_chars",
-    ),
-    PolicyField("mlflow.experiment_name", "MLflow", "Experiment name", "text", settings_field="mlflow_experiment_name"),
-    PolicyField("mlflow.experiment_name_env", "MLflow", "Experiment environment variable", "text"),
-    PolicyField("mlflow.tracking_uri", "MLflow", "Tracking URI", "text", settings_field="mlflow_tracking_uri"),
-    PolicyField(
-        "mlflow.expose_trace_id", "MLflow", "Expose trace ID", "boolean", settings_field="mlflow_expose_trace_id"
-    ),
-    PolicyField("mlflow.trace_catalog", "MLflow", "Trace catalog", "text", settings_field="mlflow_trace_catalog"),
-    PolicyField("mlflow.trace_catalog_env", "MLflow", "Trace catalog environment variable", "text"),
-    PolicyField("mlflow.trace_schema", "MLflow", "Trace schema", "text", settings_field="mlflow_trace_schema"),
-    PolicyField("mlflow.trace_schema_env", "MLflow", "Trace schema environment variable", "text"),
-    PolicyField(
-        "mlflow.trace_table_prefix", "MLflow", "Trace table prefix", "text", settings_field="mlflow_trace_table_prefix"
-    ),
-    PolicyField("mlflow.trace_table_prefix_env", "MLflow", "Trace table prefix environment variable", "text"),
-    PolicyField(
-        "mlflow.tracing_sql_warehouse_id",
-        "MLflow",
-        "Tracing SQL warehouse ID",
-        "text",
-        settings_field="mlflow_tracing_sql_warehouse_id",
-    ),
-    PolicyField(
-        "mlflow.tracing_sql_warehouse_id_env",
-        "MLflow",
-        "Tracing SQL warehouse environment variable",
-        "text",
-    ),
-    PolicyField("posthog.enabled", "PostHog", "Analytics enabled", "boolean", settings_field="posthog_enabled"),
-    PolicyField("posthog.project_token_env", "PostHog", "Project token environment variable", "text"),
-    PolicyField("posthog.host", "PostHog", "Ingestion host", "text", settings_field="posthog_host"),
+        path=spec.toml_path,
+        group=spec.group,
+        label=spec.label,
+        editor=spec.editor,
+        choices=spec.choices,
+        settings_field=spec.settings_field,
+    )
+    for spec in config_field_specs()
+    if spec.group is not None
 )
 _FIELD_BY_PATH = {field.path: field for field in _FIELDS}
 
@@ -478,9 +284,9 @@ class ConfigPolicyService:
         for profile, value in document.profiles.items():
             selected = _require_mapping(value, f"profiles.{profile}")
             _validate_policy_table(selected, f"profiles.{profile}")
-            values = _flatten_policy(_deep_merge(document.defaults, selected))
+            flattened = _flatten_policy(_deep_merge(document.defaults, selected))
             try:
-                Settings.model_validate(values)
+                Settings.model_validate(dict(flattened.settings))
             except ValueError as exc:
                 raise FleetConfigurationError("invalid Fleet configuration policy") from exc
 

--- a/src/fleet_rlm/daytona/broker_source.py
+++ b/src/fleet_rlm/daytona/broker_source.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping
 from typing import Any
 
 FINAL_OUTPUT_MARKER = "__FLEET_FINAL_OUTPUT__"
-_FINAL_OUTPUT_MARKER = FINAL_OUTPUT_MARKER
 
 
 def build_submit_setup_code(output_fields: list[dict[str, Any]] | None) -> str:
@@ -30,7 +29,7 @@ def remote_submit_setup_code(output_fields: list[dict[str, Any]] | None) -> str:
 import base64 as _base64
 import json
 _json = json
-_FINAL_OUTPUT_MARKER = {_FINAL_OUTPUT_MARKER!r}
+FINAL_OUTPUT_MARKER = {FINAL_OUTPUT_MARKER!r}
 
 class FleetFinalOutputError(Exception):
     def __init__(self, value):
@@ -47,7 +46,7 @@ import base64 as _base64
 
 def SUBMIT(**kwargs):
     payload = _base64.b64encode(_json.dumps(kwargs, ensure_ascii=False).encode("utf-8")).decode("ascii")
-    print(f"{_FINAL_OUTPUT_MARKER}{payload}{_FINAL_OUTPUT_MARKER}")
+    print(f"{FINAL_OUTPUT_MARKER}{payload}{FINAL_OUTPUT_MARKER}")
     raise FleetFinalOutputError(kwargs)
 """.strip()
 
@@ -96,12 +95,12 @@ import base64 as _base64
 def SUBMIT({signature}):
     {body}
     payload = _base64.b64encode(_json.dumps(result, ensure_ascii=False).encode("utf-8")).decode("ascii")
-    print(f"{{_FINAL_OUTPUT_MARKER}}{{payload}}{{_FINAL_OUTPUT_MARKER}}")
+    print(f"{{FINAL_OUTPUT_MARKER}}{{payload}}{{FINAL_OUTPUT_MARKER}}")
     raise FleetFinalOutputError(result)
 """.strip()
 
 
-def extract_final_payload(stdout: str, *, marker: str = _FINAL_OUTPUT_MARKER) -> dict[str, Any] | None:
+def extract_final_payload(stdout: str, *, marker: str = FINAL_OUTPUT_MARKER) -> dict[str, Any] | None:
     start = stdout.find(marker)
     if start == -1:
         return None
@@ -122,7 +121,7 @@ def extract_final_payload(stdout: str, *, marker: str = _FINAL_OUTPUT_MARKER) ->
     return parsed if isinstance(parsed, dict) else None
 
 
-def final_output_frame(value: Mapping[str, Any], *, marker: str = _FINAL_OUTPUT_MARKER) -> str:
+def final_output_frame(value: Mapping[str, Any], *, marker: str = FINAL_OUTPUT_MARKER) -> str:
     """Return the exact private stdout frame emitted by ``SUBMIT``."""
     encoded = base64.b64encode(json.dumps(dict(value), ensure_ascii=False).encode("utf-8")).decode("ascii")
     return f"{marker}{encoded}{marker}"

--- a/src/fleet_rlm/daytona/diagnostics.py
+++ b/src/fleet_rlm/daytona/diagnostics.py
@@ -24,9 +24,9 @@ from fleet_rlm.daytona.provisioning import (
     verify_sandbox_spec,
     verify_sandbox_workspace_mount,
     volume_config_from_settings,
-    workspace_volume_subpath,
 )
 from fleet_rlm.persistence.database import ensure_database_compatible
+from fleet_rlm.runtime.bindings import workspace_volume_subpath
 
 DoctorStepName = Literal["settings", "database", "provider", "rlm", "sandbox", "interpreter", "cleanup"]
 DoctorFailureCategory = Literal[

--- a/src/fleet_rlm/daytona/dspy_sync_bridge.py
+++ b/src/fleet_rlm/daytona/dspy_sync_bridge.py
@@ -57,53 +57,13 @@ class SyncBridgeDispatcher:
         return self._service_loop
 
 
-_default_dispatcher = SyncBridgeDispatcher()
-
-
-def default_bridge_dispatcher() -> SyncBridgeDispatcher:
-    """Return the legacy process-default dispatcher (transitional seam).
-
-    New compositions must own a :class:`SyncBridgeDispatcher` instead of
-    registering on this default; the default exists only so un-migrated
-    private-test and optimization lanes keep their legacy behavior.
-    """
-    return _default_dispatcher
-
-
-def set_bridge_service_loop(loop: asyncio.AbstractEventLoop | None) -> None:
-    """Register the composition-wide loop on the legacy process-default dispatcher.
-
-    Daytona SDK objects (client, Sandbox, FileSystem; their aiohttp session)
-    are loop-affine to the loop that created them — the composition/uvicorn
-    loop — and fail with "attached to a different loop" elsewhere, so every
-    ``_Sync*`` bridge posts its SDK coroutines to this one registered loop.
-    That loop also carries the RC-7 safety property: it never performs nested
-    synchronous waits (those live only on RLM worker threads and broker
-    fulfill threads), so a posted coroutine always gets serviced and the
-    worker↔bridge circular wait cannot form.
-
-    Transitional facade over :func:`default_bridge_dispatcher`; composition
-    installs route through their own :class:`SyncBridgeDispatcher` instead.
-    """
-    if loop is None:
-        _default_dispatcher.clear_loop(_default_dispatcher.service_loop())
-    else:
-        _default_dispatcher.set_loop(loop)
-
-
-def bridge_service_loop() -> asyncio.AbstractEventLoop | None:
-    """Return the loop registered on the legacy process-default dispatcher."""
-    return _default_dispatcher.service_loop()
-
-
 class _SyncBridgeLoop:
     """Service-loop routing and close state for one synchronous Daytona bridge.
 
-    Posted SDK coroutines run on the registered composition-wide service loop
-    (see :func:`set_bridge_service_loop`); when no service loop is registered
-    (e.g. private-test compositions that never install the Daytona inventory)
-    the bridge falls back to its caller-captured loop, matching legacy
-    behavior. The bridge owns no threads, so Turns cannot leak daemon threads;
+    Posted SDK coroutines run on the composition-owned service loop exposed by
+    the injected dispatcher; when no dispatcher is injected (e.g. private-test
+    compositions that never install the Daytona inventory) the bridge falls
+    back to its caller-captured loop. The bridge owns no threads, so Turns cannot leak daemon threads;
     :meth:`close` tombstones the bridge so late calls fail typed-fast instead
     of posting to a service loop after lease release.
     """
@@ -140,8 +100,7 @@ class _SyncBridgeLoop:
             registered = self._dispatcher.service_loop()
             if registered is not None:
                 return registered
-        registered = _default_dispatcher.service_loop()
-        return registered if registered is not None else self._caller_loop
+        return self._caller_loop
 
     def run(self, awaitable: Any) -> Any:
         """Post one awaitable on the service loop and block until it settles."""
@@ -278,9 +237,9 @@ class _DSPySyncSandboxView:
     """Explicit synchronous Daytona view used only by DSPy worker execution.
 
     Routes SDK coroutines through the composition-wide bridge service loop
-    (see :func:`set_bridge_service_loop`); the ``loop`` constructor argument
-    anchors the fail-fast owning-loop guard and is the fallback target only
-    when no service loop is registered.
+    exposed by the injected dispatcher; the ``loop`` constructor argument
+    anchors the fail-fast owning-loop guard and is the fallback target when
+    no dispatcher is injected.
     """
 
     def __init__(
@@ -320,8 +279,8 @@ def sync_sandbox(
     """Return a synchronous sandbox view for DSPy worker-thread execution.
 
     ``dispatcher`` injects the composition-owned bridge authority (QRE-154);
-    when omitted, the view resolves through the legacy process-default
-    dispatcher. The concrete view type is private to this module. Callers that
+    when omitted, the view falls back to its caller-captured loop. The
+    concrete view type is private to this module. Callers that
     need to invalidate a view after lease release should use
     :func:`tombstone_sync_sandbox`.
     """
@@ -342,9 +301,6 @@ def tombstone_sync_sandbox(sandbox: Any) -> None:
 
 __all__ = [
     "SyncBridgeDispatcher",
-    "bridge_service_loop",
-    "default_bridge_dispatcher",
-    "set_bridge_service_loop",
     "sync_sandbox",
     "tombstone_sync_sandbox",
 ]

--- a/src/fleet_rlm/daytona/errors.py
+++ b/src/fleet_rlm/daytona/errors.py
@@ -37,6 +37,16 @@ def sanitize_provider_message(raw: str) -> str:
     return message
 
 
+def sanitize_failure_text(exc: BaseException) -> str:
+    """Credential-free ``TypeName: message`` failure description for receipts.
+
+    Single owner for lease receipts and deletion-probe error strings; text is
+    exactly :func:`sanitize_provider_message` output, so redaction policy
+    cannot drift between lifecycle lanes.
+    """
+    return f"{type(exc).__name__}: {sanitize_provider_message(str(exc))}"
+
+
 @dataclass(slots=True)
 class DaytonaAdapterError(Exception):
     """Normalized Daytona failure safe for Fleet callers."""
@@ -116,6 +126,20 @@ def classify_provider_error(exc: object) -> ProviderFailureKind:
 def is_safe_pre_creation_retry(exc: object) -> bool:
     """True only for transient failures before sandbox creation is attempted."""
     return classify_provider_error(exc) in {"network", "timeout", "provider_5xx"}
+
+
+_TRANSIENT_STATUS_TEXT = re.compile(r"\b5\d{2}\b")
+
+
+def is_transient_provider_failure(exc: object) -> bool:
+    """True for transient provider failures: network, timeout, or 5xx.
+
+    The 5xx text-marker leg covers provider failures that arrive without
+    structured status metadata (e.g. preview-link resolution errors).
+    """
+    if is_safe_pre_creation_retry(exc):
+        return True
+    return _TRANSIENT_STATUS_TEXT.search(sanitize_provider_message(str(exc))) is not None
 
 
 def is_sandbox_not_found(exc: BaseException) -> bool:

--- a/src/fleet_rlm/daytona/errors.py
+++ b/src/fleet_rlm/daytona/errors.py
@@ -18,6 +18,8 @@ ProviderFailureKind = Literal[
     "unknown",
 ]
 
+DEFAULT_SANITIZED_FAILURE_MAX_CHARS = 200
+
 _SECRET_PATTERNS = (
     re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization)\s*[:=]\s*\S+"),
     re.compile(r"(?i)bearer\s+\S+"),
@@ -37,14 +39,14 @@ def sanitize_provider_message(raw: str) -> str:
     return message
 
 
-def sanitize_failure_text(exc: BaseException) -> str:
+def sanitize_failure_text(exc: BaseException, *, max_chars: int = DEFAULT_SANITIZED_FAILURE_MAX_CHARS) -> str:
     """Credential-free ``TypeName: message`` failure description for receipts.
 
     Single owner for lease receipts and deletion-probe error strings; text is
     exactly :func:`sanitize_provider_message` output, so redaction policy
     cannot drift between lifecycle lanes.
     """
-    return f"{type(exc).__name__}: {sanitize_provider_message(str(exc))}"
+    return f"{type(exc).__name__}: {sanitize_provider_message(str(exc))}"[:max_chars]
 
 
 @dataclass(slots=True)

--- a/src/fleet_rlm/daytona/http_broker.py
+++ b/src/fleet_rlm/daytona/http_broker.py
@@ -13,7 +13,6 @@ import inspect
 import json
 import keyword
 import logging
-import re
 import secrets
 import time
 import uuid
@@ -35,7 +34,7 @@ from fleet_rlm.daytona.broker_source import (
 from fleet_rlm.daytona.errors import (
     DaytonaAdapterError,
     ProviderRequestError,
-    is_safe_pre_creation_retry,
+    is_transient_provider_failure,
     map_provider_error,
     provider_status_code,
     sanitize_provider_message,
@@ -52,13 +51,6 @@ _BROKER_SERVER_PATH = "/home/daytona/fleet_rlm_broker_server.py"
 _BROKER_SESSION_COMMAND = f"cd /home/daytona && python {_BROKER_SERVER_PATH.rsplit('/', 1)[-1]}"
 _MAX_EXECUTE_REQUEST_BYTES = 2 * 1024 * 1024
 _MAX_EXECUTE_OUTPUT_CHARS = 64 * 1024
-
-
-def _is_retryable_preview_link_error(exc: DaytonaAdapterError) -> bool:
-    """Retry only transient provider failures while resolving the preview URL."""
-    if is_safe_pre_creation_retry(exc):
-        return True
-    return re.search(r"\b5\d{2}\b", sanitize_provider_message(str(exc))) is not None
 
 
 class FleetFinalOutputError(Exception):
@@ -181,7 +173,7 @@ class DaytonaHttpToolBroker:
             except Exception as exc:
                 mapped = map_provider_error(exc)
                 last_error = mapped
-                if not _is_retryable_preview_link_error(mapped):
+                if not is_transient_provider_failure(mapped):
                     break
 
         assert last_error is not None

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -29,6 +29,7 @@ from uuid import uuid4
 import dspy
 
 from fleet_rlm.daytona.broker_source import (
+    FINAL_OUTPUT_MARKER,
     build_submit_setup_code,
     extract_final_payload,
 )
@@ -171,7 +172,7 @@ class InProcessInterpreterBackend:
         if key == self._submit_key:
             return
         self.namespace["FleetFinalOutputError"] = FleetFinalOutputError
-        self.namespace["_FINAL_OUTPUT_MARKER"] = "__FLEET_FINAL_OUTPUT__"
+        self.namespace["FINAL_OUTPUT_MARKER"] = FINAL_OUTPUT_MARKER
         self.namespace["json"] = __import__("json")
         self.namespace["_json"] = self.namespace["json"]
         exec(build_submit_setup_code(output_fields), self.namespace, self.namespace)

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -53,9 +53,7 @@ from fleet_rlm.observability.turn_tracing import trace_preview_limit, turn_phase
 from fleet_rlm.rlm.dspy_interpreter_contract import (
     PUBLIC_FINAL_OUTPUT_LABEL,
     copy_output_fields,
-    initial_tools_registered,
     is_final_output,
-    mark_tools_registered,
     needs_tool_reinjection,
     wrap_final_output,
 )
@@ -348,7 +346,7 @@ class DaytonaCodeInterpreter:
         self._tools: dict[str, Callable[..., Any]] = dict(tools or {})
         self._bound_tools: dict[str, Callable[..., Any]] = {}
         self.output_fields: list[dict[str, Any]] | None = copy_output_fields(output_fields)
-        self._tools_registered = initial_tools_registered()
+        self._tools_registered = False
         self._started = False
         self._shutdown = False
         self._broker_port = broker_port
@@ -664,10 +662,10 @@ class DaytonaCodeInterpreter:
         if isinstance(backend, InProcessInterpreterBackend):
             backend.bind_host_tools(tools)
             backend.ensure_submit(self.output_fields)
-            self._tools_registered = mark_tools_registered()
+            self._tools_registered = True
             return
         if not isinstance(backend, _SandboxProcessBackend):
-            self._tools_registered = mark_tools_registered()
+            self._tools_registered = True
             return
         if not needs_tool_reinjection(
             tools_registered=self._tools_registered,
@@ -690,7 +688,7 @@ class DaytonaCodeInterpreter:
             self._http_broker.submit_setup_code(self.output_fields),
             timeout_s=float(backend.timeout_s or DEFAULT_EXECUTION_TIMEOUT_S),
         )
-        self._tools_registered = mark_tools_registered()
+        self._tools_registered = True
 
     def _execute_with_http_broker(
         self,

--- a/src/fleet_rlm/daytona/lifecycle.py
+++ b/src/fleet_rlm/daytona/lifecycle.py
@@ -176,7 +176,12 @@ async def confirm_absence(
             if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt, SystemExit)):
                 raise
             note("probe_error")
-            return AbsenceProbeError(sandbox_id, sanitize_failure_text(exc), tuple(observations), clock() - started)
+            return AbsenceProbeError(
+                sandbox_id,
+                sanitize_failure_text(exc, max_chars=160),
+                tuple(observations),
+                clock() - started,
+            )
         if target is None:
             note("not_found")
             return AbsenceConfirmation(sandbox_id, tuple(observations), clock() - started)

--- a/src/fleet_rlm/daytona/lifecycle.py
+++ b/src/fleet_rlm/daytona/lifecycle.py
@@ -28,6 +28,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, TypeAlias
 
+from fleet_rlm.daytona.errors import sanitize_failure_text
+
 __all__ = [
     "DEFAULT_CONFIRM_TIMEOUT_S",
     "DEFAULT_POLL_INTERVAL_S",
@@ -127,11 +129,6 @@ AbsenceOutcome: TypeAlias = AbsenceConfirmation | AbsenceTimeout | AbsenceProbeE
 """Closed outcome of one absence-confirmation wait; ``absent`` is authoritative."""
 
 
-def _sanitize_error(exc: BaseException) -> str:
-    """Bounded, credential-free probe-failure description."""
-    return f"{type(exc).__name__}: {str(exc)[:160]}"
-
-
 async def confirm_absence(
     *,
     probe: DeletionStateProbe,
@@ -179,7 +176,7 @@ async def confirm_absence(
             if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt, SystemExit)):
                 raise
             note("probe_error")
-            return AbsenceProbeError(sandbox_id, _sanitize_error(exc), tuple(observations), clock() - started)
+            return AbsenceProbeError(sandbox_id, sanitize_failure_text(exc), tuple(observations), clock() - started)
         if target is None:
             note("not_found")
             return AbsenceConfirmation(sandbox_id, tuple(observations), clock() - started)

--- a/src/fleet_rlm/daytona/memory_diagnostics.py
+++ b/src/fleet_rlm/daytona/memory_diagnostics.py
@@ -16,12 +16,12 @@ bodies, paths, or secrets — so operator telemetry cannot leak Workspace data.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
 from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
 
 from fleet_rlm.files.memory_models import WorkspaceMemoryStoreUnavailableError
+from fleet_rlm.observability.failure_diagnostics import walk_cause_chain
 
 logger = logging.getLogger(__name__)
 
@@ -61,20 +61,6 @@ class MemoryDegradation:
     fallback_outcome: str
 
 
-def _chain(exc: BaseException) -> Iterator[BaseException]:
-    """Walk the cause/context chain with a cycle guard."""
-
-    current: BaseException | None = exc
-    seen: set[int] = set()
-    try:
-        while current is not None and id(current) not in seen:
-            seen.add(id(current))
-            yield current
-            current = current.__cause__ or current.__context__
-    except Exception:
-        return
-
-
 def classify_memory_failure(exc: BaseException, *, operation: str) -> tuple[MemoryFailureCategory, str]:
     """Map one degraded operation's exception to a sanitized category + cause type.
 
@@ -88,7 +74,7 @@ def classify_memory_failure(exc: BaseException, *, operation: str) -> tuple[Memo
     from fleet_rlm.daytona.workspace_agent import WorkspaceAgentStorageError
     from fleet_rlm.files.memory_tools import MemoryToolError
 
-    chain = list(_chain(exc))
+    chain = list(walk_cause_chain(exc))
     cause_type = type(chain[-1]).__name__ if chain else type(exc).__name__
     for item in chain:
         if isinstance(item, MemoryMigrationError):

--- a/src/fleet_rlm/daytona/memory_diagnostics.py
+++ b/src/fleet_rlm/daytona/memory_diagnostics.py
@@ -1,0 +1,155 @@
+"""Sanitized Workspace Memory degradation diagnostics (fail-soft observability).
+
+Workspace Memory preparation stays fail-soft by design: a degraded optional
+Memory context must never block a Run. This module makes each degradation
+diagnosable WITHOUT changing that behavior: the Workspace Memory adapter marks
+its internal failure classes, ``classify_memory_failure`` maps low-level
+exceptions to one bounded category at the catch seam, and
+``record_memory_degradation`` emits exactly one bounded diagnostic per
+degraded operation through the existing logging + Turn-tracing facilities.
+
+Diagnostics carry only ``category``/``operation``/``runtime``/``cause_type``/
+``fallback_outcome`` — never Memory content, query text, raw provider payload
+bodies, paths, or secrets — so operator telemetry cannot leak Workspace data.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import suppress
+from dataclasses import dataclass
+from enum import StrEnum
+
+from fleet_rlm.files.memory_models import WorkspaceMemoryStoreUnavailableError
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryFailureCategory(StrEnum):
+    """Bounded internal classes for degraded Workspace Memory operations."""
+
+    NORMALIZATION = "normalization"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    CORRUPT_RECORD_SET = "corrupt_record_set"
+    INVARIANT_VIOLATION = "invariant_violation"
+    SEARCH_FAILURE = "search_failure"
+    LEGACY_MIGRATION = "legacy_migration"
+    UNEXPECTED_INTERNAL = "unexpected_internal"
+
+
+class MemoryMigrationError(WorkspaceMemoryStoreUnavailableError):
+    """Failure specific to the legacy-store migration/read sequence."""
+
+
+class MemoryInvariantError(WorkspaceMemoryStoreUnavailableError):
+    """Fail-closed duplicate/stable-ID invariant violation (stays strict)."""
+
+
+class MemoryPayloadError(ValueError):
+    """Mounted-agent Memory payload violated its checked response shape."""
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryDegradation:
+    """One bounded, sanitized degraded-operation diagnostic."""
+
+    category: MemoryFailureCategory
+    operation: str
+    runtime: str
+    cause_type: str
+    fallback_outcome: str
+
+
+def _chain(exc: BaseException) -> Iterator[BaseException]:
+    """Walk the cause/context chain with a cycle guard."""
+
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    try:
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            yield current
+            current = current.__cause__ or current.__context__
+    except Exception:
+        return
+
+
+def classify_memory_failure(exc: BaseException, *, operation: str) -> tuple[MemoryFailureCategory, str]:
+    """Map one degraded operation's exception to a sanitized category + cause type.
+
+    Marker exceptions raised at the Workspace Memory adapter own the precise
+    classes; a bare ``WorkspaceMemoryStoreUnavailableError``/workspace-agent
+    failure is the expected provider/storage class, and anything else — the
+    programming/invariant-defect bucket — is always named explicitly as
+    ``unexpected_internal`` rather than disappearing into a generic fallback.
+    """
+
+    from fleet_rlm.daytona.workspace_agent import WorkspaceAgentStorageError
+    from fleet_rlm.files.memory_tools import MemoryToolError
+
+    chain = list(_chain(exc))
+    cause_type = type(chain[-1]).__name__ if chain else type(exc).__name__
+    for item in chain:
+        if isinstance(item, MemoryMigrationError):
+            return MemoryFailureCategory.LEGACY_MIGRATION, cause_type
+        if isinstance(item, MemoryInvariantError):
+            return MemoryFailureCategory.INVARIANT_VIOLATION, cause_type
+        if isinstance(item, MemoryPayloadError):
+            return MemoryFailureCategory.CORRUPT_RECORD_SET, cause_type
+    if any(isinstance(item, MemoryToolError) for item in chain):
+        if operation == "normalize_query":
+            return MemoryFailureCategory.NORMALIZATION, cause_type
+        if operation == "relevance_search":
+            return MemoryFailureCategory.SEARCH_FAILURE, cause_type
+        return MemoryFailureCategory.UNEXPECTED_INTERNAL, cause_type
+    store_error = next((item for item in chain if isinstance(item, WorkspaceMemoryStoreUnavailableError)), None)
+    if store_error is None:
+        return MemoryFailureCategory.UNEXPECTED_INTERNAL, cause_type
+    cause = store_error.__cause__ or store_error.__context__
+    if cause is None or isinstance(cause, WorkspaceAgentStorageError):
+        return MemoryFailureCategory.PROVIDER_UNAVAILABLE, cause_type
+    return MemoryFailureCategory.UNEXPECTED_INTERNAL, cause_type
+
+
+def record_memory_degradation(
+    exc: BaseException,
+    *,
+    operation: str,
+    fallback_outcome: str,
+    runtime: str = "daytona",
+) -> MemoryDegradation:
+    """Classify and emit exactly one bounded diagnostic per degraded operation.
+
+    Emission never fails the Run: logging/tracing faults stay trapped here,
+    and tracing-disabled Turns keep the structured log only (MLflow is never
+    imported when no ``fleet_turn`` span is active).
+    """
+
+    category, cause_type = classify_memory_failure(exc, operation=operation)
+    degradation = MemoryDegradation(category, operation, runtime, cause_type, fallback_outcome)
+    # Logging emission is shielded so it can never fail the Run.
+    with suppress(Exception):
+        logger.warning(
+            "Workspace Memory degraded: category=%s operation=%s runtime=%s cause_type=%s outcome=%s",
+            degradation.category.value,
+            degradation.operation,
+            degradation.runtime,
+            degradation.cause_type,
+            degradation.fallback_outcome,
+        )
+    try:
+        from fleet_rlm.observability.turn_tracing import annotate_turn_attributes
+
+        annotate_turn_attributes(
+            {
+                "fleet.memory_degradation.category": degradation.category.value,
+                "fleet.memory_degradation.operation": degradation.operation,
+                "fleet.memory_degradation.runtime": degradation.runtime,
+                "fleet.memory_degradation.cause_type": degradation.cause_type,
+                "fleet.memory_degradation.fallback_outcome": degradation.fallback_outcome,
+            }
+        )
+    except Exception:  # pragma: no cover - tracing must never fail the Run
+        logger.debug("Workspace Memory degradation tracing annotation failed; continuing", exc_info=True)
+    return degradation

--- a/src/fleet_rlm/daytona/memory_outbox_reconcile.py
+++ b/src/fleet_rlm/daytona/memory_outbox_reconcile.py
@@ -135,11 +135,11 @@ class MemoryOutboxReconciler:
         now: datetime,
     ) -> tuple[int, int, int, int]:
         from fleet_rlm.daytona.dspy_sync_bridge import sync_sandbox
-        from fleet_rlm.daytona.workspace_memory import DaytonaWorkspaceMemoryStore
+        from fleet_rlm.daytona.workspace_memory import build_workspace_memory_store
 
         loop = asyncio.get_running_loop()
         view = sync_sandbox(sandbox, loop, self._dispatcher)
-        store = DaytonaWorkspaceMemoryStore(view, volume_paths=self._paths, max_upload_bytes=self._max_upload_bytes)
+        store = build_workspace_memory_store(view, volume_paths=self._paths, max_upload_bytes=self._max_upload_bytes)
         promoted = dropped = retried = dead_lettered = 0
         for intent in intents:
             try:

--- a/src/fleet_rlm/daytona/optimization_evaluator.py
+++ b/src/fleet_rlm/daytona/optimization_evaluator.py
@@ -29,6 +29,7 @@ from fleet_rlm.rlm.dspy_contract import (
     build_native_rlm,
     observed_usage,
     prediction_result,
+    rlm_termination_mode,
 )
 from fleet_rlm.runtime.owned_effect import OwnedEffect
 
@@ -425,7 +426,7 @@ class StrictDaytonaEvaluationLifecycle:
                 proof_id=self._proof.proof_id,
                 curated_input_sha256=curated_input.consume().sha256,
                 curated_input_schema=curated_input.receipt.schema,
-                termination_mode=_termination_mode(prediction),
+                termination_mode=rlm_termination_mode(prediction),
             )
         except BaseException as exc:
             primary_error = exc
@@ -507,21 +508,6 @@ def _strict_named_inputs(handle: dict[str, str | int]) -> dict[str, Any]:
         dict[str, Any]: Mapping containing the copied handle under `curated_input_handle`.
     """
     return {"curated_input_handle": dict(handle)}
-
-
-def _termination_mode(prediction: Any) -> str:
-    """
-    Determine how the evaluator terminated based on the prediction metadata.
-
-    Parameters:
-        prediction (Any): The evaluator prediction to inspect.
-
-    Returns:
-        str: `"native_extraction_fallback"` when forced final output extraction was used; `"typed_submit"` otherwise.
-    """
-    if getattr(prediction, "final_reasoning", None) == "Extract forced final output":
-        return "native_extraction_fallback"
-    return "typed_submit"
 
 
 def _require_sha256(value: str, label: str) -> None:

--- a/src/fleet_rlm/daytona/provisioning.py
+++ b/src/fleet_rlm/daytona/provisioning.py
@@ -11,6 +11,14 @@ from uuid import UUID
 
 from fleet_rlm.daytona.errors import DaytonaAdapterError, map_provider_error
 from fleet_rlm.files.volume_paths import DEFAULT_VOLUME_MOUNT_PATH, VolumePaths, validate_mount_path
+
+# Workspace-scoped subpath validation lives in the provider-neutral owner
+# (fleet_rlm.runtime.bindings); Daytona provisioning reuses it directly.
+from fleet_rlm.runtime.bindings import (
+    require_non_zero_workspace_id,
+    require_scoped_volume_subpath,
+    workspace_volume_subpath,
+)
 from fleet_rlm.snapshot_contract import validate_snapshot_name
 
 DEFAULT_SNAPSHOT_NAME = "fleet-rlm-python313-v5"
@@ -223,27 +231,6 @@ def verify_sandbox_spec(sandbox: Any, spec: DaytonaSandboxSpec) -> None:
         )
 
 
-def require_non_zero_workspace_id(workspace_id: UUID) -> UUID:
-    if not isinstance(workspace_id, UUID):
-        raise TypeError("workspace_id must be a UUID")
-    if workspace_id == _ZERO_UUID:
-        raise ValueError("workspace_id must not be the zero UUID")
-    return workspace_id
-
-
-def workspace_volume_subpath(workspace_id: UUID) -> str:
-    """
-    Build the canonical persistent volume subpath for a workspace.
-
-    Parameters:
-        workspace_id (UUID): The non-zero workspace identifier.
-
-    Returns:
-        str: The validated path under the workspace volume.
-    """
-    return f"workspaces/{require_non_zero_workspace_id(workspace_id)}"
-
-
 def recursive_child_volume_subpath(workspace_id: UUID, run_id: UUID, call_index: int) -> str:
     """
     Builds the canonical recursive volume scope for a disposable child RLM.
@@ -268,36 +255,6 @@ def recursive_child_volume_subpath(workspace_id: UUID, run_id: UUID, call_index:
     if not isinstance(call_index, int) or isinstance(call_index, bool) or call_index <= 0:
         raise ValueError("call_index must be a positive integer")
     return f"recursive/{workspace}/{run_id}/{call_index}"
-
-
-def require_scoped_volume_subpath(subpath: str, *, workspace_id: UUID | None = None) -> str:
-    """
-    Validate and normalize a workspace-scoped volume subpath.
-
-    Parameters:
-        subpath (str): The volume subpath, which must identify exactly one workspace.
-        workspace_id (UUID | None): If provided, the subpath must match this workspace.
-
-    Returns:
-        str: The normalized `workspaces/<workspace_id>` subpath.
-
-    Raises:
-        ValueError: If the subpath is empty, uses traversal, does not identify exactly one workspace,
-            or does not match `workspace_id`.
-    """
-    if not isinstance(subpath, str) or not subpath.strip():
-        raise ValueError("VolumeMount without workspace subpath is rejected")
-    normalized = subpath.strip().strip("/")
-    if ".." in normalized.split("/"):
-        raise ValueError("volume subpath must not contain path traversal")
-    if not normalized.startswith("workspaces/"):
-        raise ValueError("volume subpath must be under workspaces/<workspace_id>")
-    rest = normalized.removeprefix("workspaces/")
-    if not rest or "/" in rest:
-        raise ValueError("volume subpath must be exactly workspaces/<workspace_id>")
-    if workspace_id is not None and normalized != workspace_volume_subpath(workspace_id):
-        raise ValueError("volume subpath does not match workspace_id")
-    return normalized
 
 
 def require_recursive_child_volume_subpath(

--- a/src/fleet_rlm/daytona/recursive_child_runtime.py
+++ b/src/fleet_rlm/daytona/recursive_child_runtime.py
@@ -14,21 +14,14 @@ from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, sandbox_backen
 from fleet_rlm.daytona.provisioning import SandboxPlatform
 from fleet_rlm.daytona.recursive_child_acquisition import (
     acquire_child_runtime,
-    require_authorized,
-    sandbox_id_for,
 )
 from fleet_rlm.daytona.recursive_child_cleanup import (
-    CHILD_CLEANUP_RESULT_TIMEOUT_S,
+    CHILD_CLEANUP_RESULT_TIMEOUT_S as _CHILD_CLEANUP_RESULT_TIMEOUT_S,
+)
+from fleet_rlm.daytona.recursive_child_cleanup import (
     cleanup_after_failed_acquire,
     cleanup_child_runtime_async,
     close_child_runtime_sync,
-    purge_regular_files,
-)
-from fleet_rlm.daytona.recursive_child_cleanup import (
-    CHILD_DELETE_CONFIRM_POLL_S as _CHILD_DELETE_CONFIRM_POLL_S,
-)
-from fleet_rlm.daytona.recursive_child_cleanup import (
-    CHILD_DELETE_CONFIRM_TIMEOUT_S as _CHILD_DELETE_CONFIRM_TIMEOUT_S,
 )
 from fleet_rlm.daytona.recursive_child_late import LateCleanupOwner
 from fleet_rlm.daytona.recursive_child_lease import ChildRuntimeLease, ChildRuntimeLeaseState
@@ -42,13 +35,17 @@ from fleet_rlm.rlm.child_runtime import (
     ChildRuntimeFactory,
 )
 
-_CHILD_CLEANUP_RESULT_TIMEOUT_S = CHILD_CLEANUP_RESULT_TIMEOUT_S
+# Patchable compat seams (tests and live proofs monkeypatch these module-level
+# names): each binds the canonical implementation, and the call sites below read
+# them from this module's namespace at call time.
+_acquire_child_runtime = acquire_child_runtime
+_cleanup_child_runtime_async = cleanup_child_runtime_async
 
 
-# Absence-confirmation budget for one deleted ephemeral child Sandbox. Kept
-# distinctly larger than the close-path result timeout so a quarantined
-# (retained, still-running) cleanup coroutine normally confirms within its own
-# budget instead of dying unclassified with the loop.
+# Absence-confirmation budget policy lives in ``recursive_child_cleanup``
+# (``CHILD_DELETE_CONFIRM_*``): distinctly larger than the close-path result
+# timeout so a quarantined (retained, still-running) cleanup coroutine normally
+# confirms within its own budget instead of dying unclassified with the loop.
 def build_child_runtime_factory(
     *,
     loop: asyncio.AbstractEventLoop,
@@ -113,6 +110,10 @@ def build_child_runtime_factory(
             execution_output_cap=execution_output_cap,
             is_authorized=is_authorized,
             retain_pending_cleanup=late_owner.retain,
+            interpreter_factory=DaytonaCodeInterpreter,
+            sandbox_backend_factory=sandbox_backend,
+            close_child_runtime=_close_child_runtime_sync,
+            cleanup_after_failed_acquire=cleanup_after_failed_acquire,
         )
         try:
             acquisition = asyncio.run_coroutine_threadsafe(acquisition_coroutine, loop)
@@ -158,48 +159,6 @@ def build_child_runtime_factory(
     return Factory()
 
 
-async def _acquire_child_runtime(
-    *,
-    loop: asyncio.AbstractEventLoop,
-    dispatcher: SyncBridgeDispatcher | None = None,
-    platform: SandboxPlatform,
-    admission: DaytonaAdmission,
-    volume_id: str,
-    mount_path: str,
-    workspace_id: UUID,
-    run_id: UUID,
-    call_index: int,
-    deadline: float,
-    execution_timeout_s: int,
-    execution_output_cap: int,
-    is_authorized: Callable[[], bool] | None = None,
-    retain_pending_cleanup: Callable[[Future[Any]], None] | None = None,
-) -> ChildRuntimeLease:
-    """Compatibility wrapper that supplies the current provider seams."""
-    return await acquire_child_runtime(
-        loop=loop,
-        dispatcher=dispatcher,
-        platform=platform,
-        admission=admission,
-        volume_id=volume_id,
-        mount_path=mount_path,
-        workspace_id=workspace_id,
-        run_id=run_id,
-        call_index=call_index,
-        deadline=deadline,
-        execution_timeout_s=execution_timeout_s,
-        execution_output_cap=execution_output_cap,
-        is_authorized=is_authorized,
-        retain_pending_cleanup=retain_pending_cleanup,
-        interpreter_factory=DaytonaCodeInterpreter,
-        sandbox_backend_factory=sandbox_backend,
-        close_child_runtime=_close_child_runtime_sync,
-        cleanup_after_failed_acquire=_cleanup_after_failed_acquire,
-        sandbox_id_for_fn=_sandbox_id,
-        require_authorized_fn=_require_authorized,
-    )
-
-
 def _close_child_runtime_sync(
     *,
     loop: asyncio.AbstractEventLoop,
@@ -211,7 +170,8 @@ def _close_child_runtime_sync(
     permit: Any,
     retain_pending_cleanup: Callable[[Future[Any]], None] | None = None,
 ) -> None:
-    """Compatibility wrapper preserving runtime-patched timeout policy."""
+    """Patchable close seam: forwards to the canonical cleanup with this
+    module's result-timeout policy read at call time."""
     close_child_runtime_sync(
         loop=loop,
         platform=platform,
@@ -222,80 +182,7 @@ def _close_child_runtime_sync(
         permit=permit,
         retain_pending_cleanup=retain_pending_cleanup,
         cleanup_result_timeout_s=_CHILD_CLEANUP_RESULT_TIMEOUT_S,
-        cleanup_child_runtime=_cleanup_child_runtime_async,
-        confirm_timeout_s=_CHILD_DELETE_CONFIRM_TIMEOUT_S,
-        confirm_poll_interval_s=_CHILD_DELETE_CONFIRM_POLL_S,
     )
-
-
-async def _cleanup_after_failed_acquire(
-    platform: SandboxPlatform,
-    sandbox: Any | None,
-    sandbox_id: str | None,
-    permit: Any,
-) -> None:
-    """Compatibility wrapper for failed-acquisition cleanup."""
-    await cleanup_after_failed_acquire(platform, sandbox, sandbox_id, permit)
-
-
-async def _cleanup_child_runtime_async(
-    *,
-    platform: SandboxPlatform,
-    sandbox: Any,
-    sandbox_id: str,
-    mount_path: str,
-    permit: Any,
-    confirm: Callable[..., Any] | None = None,
-    confirm_timeout_s: float = _CHILD_DELETE_CONFIRM_TIMEOUT_S,
-    confirm_poll_interval_s: float = _CHILD_DELETE_CONFIRM_POLL_S,
-) -> None:
-    """
-    Clean up a child runtime and optionally confirm its sandbox deletion.
-
-    Parameters:
-        sandbox_id (str): Identifier of the sandbox to clean up.
-        mount_path (str): Path whose regular files are purged during cleanup.
-        permit (Any): Authorization permit for the cleanup operation.
-        confirm (Callable[..., Any] | None): Optional callback used to confirm sandbox deletion.
-        confirm_timeout_s (float): Maximum time to wait for deletion confirmation.
-        confirm_poll_interval_s (float): Interval between deletion confirmation checks.
-    """
-    kwargs: dict[str, Any] = {
-        "platform": platform,
-        "sandbox": sandbox,
-        "sandbox_id": sandbox_id,
-        "mount_path": mount_path,
-        "permit": permit,
-        "confirm_timeout_s": confirm_timeout_s,
-        "confirm_poll_interval_s": confirm_poll_interval_s,
-        "purge": _purge_regular_files,
-    }
-    if confirm is not None:
-        kwargs["confirm"] = confirm
-    await cleanup_child_runtime_async(**kwargs)
-
-
-async def _purge_regular_files(sandbox: Any, mount_path: str) -> None:
-    """Preserve the runtime-patchable regular-file purge seam."""
-    await purge_regular_files(sandbox, mount_path)
-
-
-def _sandbox_id(sandbox: Any) -> str:
-    """
-    Extracts the validated identifier from a sandbox.
-
-    Parameters:
-        sandbox (Any): Sandbox whose identifier is retrieved.
-
-    Returns:
-        str: The sandbox identifier.
-    """
-    return sandbox_id_for(sandbox)
-
-
-def _require_authorized(is_authorized: Callable[[], bool] | None) -> None:
-    """Preserve the runtime-patchable authorization seam."""
-    require_authorized(is_authorized)
 
 
 __all__ = [

--- a/src/fleet_rlm/daytona/recursive_child_runtime.py
+++ b/src/fleet_rlm/daytona/recursive_child_runtime.py
@@ -20,7 +20,6 @@ from fleet_rlm.daytona.recursive_child_cleanup import (
 )
 from fleet_rlm.daytona.recursive_child_cleanup import (
     cleanup_after_failed_acquire,
-    cleanup_child_runtime_async,
     close_child_runtime_sync,
 )
 from fleet_rlm.daytona.recursive_child_late import LateCleanupOwner
@@ -35,11 +34,9 @@ from fleet_rlm.rlm.child_runtime import (
     ChildRuntimeFactory,
 )
 
-# Patchable compat seams (tests and live proofs monkeypatch these module-level
-# names): each binds the canonical implementation, and the call sites below read
-# them from this module's namespace at call time.
+# Patchable compatibility seam: tests and live proofs monkeypatch this module-
+# level name, so the acquisition call site reads it at call time.
 _acquire_child_runtime = acquire_child_runtime
-_cleanup_child_runtime_async = cleanup_child_runtime_async
 
 
 # Absence-confirmation budget policy lives in ``recursive_child_cleanup``

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -545,10 +545,6 @@ class DaytonaRuntimeResources:
         if sandbox_id and sandbox_id not in self._sandbox_ids:
             self._sandbox_ids.append(sandbox_id)
 
-    def forget_sandboxes(self) -> None:
-        """Drop tracked sandbox ids without deleting (API-restart simulation)."""
-        self._sandbox_ids.clear()
-
     async def cleanup(self) -> None:
         """Delete tracked sandboxes (best-effort)."""
         for sid in list(self._sandbox_ids):

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -253,9 +253,9 @@ class _DaytonaEnvironmentProvider:
                 raise
             if sandbox is None:
                 raise RuntimeError("acquired Sandbox is unavailable")
-            from fleet_rlm.daytona.workspace_memory import DaytonaWorkspaceMemoryStore
+            from fleet_rlm.daytona.workspace_memory import build_workspace_memory_store
 
-            paths = volume_paths_from_settings(self.settings)
+            paths = self.resources.volume_paths
             sink = _DaytonaRunSink(
                 sandbox,
                 loop=asyncio.get_running_loop(),
@@ -263,7 +263,7 @@ class _DaytonaEnvironmentProvider:
                 paths=paths,
             )
             assert sink.volume_fs is not None
-            memory_store = DaytonaWorkspaceMemoryStore(
+            memory_store = build_workspace_memory_store(
                 sink.volume_fs.sandbox,
                 volume_paths=paths,
                 max_upload_bytes=self.settings.max_upload_bytes,
@@ -359,6 +359,11 @@ async def _prepare_memory_digest(memory_store: Any, *, request: str) -> str:
 class _LiveCapabilityPreparer:
     settings: Settings
     skill_catalog: SkillCatalog
+    volume_paths: VolumePaths | None = None
+
+    def __post_init__(self) -> None:
+        if self.volume_paths is None:
+            self.volume_paths = volume_paths_from_settings(self.settings)
 
     async def prepare(
         self,
@@ -378,7 +383,7 @@ class _LiveCapabilityPreparer:
             LivePreparedCapabilities: Prepared capabilities and any preparation notices.
         """
         from fleet_rlm.daytona.workspace_fs import DaytonaSessionWorkspaceFS
-        from fleet_rlm.daytona.workspace_memory import DaytonaWorkspaceMemoryStore
+        from fleet_rlm.daytona.workspace_memory import build_workspace_memory_store
         from fleet_rlm.files.memory_tools import WorkspaceMemoryToolHost
         from fleet_rlm.files.project_tools import ProjectToolHost
         from fleet_rlm.files.tools import FileToolHost
@@ -388,7 +393,7 @@ class _LiveCapabilityPreparer:
         sink = environment.attachment_sink
         volume_fs = cast(_DaytonaRunSink, sink).volume_fs
         assert volume_fs is not None  # _DaytonaRunSink is always constructed with loop
-        paths = volume_paths_from_settings(self.settings)
+        paths = self.volume_paths if self.volume_paths is not None else volume_paths_from_settings(self.settings)
         file_host = FileToolHost(
             attachments=attachments.refs,
             staged_attachments=attachments.staged,
@@ -436,7 +441,7 @@ class _LiveCapabilityPreparer:
         if memory_store is None:
             # Direct capability-preparation tests may provide only a minimal
             # RunEnvironment; production acquisition owns this store.
-            memory_store = DaytonaWorkspaceMemoryStore(
+            memory_store = build_workspace_memory_store(
                 volume_fs.sandbox,
                 volume_paths=paths,
                 max_upload_bytes=self.settings.max_upload_bytes,
@@ -522,6 +527,7 @@ class DaytonaRuntimeResources:
         self.platform = LiveDaytonaPlatform(self.client, self.sandbox_spec)
         self.volume_client = LiveDaytonaVolumeClient(self.client)
         self.volume_config = volume_config_from_settings(self.settings)
+        self.volume_paths = volume_paths_from_settings(self.settings)
         self.bindings = bindings
         self.daytona_admission = DaytonaAdmission(
             max_active_leases=max_active_leases,
@@ -579,5 +585,5 @@ def build_run_preparation(
         recursive_options=recursive_rlm_options(settings),
         attachments=_LiveAttachmentLifecycle(attachment_lifecycle),
         environments=_DaytonaEnvironmentProvider(resources, settings),
-        capabilities=_LiveCapabilityPreparer(settings, skill_catalog),
+        capabilities=_LiveCapabilityPreparer(settings, skill_catalog, volume_paths=resources.volume_paths),
     )

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -333,6 +333,28 @@ class _LiveAttachmentLifecycle:
         return await self.attachment_lifecycle.prepare_run(access, attachment_ids, run, sink)
 
 
+async def _prepare_memory_digest(memory_store: Any, *, request: str) -> str:
+    """Return the per-Run injection digest, degrading fail-soft with diagnostics.
+
+    User-visible behavior is unchanged: ANY preparation failure still degrades
+    to no injection. The failure is classified once into a bounded, sanitized
+    diagnostic so provider outages, corrupt stores, invariant violations, and
+    internal defects no longer look identical to operators.
+    """
+    from fleet_rlm.daytona.memory_diagnostics import record_memory_degradation
+    from fleet_rlm.daytona.workspace_memory import read_workspace_memory_injection_digest
+
+    try:
+        return await asyncio.to_thread(
+            read_workspace_memory_injection_digest,
+            memory_store,
+            request=request,
+        )
+    except Exception as exc:
+        record_memory_degradation(exc, operation="injection_digest", fallback_outcome="no_memory_injection")
+        return ""
+
+
 @dataclass(slots=True)
 class _LiveCapabilityPreparer:
     settings: Settings
@@ -356,10 +378,7 @@ class _LiveCapabilityPreparer:
             LivePreparedCapabilities: Prepared capabilities and any preparation notices.
         """
         from fleet_rlm.daytona.workspace_fs import DaytonaSessionWorkspaceFS
-        from fleet_rlm.daytona.workspace_memory import (
-            DaytonaWorkspaceMemoryStore,
-            read_workspace_memory_injection_digest,
-        )
+        from fleet_rlm.daytona.workspace_memory import DaytonaWorkspaceMemoryStore
         from fleet_rlm.files.memory_tools import WorkspaceMemoryToolHost
         from fleet_rlm.files.project_tools import ProjectToolHost
         from fleet_rlm.files.tools import FileToolHost
@@ -440,15 +459,9 @@ class _LiveCapabilityPreparer:
         # Per-Run Workspace Memory injection: relevant matches first, then the
         # newest complete records. Best-effort by contract; search/storage
         # failures degrade to no injection, and search failure degrades to
-        # the recency-only fallback.
-        try:
-            memory_digest = await asyncio.to_thread(
-                read_workspace_memory_injection_digest,
-                memory_store,
-                request=run.input.text,
-            )
-        except Exception:
-            memory_digest = ""
+        # the recency-only fallback. Every degraded operation records one
+        # bounded, sanitized diagnostic at this fail-soft seam (P31).
+        memory_digest = await _prepare_memory_digest(memory_store, request=run.input.text)
         file_tools = file_host.as_tools()
         workspace_tools = workspace_host.as_tools()
         project_tools = project_host.as_tools()

--- a/src/fleet_rlm/daytona/sandbox_lease.py
+++ b/src/fleet_rlm/daytona/sandbox_lease.py
@@ -35,6 +35,7 @@ from threading import Thread
 from typing import Any, Literal, Protocol, TypeAlias
 
 from fleet_rlm.daytona.admission import DaytonaAdmissionPermit
+from fleet_rlm.daytona.errors import sanitize_failure_text
 from fleet_rlm.daytona.lifecycle import AbsenceConfirmation, AbsenceOutcome, confirm_absence
 from fleet_rlm.daytona.provisioning import SandboxPlatform
 
@@ -58,11 +59,6 @@ LeaseKind: TypeAlias = Literal["retained_session", "recursive_child", "volume_io
 #: Bound for one blocking close result before ownership quarantines the
 #: still-running close (it keeps the permit until it settles).
 DEFAULT_CLOSE_RESULT_TIMEOUT_S = 60.0
-
-
-def _sanitize_error(exc: BaseException) -> str:
-    """Bounded, credential-free failure description for receipts."""
-    return f"{type(exc).__name__}: {str(exc)[:200]}"
 
 
 class LeaseCleanupError(RuntimeError):
@@ -241,7 +237,7 @@ class SandboxLease:
         try:
             interpreter.shutdown(strict_broker_cleanup=policy.strict_broker_cleanup)
         except BaseException as exc:
-            error = _sanitize_error(exc)
+            error = sanitize_failure_text(exc)
             # Consolidated shutdown: broker/backend share the recorded failure.
             return InterpreterCloseOutcome(
                 status="failed",
@@ -286,7 +282,7 @@ class SandboxLease:
                 else:
                     await request
             except BaseException as exc:
-                request_error = _sanitize_error(exc)
+                request_error = sanitize_failure_text(exc)
             # Confirmation runs even when the delete request itself failed:
             # the Sandbox may be absent already, or deletion may have been
             # accepted provider-side despite the client error (QRE-151
@@ -337,7 +333,7 @@ class SandboxLease:
                 requested=True,
                 confirmed_absent=False,
                 duration_s=time.monotonic() - started,
-                error=_sanitize_error(exc),
+                error=sanitize_failure_text(exc),
             )
         return ProviderCleanupOutcome(
             action="stop",
@@ -363,7 +359,7 @@ class SandboxLease:
                 await self._purge(self._sandbox)
             except BaseException as exc:
                 if first_error is None:
-                    first_error = _sanitize_error(exc)
+                    first_error = sanitize_failure_text(exc)
 
         provider = await self._provider_close()
         if provider.error is not None and first_error is None:
@@ -441,9 +437,11 @@ class SandboxLease:
                     released=self._permit is not None,
                     released_after="quarantine_failure" if self._permit is not None else "not_held",
                 ),
-                quarantine=QuarantineOutcome(quarantined=True, lane="fallback_thread", error=_sanitize_error(exc)),
+                quarantine=QuarantineOutcome(
+                    quarantined=True, lane="fallback_thread", error=sanitize_failure_text(exc)
+                ),
                 duration_s=0.0,
-                first_error=_sanitize_error(exc),
+                first_error=sanitize_failure_text(exc),
             )
             if self._permit is not None:
                 self._permit.release()

--- a/src/fleet_rlm/daytona/sandbox_lease.py
+++ b/src/fleet_rlm/daytona/sandbox_lease.py
@@ -14,10 +14,8 @@ This module concentrates those semantics behind one deep lease seam:
   :meth:`SandboxLease.aclose` (async) execution; repeated closes are
   idempotent and the close returns a typed :class:`SandboxLeaseReceipt`
   exposing interpreter/broker/provider/admission/quarantine outcomes.
-- :func:`acquire_owned_lease` implements late-acquisition ownership once:
-  provider work started before a deadline/cancellation boundary is adopted by
-  a registered owner instead of being cancelled mid-flight (cancelling would
-  strand sandboxes/permits).
+- Late-acquisition ownership (P30) is adopted by the recursive child lease
+  machinery and the runtime owned-effect queue instead of a parallel seam.
 
 The seam never broadens public error surfaces: receipts carry typed statuses
 and sanitized, credential-free error strings only.
@@ -32,7 +30,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import Future
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from threading import Thread
 from typing import Any, Literal, Protocol, TypeAlias
 
@@ -53,7 +51,6 @@ __all__ = [
     "SandboxLease",
     "SandboxLeasePolicy",
     "SandboxLeaseReceipt",
-    "acquire_owned_lease",
 ]
 
 LeaseKind: TypeAlias = Literal["retained_session", "recursive_child", "volume_io", "recovery_fence"]
@@ -453,45 +450,6 @@ class SandboxLease:
         return self._receipt
 
 
-def _sandbox_id_or_none(sandbox: Any) -> str | None:
-    value = getattr(sandbox, "id", None)
-    return value if isinstance(value, str) and value else None
-
-
-@dataclass
-class OwnedAcquisition:
-    """Late-acquisition ownership: adopted provider work always gets closed.
-
-    Wraps a started coroutine (posted future): the owner registers a close
-    hook once; whoever resolves the future last (normal return or late
-    settle) runs the close. Cancelling provider work mid-flight is forbidden:
-    it would strand Sandboxes and admission permits.
-    """
-
-    loop: asyncio.AbstractEventLoop
-    close_lease: Callable[[Any], Awaitable[Any]]
-    owned_futures: list[Future[Any]] = field(default_factory=list)
-
-    def adopt(self, coroutine: Coroutine[Any, Any, Any]) -> Future[Any]:
-        """Adopt started provider work; its result is owned and closed."""
-        future = asyncio.run_coroutine_threadsafe(coroutine, self.loop)
-        self.owned_futures.append(future)
-        return future
-
-    def settle_adopted(self, future: Future[Any]) -> SandboxLeaseReceipt | None:
-        """Close the lease embodied in one adopted future result, if any."""
-        try:
-            lease = future.result(timeout=DEFAULT_CLOSE_RESULT_TIMEOUT_S)
-        except BaseException:
-            return None
-        if isinstance(lease, SandboxLease):
-            return lease.close()
-        close = getattr(lease, "close", None)
-        if callable(close):
-            close()
-        return None
-
-
 @dataclass(slots=True)
 class OwnedCloseExecution:
     """One scheduled owned async close, with its disposable-loop fallback record.
@@ -559,15 +517,6 @@ def schedule_owned_close(
     return OwnedCloseExecution(future=fallback, used_fallback=True, coroutine=None)
 
 
-def acquire_owned_lease(
-    *,
-    loop: asyncio.AbstractEventLoop,
-    acquire: Callable[[], Coroutine[Any, Any, SandboxLease]],
-) -> Future[SandboxLease]:
-    """Post lease acquisition to the owner loop; caller owns the future.
-
-    The acquisition coroutine itself is responsible for adopting late
-    completion (see :class:`OwnedAcquisition`); this seam only standardizes
-    the thread-safe posting + ownership typing.
-    """
-    return asyncio.run_coroutine_threadsafe(acquire(), loop)
+def _sandbox_id_or_none(sandbox: Any) -> str | None:
+    value = getattr(sandbox, "id", None)
+    return value if isinstance(value, str) and value else None

--- a/src/fleet_rlm/daytona/session_manager.py
+++ b/src/fleet_rlm/daytona/session_manager.py
@@ -110,7 +110,6 @@ class InterpreterLease:
     session_id: str | None = None
     run_id: str | None = None
     volume_subpath: str | None = None
-    delete_sandbox: Callable[[str], None] | None = None
     created_sandbox: bool = False
     _released: bool = field(default=False, init=False, repr=False)
     _on_release: Callable[[], None] | None = field(default=None, init=False, repr=False)
@@ -617,7 +616,6 @@ class DaytonaSessionManager:
             interpreter=interpreter,
             session_id=str(session_id),
             run_id=str(run_id),
-            delete_sandbox=None,
             created_sandbox=created_sandbox,
         )
 

--- a/src/fleet_rlm/daytona/session_manager.py
+++ b/src/fleet_rlm/daytona/session_manager.py
@@ -10,7 +10,7 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from threading import Lock
 from typing import Any, Protocol
@@ -47,12 +47,14 @@ from fleet_rlm.daytona.provisioning import (
     VolumeClient,
     VolumeConfig,
     get_or_create_volume_id,
+)
+from fleet_rlm.daytona.sandbox_lease import SandboxLease, SandboxLeasePolicy, SandboxLeaseReceipt
+from fleet_rlm.runtime.bindings import (
+    SandboxBinding,
     require_non_zero_workspace_id,
     require_scoped_volume_subpath,
     workspace_volume_subpath,
 )
-from fleet_rlm.daytona.sandbox_lease import SandboxLease, SandboxLeasePolicy, SandboxLeaseReceipt
-from fleet_rlm.runtime.bindings import SandboxBinding
 from fleet_rlm.runtime.owned_effect import OwnedEffect
 
 logger = logging.getLogger(__name__)
@@ -383,18 +385,7 @@ class DaytonaSessionManager:
 
     async def _fence_binding(self, binding: SandboxBinding) -> None:
         """Persist fencing around one awaited provider stop."""
-        await self._bindings.upsert(
-            SandboxBinding(
-                session_id=binding.session_id,
-                sandbox_id=binding.sandbox_id,
-                workspace_id=binding.workspace_id,
-                volume_id=binding.volume_id,
-                volume_subpath=binding.volume_subpath,
-                mount_path=binding.mount_path,
-                provider_state="fencing",
-                last_verified_at=datetime.now(UTC),
-            )
-        )
+        await self._bindings.upsert(replace(binding, provider_state="fencing", last_verified_at=datetime.now(UTC)))
         if binding.sandbox_id is None:
             return
         # Lease-backed (QRE-156/AC4): recovery fencing rides the shared
@@ -422,18 +413,7 @@ class DaytonaSessionManager:
             _fenced_stop(),
             timeout=60,
         )
-        await self._bindings.upsert(
-            SandboxBinding(
-                session_id=binding.session_id,
-                sandbox_id=binding.sandbox_id,
-                workspace_id=binding.workspace_id,
-                volume_id=binding.volume_id,
-                volume_subpath=binding.volume_subpath,
-                mount_path=binding.mount_path,
-                provider_state="quarantined",
-                last_verified_at=datetime.now(UTC),
-            )
-        )
+        await self._bindings.upsert(replace(binding, provider_state="quarantined", last_verified_at=datetime.now(UTC)))
 
     @staticmethod
     def _bind_lease_ownership(
@@ -518,16 +498,11 @@ class DaytonaSessionManager:
         except DaytonaAdapterError as exc:
             if exc.cause_type not in {"SandboxUnrecoverable", "SandboxSnapshotMismatch"}:
                 raise
+            # binding_matches_expected above proved identity/mount fields match
+            # this request's scope; mark the bound record unrecoverable with a
+            # reset verification timestamp.
             replacement = await self.replace(
-                SandboxBinding(
-                    session_id=request.session_id,
-                    sandbox_id=binding.sandbox_id,
-                    workspace_id=request.workspace_id,
-                    volume_id=context.expected.volume_id,
-                    volume_subpath=context.expected.volume_subpath,
-                    mount_path=context.expected.mount_path,
-                    provider_state="unrecoverable",
-                ),
+                replace(binding, provider_state="unrecoverable", last_verified_at=None),
                 workspace_id=request.workspace_id,
                 user_id=request.user_id,
             )
@@ -669,18 +644,7 @@ class DaytonaSessionManager:
         if sandbox is None:
             return
         await self._platform.stop(sandbox_id)
-        await self._bindings.upsert(
-            SandboxBinding(
-                session_id=binding.session_id,
-                sandbox_id=binding.sandbox_id,
-                workspace_id=binding.workspace_id,
-                volume_id=binding.volume_id,
-                volume_subpath=binding.volume_subpath,
-                mount_path=binding.mount_path,
-                provider_state="stopped",
-                last_verified_at=datetime.now(UTC),
-            )
-        )
+        await self._bindings.upsert(replace(binding, provider_state="stopped", last_verified_at=datetime.now(UTC)))
 
     async def aclose(self) -> None:
         """Cancel process-local idle policy tasks during composition shutdown."""

--- a/src/fleet_rlm/daytona/workspace_agent.py
+++ b/src/fleet_rlm/daytona/workspace_agent.py
@@ -305,6 +305,66 @@ class _WorkspaceAgentSession:
         self.metrics.latency_ms_total += (time.monotonic() - started) * 1000.0
         return response
 
+    def _handshake_code(self) -> str:
+        """Build the handshake request and count the attempt."""
+        code = build_workspace_agent_request_code({"operation": "__handshake__", "relative": ""})
+        self.metrics.handshake_calls += 1
+        return code
+
+    def _operation_code(self, arguments: dict[str, object]) -> str:
+        """Build an operation request and count the call."""
+        code = build_workspace_agent_request_code(arguments)
+        self.metrics.operation_calls += 1
+        return code
+
+    def _install_source(self) -> bytes:
+        """Return the installable runtime source bytes."""
+        return build_installed_workspace_agent_source().encode("utf-8")
+
+    def _count_install(self, installed: bytes) -> None:
+        """Count one completed install transfer."""
+        self.metrics.source_transfer_bytes += len(installed)
+        self.metrics.bootstrap_count += 1
+
+    def _finish_ensure(self, payload: dict[str, object] | None) -> None:
+        if not self._valid_handshake(payload):
+            raise WorkspaceAgentProtocolError("Workspace Agent protocol handshake failed")
+        self.verified = True
+
+    @staticmethod
+    def _relative(arguments: dict[str, object]) -> str:
+        return str(arguments.get("relative") or "")
+
+    async def _handshake_async(self, sandbox: Any, timeout_s: float) -> dict[str, object] | None:
+        try:
+            return self._json_response(await self._raw_async(sandbox, self._handshake_code(), timeout_s))
+        except Exception:
+            return None
+
+    def _handshake_sync(self, sandbox: Any, timeout_s: float) -> dict[str, object] | None:
+        try:
+            return self._json_response(self._raw_sync(sandbox, self._handshake_code(), timeout_s))
+        except Exception:
+            return None
+
+    async def _ensure_async(self, sandbox: Any, timeout_s: float) -> None:
+        payload = await self._handshake_async(sandbox, timeout_s)
+        if not self._valid_handshake(payload):
+            installed = self._install_source()
+            await sandbox.fs.upload_file(installed, WORKSPACE_AGENT_INSTALL_PATH)
+            self._count_install(installed)
+            payload = await self._handshake_async(sandbox, timeout_s)
+        self._finish_ensure(payload)
+
+    def _ensure_sync(self, sandbox: Any, timeout_s: float) -> None:
+        payload = self._handshake_sync(sandbox, timeout_s)
+        if not self._valid_handshake(payload):
+            installed = self._install_source()
+            sandbox.fs.upload_file(installed, WORKSPACE_AGENT_INSTALL_PATH)
+            self._count_install(installed)
+            payload = self._handshake_sync(sandbox, timeout_s)
+        self._finish_ensure(payload)
+
     async def ensure_async(self, sandbox: Any, timeout_s: float) -> None:
         if self.verified:
             return
@@ -313,25 +373,7 @@ class _WorkspaceAgentSession:
         async with self._async_lock:
             if self.verified:
                 return
-            handshake = build_workspace_agent_request_code({"operation": "__handshake__", "relative": ""})
-            self.metrics.handshake_calls += 1
-            try:
-                payload = self._json_response(await self._raw_async(sandbox, handshake, timeout_s))
-            except Exception:
-                payload = None
-            if not self._valid_handshake(payload):
-                installed = build_installed_workspace_agent_source().encode("utf-8")
-                await sandbox.fs.upload_file(installed, WORKSPACE_AGENT_INSTALL_PATH)
-                self.metrics.source_transfer_bytes += len(installed)
-                self.metrics.bootstrap_count += 1
-                self.metrics.handshake_calls += 1
-                try:
-                    payload = self._json_response(await self._raw_async(sandbox, handshake, timeout_s))
-                except Exception:
-                    payload = None
-            if not self._valid_handshake(payload):
-                raise WorkspaceAgentProtocolError("Workspace Agent protocol handshake failed")
-            self.verified = True
+            await self._ensure_async(sandbox, timeout_s)
 
     def ensure_sync(self, sandbox: Any, timeout_s: float) -> None:
         if self.verified:
@@ -339,43 +381,17 @@ class _WorkspaceAgentSession:
         with self._sync_lock:
             if self.verified:
                 return
-            handshake = build_workspace_agent_request_code({"operation": "__handshake__", "relative": ""})
-            self.metrics.handshake_calls += 1
-            try:
-                payload = self._json_response(self._raw_sync(sandbox, handshake, timeout_s))
-            except Exception:
-                payload = None
-            if not self._valid_handshake(payload):
-                installed = build_installed_workspace_agent_source().encode("utf-8")
-                sandbox.fs.upload_file(installed, WORKSPACE_AGENT_INSTALL_PATH)
-                self.metrics.source_transfer_bytes += len(installed)
-                self.metrics.bootstrap_count += 1
-                self.metrics.handshake_calls += 1
-                try:
-                    payload = self._json_response(self._raw_sync(sandbox, handshake, timeout_s))
-                except Exception:
-                    payload = None
-            if not self._valid_handshake(payload):
-                raise WorkspaceAgentProtocolError("Workspace Agent protocol handshake failed")
-            self.verified = True
+            self._ensure_sync(sandbox, timeout_s)
 
     async def request_async(self, sandbox: Any, arguments: dict[str, object], timeout_s: float) -> dict[str, object]:
         await self.ensure_async(sandbox, timeout_s)
-        code = build_workspace_agent_request_code(arguments)
-        self.metrics.operation_calls += 1
-        return decode_workspace_agent_response(
-            await self._raw_async(sandbox, code, timeout_s),
-            str(arguments.get("relative") or ""),
-        )
+        response = await self._raw_async(sandbox, self._operation_code(arguments), timeout_s)
+        return decode_workspace_agent_response(response, self._relative(arguments))
 
     def request_sync(self, sandbox: Any, arguments: dict[str, object], timeout_s: float) -> dict[str, object]:
         self.ensure_sync(sandbox, timeout_s)
-        code = build_workspace_agent_request_code(arguments)
-        self.metrics.operation_calls += 1
-        return decode_workspace_agent_response(
-            self._raw_sync(sandbox, code, timeout_s),
-            str(arguments.get("relative") or ""),
-        )
+        response = self._raw_sync(sandbox, self._operation_code(arguments), timeout_s)
+        return decode_workspace_agent_response(response, self._relative(arguments))
 
 
 _AGENT_SESSIONS: dict[object, _WorkspaceAgentSession] = {}

--- a/src/fleet_rlm/daytona/workspace_fs.py
+++ b/src/fleet_rlm/daytona/workspace_fs.py
@@ -755,12 +755,6 @@ class AsyncDaytonaSessionWorkspaceFS:
             eof,
         )
 
-    async def read_text(self, path: str, *, max_bytes: int) -> str:
-        page = await self.read_text_page(path, cursor=None, max_chars=max_bytes, max_bytes=max_bytes)
-        if not page.eof:
-            raise ValueError("workspace file exceeds read bound")
-        return page.content
-
     async def write_text(
         self,
         path: str,
@@ -939,10 +933,6 @@ class DaytonaSessionWorkspaceFS:
         max_bytes: int,
     ) -> WorkspaceTextPage:
         return _run_blocking(self._core.read_text_page(path, cursor=cursor, max_chars=max_chars, max_bytes=max_bytes))
-
-    def read_text(self, path: str, *, max_bytes: int) -> str:
-        """Compatibility adapter for internal callers that need a bounded whole read."""
-        return _run_blocking(self._core.read_text(path, max_bytes=max_bytes))
 
     def write_text(
         self,

--- a/src/fleet_rlm/daytona/workspace_memory.py
+++ b/src/fleet_rlm/daytona/workspace_memory.py
@@ -215,6 +215,21 @@ def read_workspace_memory_injection_digest(
     return _relevant_recent_workspace_memory_digest(store, request=request)
 
 
+def build_workspace_memory_store(
+    sandbox_view: Any,
+    *,
+    volume_paths: VolumePaths,
+    max_upload_bytes: int,
+) -> DaytonaWorkspaceMemoryStore:
+    """Assemble the canonical Workspace Memory store over one sync sandbox view.
+
+    Single construction seam used by Run acquisition/capability preparation and
+    the memory-outbox reconciler so the (sync view + VolumePaths + upload cap)
+    assembly stays identical at every call site.
+    """
+    return DaytonaWorkspaceMemoryStore(sandbox_view, volume_paths=volume_paths, max_upload_bytes=max_upload_bytes)
+
+
 class DaytonaWorkspaceMemoryStore:
     """Use the mounted Workspace Volume's canonical ``memory/MEMORIES.md`` file only."""
 

--- a/src/fleet_rlm/daytona/workspace_memory.py
+++ b/src/fleet_rlm/daytona/workspace_memory.py
@@ -18,6 +18,12 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any
 
+from fleet_rlm.daytona.memory_diagnostics import (
+    MemoryInvariantError,
+    MemoryMigrationError,
+    MemoryPayloadError,
+    record_memory_degradation,
+)
 from fleet_rlm.daytona.workspace_agent import WorkspaceAgentStorageError, run_workspace_agent
 from fleet_rlm.files.memory_models import (
     WORKSPACE_MEMORY_BYTE_BUDGET,
@@ -127,7 +133,9 @@ def _injection_query(request: str) -> str:
         from fleet_rlm.files.memory_tools import normalize_memory_search_query
 
         return normalize_memory_search_query(bounded)
-    except Exception:
+    except Exception as exc:
+        # Preparation stays fail-soft; the degradation is now diagnosable.
+        record_memory_degradation(exc, operation="normalize_query", fallback_outcome="recency_only_digest")
         return ""
 
 
@@ -162,7 +170,10 @@ def _relevant_recent_workspace_memory_digest(store: DaytonaWorkspaceMemoryStore,
         from fleet_rlm.files.memory_tools import search_workspace_memory_entries
 
         scored, _warnings = search_workspace_memory_entries(store, normalized_query=query)
-    except Exception:
+    except Exception as exc:
+        # Expected provider/storage degradation or a search defect: classify it
+        # without losing the fail-soft recency-only contract.
+        record_memory_degradation(exc, operation="relevance_search", fallback_outcome="recency_only_digest")
         return fallback
     if not scored:
         return fallback
@@ -316,14 +327,14 @@ class DaytonaWorkspaceMemoryStore:
                 except WorkspaceMemoryRecordError:
                     continue
         if len(set(shape_ids)) != len(shape_ids):
-            raise WorkspaceMemoryStoreUnavailableError()
+            raise MemoryInvariantError()
         entries = [line.entry for line in lines if line.entry is not None]
         warnings = count_workspace_memory_warnings(lines)
         if len({entry.memory_id for entry in entries}) != len(entries):
             # A cursor must name one physical row. Human edits can still forge
             # duplicate ids, so fail closed rather than skip or target an
             # arbitrary row while paging or mutating.
-            raise WorkspaceMemoryStoreUnavailableError()
+            raise MemoryInvariantError()
         if after is not None:
             matches = [index for index, entry in enumerate(entries) if entry.memory_id == after]
             if not matches:
@@ -457,14 +468,17 @@ class DaytonaWorkspaceMemoryStore:
             or legacy_entry.get("kind") != "file"
             or legacy_entry.get("is_regular_file") is False
         ):
-            raise WorkspaceMemoryStoreUnavailableError()
-        self._run(
-            root=self._volume_root,
-            operation="memory_migrate",
-            relative=_MEMORY_NAME,
-            max_bytes=self._max_file_bytes,
-            total_file_bytes=self._max_file_bytes,
-        )
+            raise MemoryMigrationError()
+        try:
+            self._run(
+                root=self._volume_root,
+                operation="memory_migrate",
+                relative=_MEMORY_NAME,
+                max_bytes=self._max_file_bytes,
+                total_file_bytes=self._max_file_bytes,
+            )
+        except Exception as exc:
+            raise MemoryMigrationError() from exc
 
     def _read_full_content(self) -> str:
         """Read the entire store body (bounded by the file cap), untransformed."""
@@ -513,7 +527,7 @@ class DaytonaWorkspaceMemoryStore:
             or type(total_bytes) is not int
             or type(bytes_returned) is not int
         ):
-            raise ValueError("invalid memory response")
+            raise MemoryPayloadError("invalid memory response")
         if (
             bytes_returned < 0
             or bytes_returned > byte_budget
@@ -521,7 +535,7 @@ class DaytonaWorkspaceMemoryStore:
             or total_bytes > self._max_file_bytes
             or bytes_returned != len(content.encode("utf-8"))
         ):
-            raise ValueError("invalid memory response")
+            raise MemoryPayloadError("invalid memory response")
         return content, truncated, total_bytes, bytes_returned
 
     def _run(

--- a/src/fleet_rlm/files/host_volume.py
+++ b/src/fleet_rlm/files/host_volume.py
@@ -127,51 +127,6 @@ class _HostWorkspaceVolumeSession:
         )
 
 
-class HostWorkspaceVolumeGateway:
-    """One isolated host-backed Volume root per Workspace."""
-
-    def __init__(self, root: Path | str, *, volume_paths: VolumePaths) -> None:
-        self._root = Path(root)
-        self._paths = volume_paths
-
-    def _mirror(self, workspace_id: UUID) -> HostVolumeMirror:
-        return HostVolumeMirror(
-            self._root / "workspaces" / str(workspace_id),
-            volume_paths=self._paths,
-        )
-
-    @asynccontextmanager
-    async def open_workspace(self, workspace_id: UUID) -> AsyncIterator[WorkspaceVolumeSession]:
-        yield _HostWorkspaceVolumeSession(self._mirror(workspace_id))
-
-    async def write_bytes(self, workspace_id: UUID, logical_path: str, data: bytes) -> None:
-        async with self.open_workspace(workspace_id) as volume:
-            await volume.write_bytes(logical_path, data)
-
-    async def read_bytes(self, workspace_id: UUID, logical_path: str) -> bytes:
-        async with self.open_workspace(workspace_id) as volume:
-            return await volume.read_bytes(logical_path)
-
-    async def remove_bytes(self, workspace_id: UUID, logical_path: str) -> None:
-        async with self.open_workspace(workspace_id) as volume:
-            await volume.remove_bytes(logical_path)
-
-    async def list_files(
-        self,
-        workspace_id: UUID,
-        logical_root: str,
-        *,
-        max_depth: int,
-        max_files: int,
-    ) -> tuple[VolumeFile, ...]:
-        async with self.open_workspace(workspace_id) as volume:
-            return await volume.list_files(
-                logical_root,
-                max_depth=max_depth,
-                max_files=max_files,
-            )
-
-
 class OfflineHostVolumeGateway:
     """Adapt one shared local mirror to the async durable-store port."""
 
@@ -213,6 +168,5 @@ class OfflineHostVolumeGateway:
 
 __all__ = [
     "HostVolumeMirror",
-    "HostWorkspaceVolumeGateway",
     "OfflineHostVolumeGateway",
 ]

--- a/src/fleet_rlm/files/memory_candidates.py
+++ b/src/fleet_rlm/files/memory_candidates.py
@@ -117,6 +117,61 @@ class MemoryPromotionIntent:
     source: str = WORKSPACE_MEMORY_CANDIDATE_SOURCE
 
 
+@dataclass(frozen=True, slots=True)
+class _ValidatedPromotionCandidate:
+    """One candidate after shared shape validation for both promotion paths."""
+
+    category: str
+    learning: str
+    byte_size: int
+    supersedes_id: str | None
+
+
+def _validate_promotion_candidate(candidate: MemoryCandidate) -> _ValidatedPromotionCandidate:
+    """Validate one candidate's shape, raising the WorkspaceMemory*Error taxonomy.
+
+    The intent builder propagates the raise; post-commit promotion catches it and
+    drops the candidate as ``invalid_entry``.
+    """
+    normalized = normalize_memory_candidate_categories((candidate.category,))[0]
+    learning = normalize_workspace_memory_learning(candidate.learning)
+    supersedes_id = None if candidate.supersedes_id is None else normalize_workspace_memory_id(candidate.supersedes_id)
+    byte_size = len(learning.encode("utf-8"))
+    if byte_size > WORKSPACE_MEMORY_CANDIDATE_MAX_LEARNING_BYTES or byte_size != candidate.byte_size:
+        raise WorkspaceMemoryRecordError
+    if candidate.source != WORKSPACE_MEMORY_CANDIDATE_SOURCE:
+        raise WorkspaceMemoryRecordError
+    return _ValidatedPromotionCandidate(normalized, learning, byte_size, supersedes_id)
+
+
+def _mint_candidate_record(
+    learning: str,
+    category: str,
+    *,
+    promoted_at: datetime,
+    supersedes_id: str | None,
+) -> tuple[str, str]:
+    """Mint ``(memory_id, canonical v3 record)`` for one promotion timestamp.
+
+    Shared by crash-recoverable intent pinning and the post-commit fast path so
+    replay identity and the wired record text cannot drift between them.
+    """
+    if promoted_at.tzinfo is None:
+        promoted_at = promoted_at.replace(tzinfo=UTC)
+    timestamp = promoted_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    memory_id = workspace_memory_record_id(timestamp, category, learning)
+    record_text = format_workspace_memory_v3_record(
+        learning,
+        category,
+        memory_id=memory_id,
+        created_at=timestamp,
+        updated_at=timestamp,
+        source=WORKSPACE_MEMORY_CANDIDATE_SOURCE,
+        supersedes_id=supersedes_id,
+    )
+    return memory_id, record_text
+
+
 def build_memory_promotion_intents(
     *,
     run_id: UUID,  # identity anchor: intents are (run_id, candidate_id)-scoped rows
@@ -140,9 +195,6 @@ def build_memory_promotion_intents(
         raise WorkspaceMemoryCategoryError("no autonomous Memory categories allowed")
     now = clock or (lambda: datetime.now(UTC))
     pinned_at = now()
-    if pinned_at.tzinfo is None:
-        pinned_at = pinned_at.replace(tzinfo=UTC)
-    timestamp = pinned_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     intents: list[MemoryPromotionIntent] = []
     if run_id is None:
         raise WorkspaceMemoryRecordError("run_id is required for intent scoping")
@@ -152,40 +204,28 @@ def build_memory_promotion_intents(
         normalized = normalize_memory_candidate_categories((candidate.category,))[0]
         if normalized not in allowed:
             raise WorkspaceMemoryCategoryError("candidate category is not allowed")
-        learning = normalize_workspace_memory_learning(candidate.learning)
-        byte_size = len(learning.encode("utf-8"))
-        if byte_size > WORKSPACE_MEMORY_CANDIDATE_MAX_LEARNING_BYTES or byte_size != candidate.byte_size:
-            raise WorkspaceMemoryRecordError("candidate byte size is invalid")
-        if candidate.source != WORKSPACE_MEMORY_CANDIDATE_SOURCE:
-            raise WorkspaceMemoryRecordError("candidate source is invalid")
-        supersedes_id = (
-            None if candidate.supersedes_id is None else normalize_workspace_memory_id(candidate.supersedes_id)
-        )
-        claim = (normalized, learning)
+        validated = _validate_promotion_candidate(candidate)
+        claim = (validated.category, validated.learning)
         if claim in claims:
             raise WorkspaceMemoryRecordError("duplicate candidate in batch")
         claims.add(claim)
-        total_bytes += byte_size
+        total_bytes += validated.byte_size
         if total_bytes > WORKSPACE_MEMORY_CANDIDATE_MAX_TOTAL_BYTES:
             raise WorkspaceMemoryRecordError("candidate batch exceeds its aggregate bound")
-        memory_id = workspace_memory_record_id(timestamp, normalized, learning)
-        record_text = format_workspace_memory_v3_record(
-            learning,
-            normalized,
-            memory_id=memory_id,
-            created_at=timestamp,
-            updated_at=timestamp,
-            source=WORKSPACE_MEMORY_CANDIDATE_SOURCE,
-            supersedes_id=supersedes_id,
+        memory_id, record_text = _mint_candidate_record(
+            validated.learning,
+            validated.category,
+            promoted_at=pinned_at,
+            supersedes_id=validated.supersedes_id,
         )
         intents.append(
             MemoryPromotionIntent(
                 candidate_id=candidate.candidate_id,
                 candidate_ordinal=ordinal,
-                category=normalized,
-                learning=learning,
-                byte_size=byte_size,
-                supersedes_id=supersedes_id,
+                category=validated.category,
+                learning=validated.learning,
+                byte_size=validated.byte_size,
+                supersedes_id=validated.supersedes_id,
                 memory_id=memory_id,
                 record_text=record_text,
             )
@@ -232,33 +272,22 @@ def promote_memory_candidates(
     batch_claims: set[tuple[str, str]] = set()
     for candidate in candidates:
         try:
-            normalized = normalize_memory_candidate_categories((candidate.category,))[0]
-            learning = normalize_workspace_memory_learning(candidate.learning)
-            supersedes_id = (
-                None if candidate.supersedes_id is None else normalize_workspace_memory_id(candidate.supersedes_id)
-            )
-            byte_size = len(learning.encode("utf-8"))
-            if byte_size > WORKSPACE_MEMORY_CANDIDATE_MAX_LEARNING_BYTES:
-                raise WorkspaceMemoryRecordError
-            if byte_size != candidate.byte_size:
-                raise WorkspaceMemoryRecordError
-            if candidate.source != WORKSPACE_MEMORY_CANDIDATE_SOURCE:
-                raise WorkspaceMemoryRecordError
+            validated = _validate_promotion_candidate(candidate)
         except (WorkspaceMemoryCategoryError, WorkspaceMemoryIdError, WorkspaceMemoryRecordError):
             dropped_count += 1
             reasons.append("invalid_entry")
             continue
-        if normalized not in allowed:
+        if validated.category not in allowed:
             dropped_count += 1
             reasons.append("policy_denied")
             continue
-        candidate_bytes += byte_size
-        batch_claim = (normalized, learning)
+        candidate_bytes += validated.byte_size
+        batch_claim = (validated.category, validated.learning)
         if batch_claim in batch_claims:
             duplicate_count += 1
             continue
         batch_claims.add(batch_claim)
-        prepared.append((normalized, learning, supersedes_id))
+        prepared.append((validated.category, validated.learning, validated.supersedes_id))
 
     if prepared:
         try:
@@ -286,17 +315,10 @@ def promote_memory_candidates(
             reasons.append("supersedes_not_active")
             continue
         try:
-            promoted_at = now()
-            if promoted_at.tzinfo is None:
-                promoted_at = promoted_at.replace(tzinfo=UTC)
-            timestamp = promoted_at.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-            record = format_workspace_memory_v3_record(
+            memory_id, record = _mint_candidate_record(
                 learning,
                 normalized,
-                memory_id=workspace_memory_record_id(timestamp, normalized, learning),
-                created_at=timestamp,
-                updated_at=timestamp,
-                source=WORKSPACE_MEMORY_CANDIDATE_SOURCE,
+                promoted_at=now(),
                 supersedes_id=supersedes_id,
             )
         except (WorkspaceMemoryRecordError, UnicodeError, ValueError, OverflowError):
@@ -320,7 +342,7 @@ def promote_memory_candidates(
             continue
         promoted_count += 1
         active_content.add((normalized, learning))
-        active_ids.add(workspace_memory_record_id(timestamp, normalized, learning))
+        active_ids.add(memory_id)
     return MemoryCandidatePromotionResult(
         proposed_count=proposed_count,
         promoted_count=promoted_count,

--- a/src/fleet_rlm/files/memory_models.py
+++ b/src/fleet_rlm/files/memory_models.py
@@ -26,9 +26,8 @@ synthesized id and original timestamp.
 
 Humans edit this file, so reads are *tolerant*: malformed lines are skipped
 with a bounded warning count instead of poisoning the whole read. Writes stay
-strict: :func:`validate_workspace_memory_record` and
-:func:`validate_workspace_memory_content` reject anything outside the v1/v2/v3
-shapes plus optional header.
+strict: :func:`validate_workspace_memory_record` rejects anything outside the
+v1/v2/v3 shapes.
 """
 
 from __future__ import annotations
@@ -156,7 +155,7 @@ def format_workspace_memory_record(
     *,
     timestamp: datetime,
 ) -> tuple[str, str]:
-    """Normalize and format one canonical v2 Workspace Memory record."""
+    """Normalize and format one fresh canonical v3 ``user_explicit`` record."""
     learning = normalize_workspace_memory_learning(key_learning)
     normalized_category = normalize_workspace_memory_category(category)
     if not isinstance(timestamp, datetime):
@@ -166,49 +165,6 @@ def format_workspace_memory_record(
     record = (
         f"- [{timestamp_text}] **{normalized_category}** <!-- id:{memory_id} source:user_explicit "
         f"updated:{timestamp_text} -->: {learning}\n"
-    )
-    validate_workspace_memory_record(record)
-    return record, normalized_category
-
-
-_TIMESTAMP_TEXT = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
-
-
-def reformat_workspace_memory_record(
-    *,
-    timestamp: str,
-    memory_id: str,
-    category: str,
-    key_learning: str,
-    source: WorkspaceMemorySource = "legacy_unknown",
-    updated_at: str | None = None,
-    supersedes_id: str | None = None,
-) -> tuple[str, str]:
-    """Rebuild one canonical v3 record preserving identity and provenance.
-
-    The creation timestamp and effective id are preserved verbatim. Legacy v1
-    and v2 rows upgrade in place to v3 with ``legacy_unknown`` provenance;
-    provenance and supersession metadata are carried forward rather than
-    silently re-identifying the memory.
-    """
-    if not isinstance(timestamp, str) or _TIMESTAMP_TEXT.fullmatch(timestamp) is None:
-        raise WorkspaceMemoryRecordError
-    try:
-        datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
-        update_text = updated_at or timestamp
-        datetime.strptime(update_text, "%Y-%m-%dT%H:%M:%SZ")
-    except ValueError as exc:
-        raise WorkspaceMemoryRecordError from exc
-    learning = normalize_workspace_memory_learning(key_learning)
-    normalized_category = normalize_workspace_memory_category(category)
-    normalize_workspace_memory_id(memory_id)
-    normalize_workspace_memory_source(source)
-    if supersedes_id is not None:
-        normalize_workspace_memory_id(supersedes_id)
-    supersession = f" supersedes:{supersedes_id}" if supersedes_id is not None else ""
-    record = (
-        f"- [{timestamp}] **{normalized_category}** <!-- id:{memory_id} source:{source} "
-        f"updated:{update_text}{supersession} -->: {learning}\n"
     )
     validate_workspace_memory_record(record)
     return record, normalized_category
@@ -251,23 +207,6 @@ def validate_workspace_memory_record(record: str) -> None:
                 normalize_workspace_memory_id(supersedes_id)
             except WorkspaceMemoryIdError as exc:
                 raise WorkspaceMemoryRecordError from exc
-
-
-def validate_workspace_memory_content(content: str) -> None:
-    """Strictly validate a whole memory file body for writes.
-
-    Accepts zero or more complete v1/v2/v3 records with at most one leading
-    :data:`WORKSPACE_MEMORY_HEADER` line; rejects blank and malformed lines.
-    """
-    if not isinstance(content, str):
-        raise WorkspaceMemoryRecordError
-    lines = content.splitlines(keepends=True)
-    if lines and lines[0] == _HEADER_LINE:
-        lines = lines[1:]
-    for record in lines:
-        validate_workspace_memory_record(record)
-    if any(line.malformed for line in parse_workspace_memory_lines(content)):
-        raise WorkspaceMemoryRecordError
 
 
 def format_workspace_memory_v3_record(
@@ -454,27 +393,6 @@ def parse_workspace_memory_lines(
 def count_workspace_memory_warnings(lines: tuple[WorkspaceMemoryParsedLine, ...]) -> int:
     """Bounded count of malformed lines skipped by one tolerant read."""
     return min(sum(1 for line in lines if line.malformed), WORKSPACE_MEMORY_MAX_WARNINGS)
-
-
-def build_workspace_memory_digest(content: str) -> tuple[str, int]:
-    """Project memory content into a bounded turn-injection digest.
-
-    Returns ``(digest, warnings)``: the digest keeps complete v1/v2/v3 record lines
-    only (header, blanks, and malformed lines dropped), bounded to at most
-    :data:`WORKSPACE_MEMORY_INJECTION_TAIL_BYTES` UTF-8 bytes taken from the
-    tail on whole-record boundaries; ``warnings`` is the bounded malformed-line
-    count.
-    """
-    lines = parse_workspace_memory_lines(content)
-    warnings = count_workspace_memory_warnings(lines)
-    body = "".join(line.raw for line in lines if line.entry is not None)
-    encoded = body.encode("utf-8")
-    if len(encoded) > WORKSPACE_MEMORY_INJECTION_TAIL_BYTES:
-        encoded = encoded[-WORKSPACE_MEMORY_INJECTION_TAIL_BYTES:]
-        if not encoded.startswith(b"- ["):
-            boundary = encoded.find(b"\n")
-            encoded = b"" if boundary < 0 else encoded[boundary + 1 :]
-    return encoded.decode("utf-8"), warnings
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/fleet_rlm/files/project_tools.py
+++ b/src/fleet_rlm/files/project_tools.py
@@ -18,7 +18,7 @@ import dspy
 
 from fleet_rlm.files.volume_paths import UnsafePathError, validate_project_slug
 from fleet_rlm.files.workspace_models import SessionWorkspaceFS, WorkspaceEntry
-from fleet_rlm.files.workspace_tools import MAX_WORKSPACE_READ_CHARS, WorkspaceToolError
+from fleet_rlm.files.workspace_tools import MAX_WORKSPACE_READ_CHARS, WorkspaceToolError, _translate_fs_tool_errors
 from fleet_rlm.files.workspace_validation import WorkspacePathError, normalize_workspace_path
 from fleet_rlm.rlm.events import JsonValue
 from fleet_rlm.rlm.tool_observer import ToolEventView, bound_event_text
@@ -43,40 +43,7 @@ def _entry(entry: WorkspaceEntry) -> dict[str, object]:
 
 
 def _raise_tool_error(exc: BaseException) -> NoReturn:
-    if isinstance(exc, WorkspaceToolError):
-        raise exc
-    if getattr(exc, "code", None) == "unsupported_storage":
-        raise ProjectToolError(
-            "unsupported_storage",
-            "Project storage does not support this mutation",
-        ) from None
-    if isinstance(exc, FileNotFoundError):
-        raise ProjectToolError("not_found", "Project file was not found") from None
-    if isinstance(exc, FileExistsError):
-        detail = getattr(exc, "detail", "")
-        if detail == "checksum_mismatch":
-            raise ProjectToolError(
-                "conflict", "Project checksum precondition did not match the current file content"
-            ) from None
-        if detail == "not_empty":
-            raise ProjectToolError("conflict", "Project directory is not empty; delete its contents first") from None
-        if detail == "ambiguous":
-            raise ProjectToolError("conflict", "Project edit text occurs more than once; make it unique") from None
-        if detail == "missing":
-            raise ProjectToolError("conflict", "Project edit text was not found in the file") from None
-        raise ProjectToolError("conflict", "Project file already exists; use overwrite=True to replace it") from None
-    if isinstance(exc, IsADirectoryError):
-        raise ProjectToolError("is_directory", "Project path is a directory") from None
-    if isinstance(exc, NotADirectoryError):
-        raise ProjectToolError("invalid_path", "Project path has a non-directory parent") from None
-    if isinstance(exc, ValueError):
-        message = str(exc)
-        if "cursor" in message:
-            raise ProjectToolError("invalid_cursor", "Project cursor is invalid") from None
-        if "size" in message or "bound" in message:
-            raise ProjectToolError("too_large", "Project file exceeds its size bound") from None
-        raise ProjectToolError("invalid_path", "Project request is invalid") from None
-    raise ProjectToolError("unavailable", "Project storage is unavailable") from None
+    _translate_fs_tool_errors(exc, ProjectToolError, domain="Project")
 
 
 def _normalize_project_path(path: str, *, allow_root: bool = False) -> str:

--- a/src/fleet_rlm/files/tools.py
+++ b/src/fleet_rlm/files/tools.py
@@ -31,10 +31,6 @@ from fleet_rlm.rlm.tool_observer import ToolEventView, bound_event_text
 _EVENT_TEXT_MAX_CHARS = 256
 
 
-def _bounded_text(value: object) -> str:
-    return bound_event_text(value, max_chars=_EVENT_TEXT_MAX_CHARS)
-
-
 def _project_fields(result: object, fields: tuple[str, ...]) -> JsonValue:
     if not isinstance(result, Mapping):
         return {}
@@ -320,21 +316,21 @@ class FileToolHost:
         """Return bounded public metadata projections for File Tools."""
 
         def read_input(arguments: Mapping[str, Any]) -> JsonValue:
-            return {"attachment_id": _bounded_text(arguments.get("attachment_id"))}
+            return {"attachment_id": bound_event_text(arguments.get("attachment_id"))}
 
         def artifact_input(arguments: Mapping[str, Any]) -> JsonValue:
             content = arguments.get("content")
             return {
-                "kind": _bounded_text(arguments.get("kind")),
-                "title": _bounded_text(arguments.get("title")) if arguments.get("title") is not None else None,
+                "kind": bound_event_text(arguments.get("kind")),
+                "title": bound_event_text(arguments.get("title")) if arguments.get("title") is not None else None,
                 "content_chars": len(str(content or "")),
             }
 
         def workspace_artifact_input(arguments: Mapping[str, Any]) -> JsonValue:
             return {
-                "path": _bounded_text(arguments.get("path")),
-                "kind": _bounded_text(arguments.get("kind")),
-                "title": _bounded_text(arguments.get("title")) if arguments.get("title") is not None else None,
+                "path": bound_event_text(arguments.get("path")),
+                "kind": bound_event_text(arguments.get("kind")),
+                "title": bound_event_text(arguments.get("title")) if arguments.get("title") is not None else None,
                 "expected_sha256_present": bool(arguments.get("expected_sha256")),
             }
 

--- a/src/fleet_rlm/files/volume_paths.py
+++ b/src/fleet_rlm/files/volume_paths.py
@@ -159,26 +159,6 @@ class VolumePaths:
         return self.mount_path
 
     @property
-    def files(self) -> PurePosixPath:
-        return self.files_root()
-
-    @property
-    def attachments(self) -> PurePosixPath:
-        return self.attachments_root()
-
-    @property
-    def artifacts(self) -> PurePosixPath:
-        return self.artifacts_root()
-
-    @property
-    def projects(self) -> PurePosixPath:
-        return self.projects_root()
-
-    @property
-    def runs(self) -> PurePosixPath:
-        return resolve_under_root(self.mount_path, "runs")
-
-    @property
     def memory_dir(self) -> PurePosixPath:
         """Browsable memory root: memory/."""
         return resolve_under_root(self.mount_path, "memory")
@@ -187,11 +167,6 @@ class VolumePaths:
     def memory_file(self) -> PurePosixPath:
         """Canonical Workspace Memory log: memory/MEMORIES.md."""
         return resolve_under_root(self.mount_path, "memory", "MEMORIES.md")
-
-    @property
-    def legacy_memory_file(self) -> PurePosixPath:
-        """Pre-migration Workspace Memory log at the volume root."""
-        return resolve_under_root(self.mount_path, "MEMORIES.md")
 
     def artifacts_root(self) -> PurePosixPath:
         return resolve_under_root(self.mount_path, "artifacts")

--- a/src/fleet_rlm/files/workspace_models.py
+++ b/src/fleet_rlm/files/workspace_models.py
@@ -51,13 +51,6 @@ class WorkspaceCapabilityMetadata:
     root: str
     instructions: str
 
-    def to_input(self) -> dict[str, object]:
-        return {
-            "available": self.available,
-            "root": self.root,
-            "instructions": self.instructions,
-        }
-
 
 DAYTONA_WORKSPACE_CAPABILITY = WorkspaceCapabilityMetadata(
     available=True,

--- a/src/fleet_rlm/files/workspace_tools.py
+++ b/src/fleet_rlm/files/workspace_tools.py
@@ -37,48 +37,48 @@ def _entry(entry: WorkspaceEntry) -> dict[str, object]:
     return result
 
 
-def _raise_tool_error(exc: BaseException) -> NoReturn:
+def _translate_fs_tool_errors(exc: BaseException, error_type: type[WorkspaceToolError], *, domain: str) -> NoReturn:
+    """Map one mounted-FS failure into the owning host's closed tool-error vocabulary.
+
+    ``WorkspaceToolHost`` and ``ProjectToolHost`` share this translation (P33):
+    the code vocabulary, exception mapping, and per-domain message shape are
+    owned once here; each host binds its own error class and noun only.
+    """
     if isinstance(exc, WorkspaceToolError):
         raise exc
     if getattr(exc, "code", None) == "unsupported_storage":
-        raise WorkspaceToolError(
-            "unsupported_storage",
-            "Session Workspace storage does not support this mutation",
-        ) from None
+        raise error_type("unsupported_storage", f"{domain} storage does not support this mutation") from None
     if isinstance(exc, FileNotFoundError):
-        raise WorkspaceToolError("not_found", "Session Workspace file was not found") from None
+        raise error_type("not_found", f"{domain} file was not found") from None
     if isinstance(exc, FileExistsError):
         detail = getattr(exc, "detail", "")
         if detail == "checksum_mismatch":
-            raise WorkspaceToolError(
-                "conflict",
-                "Session Workspace checksum precondition did not match the current file content",
+            raise error_type(
+                "conflict", f"{domain} checksum precondition did not match the current file content"
             ) from None
         if detail == "not_empty":
-            raise WorkspaceToolError(
-                "conflict", "Session Workspace directory is not empty; delete its contents first"
-            ) from None
+            raise error_type("conflict", f"{domain} directory is not empty; delete its contents first") from None
         if detail == "ambiguous":
-            raise WorkspaceToolError(
-                "conflict", "Session Workspace edit text occurs more than once; make it unique"
-            ) from None
+            raise error_type("conflict", f"{domain} edit text occurs more than once; make it unique") from None
         if detail == "missing":
-            raise WorkspaceToolError("conflict", "Session Workspace edit text was not found in the file") from None
-        raise WorkspaceToolError(
-            "conflict", "Session Workspace file already exists; use overwrite=True to replace it"
-        ) from None
+            raise error_type("conflict", f"{domain} edit text was not found in the file") from None
+        raise error_type("conflict", f"{domain} file already exists; use overwrite=True to replace it") from None
     if isinstance(exc, IsADirectoryError):
-        raise WorkspaceToolError("is_directory", "Session Workspace path is a directory") from None
+        raise error_type("is_directory", f"{domain} path is a directory") from None
     if isinstance(exc, NotADirectoryError):
-        raise WorkspaceToolError("invalid_path", "Session Workspace path has a non-directory parent") from None
+        raise error_type("invalid_path", f"{domain} path has a non-directory parent") from None
     if isinstance(exc, ValueError):
         message = str(exc)
         if "cursor" in message:
-            raise WorkspaceToolError("invalid_cursor", "Session Workspace cursor is invalid") from None
+            raise error_type("invalid_cursor", f"{domain} cursor is invalid") from None
         if "size" in message or "bound" in message:
-            raise WorkspaceToolError("too_large", "Session Workspace file exceeds its size bound") from None
-        raise WorkspaceToolError("invalid_path", "Session Workspace request is invalid") from None
-    raise WorkspaceToolError("unavailable", "Session Workspace is unavailable") from None
+            raise error_type("too_large", f"{domain} file exceeds its size bound") from None
+        raise error_type("invalid_path", f"{domain} request is invalid") from None
+    raise error_type("unavailable", f"{domain} storage is unavailable") from None
+
+
+def _raise_tool_error(exc: BaseException) -> NoReturn:
+    _translate_fs_tool_errors(exc, WorkspaceToolError, domain="Session Workspace")
 
 
 class WorkspaceToolHost:

--- a/src/fleet_rlm/observability/__init__.py
+++ b/src/fleet_rlm/observability/__init__.py
@@ -1,5 +1,1 @@
 """Safe observability helpers for public transport boundaries."""
-
-from fleet_rlm.observability.failure_diagnostics import FailureDiagnostic, normalize_turn_failure
-
-__all__ = ["FailureDiagnostic", "normalize_turn_failure"]

--- a/src/fleet_rlm/observability/failure_diagnostics.py
+++ b/src/fleet_rlm/observability/failure_diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 from dataclasses import dataclass
 
 from dspy.utils.exceptions import AdapterParseError
@@ -65,15 +66,27 @@ def trace_failure_category(exc: BaseException) -> str:
     return normalize_turn_failure(exc).cause_type
 
 
+def walk_cause_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield ``exc`` then each nested ``__cause__``/``__context__`` with a cycle guard.
+
+    Attribute access stays guarded so failure classification can never raise
+    while inspecting another failure.
+    """
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    try:
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            yield current
+            current = current.__cause__ or current.__context__
+    except Exception:
+        return
+
+
 def _diagnostic_cause(exc: BaseException) -> BaseException:
     current = exc
-    seen: set[int] = set()
-    while id(current) not in seen:
-        seen.add(id(current))
-        nested = current.__cause__ or current.__context__
-        if nested is None:
-            break
-        if isinstance(nested, (DaytonaAdapterError, AdapterParseError)):
-            return nested
-        current = nested
+    for item in walk_cause_chain(exc):
+        if item is not current and isinstance(item, (DaytonaAdapterError, AdapterParseError)):
+            return item
+        current = item
     return current

--- a/src/fleet_rlm/observability/turn_tracing.py
+++ b/src/fleet_rlm/observability/turn_tracing.py
@@ -173,6 +173,29 @@ def annotate_trace_io(
         logger.debug("annotate_trace_io failed; continuing without root span I/O", exc_info=True)
 
 
+def annotate_turn_attributes(attributes: Mapping[str, object]) -> None:
+    """Attach bounded, sanitized attributes to the active ``fleet_turn`` span.
+
+    Fail-soft by contract: with no active Turn trace (or when MLflow is
+    unavailable) this is a no-op that never imports MLflow, and annotation
+    faults are logged at debug level without affecting the Turn.
+    Callers supply only bounded low-cardinality metadata.
+    """
+    if not _fleet_trace_active.get():
+        return
+    try:
+        import mlflow
+
+        span = mlflow.get_current_active_span()
+        if span is None:
+            return
+        setter = getattr(span, "set_attributes", None)
+        if callable(setter):
+            setter(_trace_mapping(attributes))
+    except Exception:
+        logger.debug("annotate_turn_attributes failed; continuing", exc_info=True)
+
+
 def current_turn_trace_id() -> str | None:
     """Return the active Turn trace id for this context, if any."""
     return _current_trace_id.get()

--- a/src/fleet_rlm/persistence/repositories/run_codec.py
+++ b/src/fleet_rlm/persistence/repositories/run_codec.py
@@ -22,6 +22,7 @@ from fleet_rlm.chat.run_claim import (
     ClaimState,
     ClaimStatus,
     ClaimTransition,
+    failure_code_for_terminal_status,
 )
 from fleet_rlm.chat.run_lifecycle import (
     ClaimedRun,
@@ -29,7 +30,6 @@ from fleet_rlm.chat.run_lifecycle import (
     RunFailure,
     RunFailureCode,
     RunStateError,
-    failure_code_for_terminal_status,
 )
 from fleet_rlm.chat.turn_detail_policy import commit_cancelled_tombstone
 from fleet_rlm.persistence.models import ArtifactRow, RunRow, TurnRow

--- a/src/fleet_rlm/rlm/delegation_metrics.py
+++ b/src/fleet_rlm/rlm/delegation_metrics.py
@@ -36,7 +36,9 @@ class DelegationMetricsSnapshot:
     peak_child_concurrency: int = 0
     lm_call_counts: tuple[tuple[str, int, int], ...] = ()
     lm_latency_ms: tuple[tuple[str, int, float], ...] = ()
-    lm_token_totals: tuple[tuple[str, int, int], ...] = ()
+    # Entries are (role, recursive_depth, input_tokens, output_tokens, total_tokens);
+    # input/output are kept alongside the total so partial usage never reads as 0.
+    lm_token_totals: tuple[tuple[str, int, int, int, int], ...] = ()
 
     def as_dict(self) -> dict[str, object]:
         """Return a bounded JSON/MLflow-safe representation."""
@@ -59,8 +61,14 @@ class DelegationMetricsSnapshot:
                 for role, depth, total in self.lm_latency_ms
             ],
             "lm_token_totals": [
-                {"role": role, "recursive_depth": depth, "tokens": tokens}
-                for role, depth, tokens in self.lm_token_totals
+                {
+                    "role": role,
+                    "recursive_depth": depth,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "tokens": tokens,
+                }
+                for role, depth, input_tokens, output_tokens, tokens in self.lm_token_totals
             ],
         }
 
@@ -72,6 +80,8 @@ class DelegationMetrics:
         self._lock = Lock()
         self._lm_calls: dict[tuple[str, int], int] = {}
         self._lm_latency_ms: dict[tuple[str, int], float] = {}
+        self._lm_input_tokens: dict[tuple[str, int], int] = {}
+        self._lm_output_tokens: dict[tuple[str, int], int] = {}
         self._lm_tokens: dict[tuple[str, int], int] = {}
         self._recursive_child_calls = 0
         self._recursive_batch_calls = 0
@@ -92,10 +102,15 @@ class DelegationMetrics:
         """Record one completed or failed LM request without retaining content."""
         normalized_role = role if role in {"root", "sub"} else "unknown"
         key = (normalized_role, max(0, int(recursive_depth)))
-        tokens = normalize_lm_token_usage(usage).get("total_tokens", 0)
+        normalized_usage = normalize_lm_token_usage(usage)
+        input_tokens = normalized_usage.get("input_tokens", 0)
+        output_tokens = normalized_usage.get("output_tokens", 0)
+        tokens = normalized_usage.get("total_tokens", 0)
         with self._lock:
             self._lm_calls[key] = self._lm_calls.get(key, 0) + 1
             self._lm_latency_ms[key] = self._lm_latency_ms.get(key, 0.0) + max(0.0, float(duration_ms))
+            self._lm_input_tokens[key] = self._lm_input_tokens.get(key, 0) + input_tokens
+            self._lm_output_tokens[key] = self._lm_output_tokens.get(key, 0) + output_tokens
             self._lm_tokens[key] = self._lm_tokens.get(key, 0) + tokens
 
     def record_recursive_call(self) -> None:
@@ -125,7 +140,19 @@ class DelegationMetrics:
         with self._lock:
             calls = tuple(sorted((role, depth, count) for (role, depth), count in self._lm_calls.items()))
             latency = tuple(sorted((role, depth, total) for (role, depth), total in self._lm_latency_ms.items()))
-            tokens = tuple(sorted((role, depth, total) for (role, depth), total in self._lm_tokens.items()))
+            token_keys = self._lm_input_tokens.keys() | self._lm_output_tokens.keys() | self._lm_tokens.keys()
+            tokens = tuple(
+                sorted(
+                    (
+                        role,
+                        depth,
+                        self._lm_input_tokens.get((role, depth), 0),
+                        self._lm_output_tokens.get((role, depth), 0),
+                        self._lm_tokens.get((role, depth), 0),
+                    )
+                    for (role, depth) in token_keys
+                )
+            )
             return DelegationMetricsSnapshot(
                 root_lm_calls_depth_0=self._lm_calls.get(("root", 0), 0),
                 sub_lm_calls_depth_0=self._lm_calls.get(("sub", 0), 0),

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -878,3 +878,19 @@ def observed_usage(prediction: Any, *, duration_ms: int) -> RLMUsage:
             "duration_ms": duration_ms,
         }
     )
+
+
+_RLM_EXTRACTION_FALLBACK_REASONING = "Extract forced final output"
+
+
+def rlm_termination_mode(prediction: Any) -> str:
+    """Classify one completed RLM prediction's termination mode.
+
+    DSPy's forced final-output extraction lands on the reserved
+    ``final_reasoning`` marker; its presence means the RLM could not settle
+    through typed SUBMIT payloads, so the fallback is named explicitly rather
+    than re-derived with the magic string at each call site.
+    """
+    if getattr(prediction, "final_reasoning", None) == _RLM_EXTRACTION_FALLBACK_REASONING:
+        return "native_extraction_fallback"
+    return "typed_submit"

--- a/src/fleet_rlm/rlm/dspy_interpreter_contract.py
+++ b/src/fleet_rlm/rlm/dspy_interpreter_contract.py
@@ -31,21 +31,11 @@ def copy_output_fields(
     return deepcopy(output_fields)
 
 
-def initial_tools_registered() -> bool:
-    """Return the inject-cycle registration flag before the first reinjection."""
-    return False
-
-
 def needs_tool_reinjection(*, tools_registered: bool, http_broker_ready: bool) -> bool:
     """Return whether the adapter must register tools and SUBMIT for this cycle."""
     if not tools_registered:
         return True
     return not http_broker_ready
-
-
-def mark_tools_registered() -> bool:
-    """Return the registration flag after tools and SUBMIT are bound."""
-    return True
 
 
 def wrap_final_output(value: Any) -> FinalOutput:
@@ -63,9 +53,7 @@ __all__ = [
     "CodeInterpreter",
     "FinalOutput",
     "copy_output_fields",
-    "initial_tools_registered",
     "is_final_output",
-    "mark_tools_registered",
     "needs_tool_reinjection",
     "wrap_final_output",
 ]

--- a/src/fleet_rlm/rlm/execution_trace.py
+++ b/src/fleet_rlm/rlm/execution_trace.py
@@ -12,7 +12,7 @@ import dspy
 from fleet_rlm.observability.failure_diagnostics import trace_failure_category
 from fleet_rlm.observability.turn_tracing import turn_phase_span
 from fleet_rlm.rlm.context import RLMExecutionContext
-from fleet_rlm.rlm.dspy_contract import _RLMTraceCallback, observed_usage
+from fleet_rlm.rlm.dspy_contract import _RLMTraceCallback, observed_usage, rlm_termination_mode
 from fleet_rlm.rlm.recursive_calls import RecursiveCallSummary, RecursiveRLMExecutor
 from fleet_rlm.rlm.worker_execution import invoke_native_rlm
 
@@ -33,19 +33,7 @@ def recursive_summary(executor: RecursiveRLMExecutor | None, metrics: Any | None
         return executor.summary()
     if metrics is not None and callable(getattr(metrics, "snapshot", None)):
         snapshot = metrics.snapshot()
-        return RecursiveCallSummary(
-            0,
-            0,
-            0,
-            0,
-            snapshot.depth_fallback_calls,
-            (),
-            recursive_batch_calls=snapshot.recursive_batch_calls,
-            recursive_children_started=snapshot.recursive_children_started,
-            recursive_children_completed=snapshot.recursive_children_completed,
-            peak_child_concurrency=snapshot.peak_child_concurrency,
-            delegation_metrics=snapshot,
-        )
+        return RecursiveCallSummary.from_snapshot(snapshot, depth_fallback_count=snapshot.depth_fallback_calls)
     return RecursiveCallSummary(0, 0, 0, 0, 0, ())
 
 
@@ -104,10 +92,7 @@ def record_phase_success(
     Returns:
         Any: The original prediction.
     """
-    final_reasoning = getattr(prediction, "final_reasoning", None)
-    termination_mode = (
-        "native_extraction_fallback" if final_reasoning == "Extract forced final output" else "typed_submit"
-    )
+    termination_mode = rlm_termination_mode(prediction)
     usage = observed_usage(prediction, duration_ms=int((time.perf_counter() - started) * 1000))
     summary = recursive_summary(recursive_executor, metrics)
     phase.set_outputs(

--- a/src/fleet_rlm/rlm/lm_factory.py
+++ b/src/fleet_rlm/rlm/lm_factory.py
@@ -113,10 +113,21 @@ def build_lm(
         dspy.LM: Configured DSPy language model.
     """
     model_id = normalize_model_id(model)
+    allowed_openai_params: list[str] = ["stream_options"]
     kwargs: dict[str, Any] = {
         "model_type": "chat",
         "cache": cache,
         "num_retries": num_retries,
+        # Stream and ask for a usage block on the final chunk. Gateways such as
+        # the Databricks AI Gateway ignore ``stream_options.include_usage`` on a
+        # non-streamed request, so streaming is required to observe token usage.
+        # DSPy/litellm aggregate the streamed deltas internally and ``lm()``
+        # still returns the same final outputs, leaving ChatAdapter parsing
+        # untouched. ``stream`` is a litellm transport toggle (a first-class
+        # completion() param), while ``stream_options`` is an OpenAI body param
+        # LiteLLM filters unless allowlisted.
+        "stream": True,
+        "stream_options": {"include_usage": True},
     }
     if api_key:
         kwargs["api_key"] = api_key
@@ -130,7 +141,8 @@ def build_lm(
         kwargs["reasoning_effort"] = reasoning_effort
         # LiteLLM normally filters this OpenAI-compatible parameter; explicitly
         # allow it for providers that expose reasoning controls.
-        kwargs["allowed_openai_params"] = ["reasoning_effort"]
+        allowed_openai_params.append("reasoning_effort")
+    kwargs["allowed_openai_params"] = allowed_openai_params
     return dspy.LM(model_id, **kwargs)
 
 

--- a/src/fleet_rlm/rlm/provider_probe.py
+++ b/src/fleet_rlm/rlm/provider_probe.py
@@ -12,7 +12,7 @@ from dspy.utils.exceptions import AdapterParseError
 
 from fleet_rlm.config import Settings
 from fleet_rlm.rlm.child_runtime import ChildRuntimeFactory
-from fleet_rlm.rlm.dspy_contract import RLMOptions, build_native_rlm
+from fleet_rlm.rlm.dspy_contract import RLMOptions, build_native_rlm, rlm_termination_mode
 from fleet_rlm.rlm.dspy_interpreter_contract import CodeInterpreter
 from fleet_rlm.rlm.errors import RLMConfigError
 from fleet_rlm.rlm.lm_factory import build_lm, resolve_role_api_key, sanitize_base_url
@@ -120,11 +120,7 @@ async def probe_root_lm(
         raise RLMProviderContractError("Root LM did not exercise the recursive child Tool")
     return RLMProviderProbeResult(
         iterations=len(trajectory),
-        termination_mode=(
-            "native_extraction_fallback"
-            if getattr(prediction, "final_reasoning", None) == "Extract forced final output"
-            else "typed_submit"
-        ),
+        termination_mode=rlm_termination_mode(prediction),
     )
 
 

--- a/src/fleet_rlm/rlm/recursive_calls.py
+++ b/src/fleet_rlm/rlm/recursive_calls.py
@@ -21,7 +21,13 @@ from fleet_rlm.rlm.child_runtime import (
     ChildRuntimeLease,
 )
 from fleet_rlm.rlm.delegation_metrics import DelegationMetrics, DelegationMetricsSnapshot
-from fleet_rlm.rlm.dspy_contract import RLMOptions, _RLMTraceCallback, build_native_rlm, prediction_result
+from fleet_rlm.rlm.dspy_contract import (
+    RLMOptions,
+    _RLMTraceCallback,
+    build_native_rlm,
+    prediction_result,
+    rlm_termination_mode,
+)
 from fleet_rlm.rlm.errors import RLMConfigError
 from fleet_rlm.rlm.events import Status
 from fleet_rlm.rlm.model_bundle import RLMModelBundle
@@ -86,6 +92,33 @@ class RecursiveCallSummary:
     recursive_children_completed: int = 0
     peak_child_concurrency: int = 0
     delegation_metrics: DelegationMetricsSnapshot = field(default_factory=DelegationMetricsSnapshot)
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        snapshot: DelegationMetricsSnapshot,
+        *,
+        call_count: int = 0,
+        delegated_prompt_chars: int = 0,
+        maximum_prompt_chars: int = 0,
+        child_iterations: int = 0,
+        depth_fallback_count: int = 0,
+        termination_modes: tuple[str, ...] = (),
+    ) -> RecursiveCallSummary:
+        """Assemble one bounded summary from a shared delegation snapshot."""
+        return cls(
+            call_count,
+            delegated_prompt_chars,
+            maximum_prompt_chars,
+            child_iterations,
+            depth_fallback_count,
+            termination_modes,
+            recursive_batch_calls=snapshot.recursive_batch_calls,
+            recursive_children_started=snapshot.recursive_children_started,
+            recursive_children_completed=snapshot.recursive_children_completed,
+            peak_child_concurrency=snapshot.peak_child_concurrency,
+            delegation_metrics=snapshot,
+        )
 
 
 @dataclass(slots=True)
@@ -295,19 +328,14 @@ class RecursiveRLMExecutor:
     def summary(self) -> RecursiveCallSummary:
         """Return bounded aggregate recursion metadata without content."""
         with self._state.lock:
-            snapshot = self._metrics.snapshot()
-            return RecursiveCallSummary(
+            return RecursiveCallSummary.from_snapshot(
+                self._metrics.snapshot(),
                 call_count=self._state.reserved_call_count,
                 delegated_prompt_chars=self._state.delegated_prompt_chars,
                 maximum_prompt_chars=self._state.maximum_prompt_chars,
                 child_iterations=self._state.child_iterations,
                 depth_fallback_count=self._state.depth_fallback_count,
                 termination_modes=tuple(self._state.termination_modes),
-                recursive_batch_calls=snapshot.recursive_batch_calls,
-                recursive_children_started=snapshot.recursive_children_started,
-                recursive_children_completed=snapshot.recursive_children_completed,
-                peak_child_concurrency=snapshot.peak_child_concurrency,
-                delegation_metrics=snapshot,
             )
 
     def raise_if_cleanup_failed(self) -> None:
@@ -585,11 +613,7 @@ class RecursiveRLMExecutor:
         self._ensure_call_authorized(batch_cancelled)
         trajectory = getattr(prediction, "trajectory", ())
         child_iterations = len(trajectory) if isinstance(trajectory, list) else 0
-        mode = (
-            "native_extraction_fallback"
-            if getattr(prediction, "final_reasoning", None) == "Extract forced final output"
-            else "typed_submit"
-        )
+        mode = rlm_termination_mode(prediction)
         completion_outputs = self._record_completion(call, mode=mode, child_iterations=child_iterations)
         return result.display_text, completion_outputs
 

--- a/src/fleet_rlm/rlm/routing_eval.py
+++ b/src/fleet_rlm/rlm/routing_eval.py
@@ -416,17 +416,11 @@ async def run_routing_scenario(
             counts["rlm_query"] = counts.get("rlm_query", 0) + summary.call_count
         if summary.recursive_batch_calls:
             counts["rlm_query_batched"] = counts.get("rlm_query_batched", 0) + summary.recursive_batch_calls
-        facts = RoutingFacts(
-            tool_counts=counts,
-            native_child_count=summary.call_count - summary.depth_fallback_count,
-            max_native_child_depth=1 if summary.call_count > summary.depth_fallback_count else 0,
-            depth_fallback_count=summary.depth_fallback_count,
-            child_iterations=summary.child_iterations,
-            recursive_prompt_chars=summary.maximum_prompt_chars,
+        facts = facts_from_recursive_summary(
+            summary,
             latency_ms=details_facts.latency_ms,
+            tool_counts=counts,
             sandbox_count=tracked_child_factory.created,
-            recursive_batch_calls=summary.recursive_batch_calls,
-            peak_child_concurrency=summary.peak_child_concurrency,
         )
         scenarios.append(
             score_routing_execution(

--- a/src/fleet_rlm/rlm/runner.py
+++ b/src/fleet_rlm/rlm/runner.py
@@ -149,8 +149,8 @@ def _terminal_status(exc: BaseException) -> TerminalStatus:
 
 def _public_failure_message(exc: BaseException) -> str:
     # Read the instance attribute so a parametrized ``RunTerminalError("...")``
-    # override is honored, matching ``sanitize_public_error``. Class-attr
-    # defaults (currently all raise sites) fall through the same lookup.
+    # override is honored. Class-attr defaults (currently all raise sites)
+    # fall through the same lookup.
     """Return a sanitized public message for a run failure.
 
     Parameters:

--- a/src/fleet_rlm/rlm/sanitize.py
+++ b/src/fleet_rlm/rlm/sanitize.py
@@ -115,32 +115,6 @@ _DECLARED_SAFE_PLACEHOLDERS = frozenset(
 )
 
 
-def sanitize_public_error(exc: BaseException | str) -> str:
-    """Return a concise client-safe message; never rethrow raw provider text."""
-    if isinstance(exc, BaseException):
-        # Prefer typed public messages when available
-        public = getattr(exc, "public_message", None)
-        status = getattr(exc, "status", None)
-        if isinstance(public, str) and public.strip() and status:
-            return public.strip()
-        raw = str(exc).strip() or type(exc).__name__
-    else:
-        raw = str(exc).strip() or "Turn failed"
-
-    cleaned = _TOKENISH.sub("[redacted]", raw)
-    cleaned = _SECRETISH.sub("[redacted]", cleaned)
-    cleaned = _DSNISH.sub("[redacted-dsn]", cleaned)
-    cleaned = _PATHISH.sub("[path]", cleaned)
-    cleaned = _PROMPTISH.sub("[redacted-prompt]", cleaned)
-    if _STACKISH.search(cleaned) or "Traceback" in cleaned or "\n  File " in cleaned:
-        return "Turn failed"
-    # Cap length so stack-like dumps never fill SSE frames.
-    if len(cleaned) > 240:
-        cleaned = cleaned[:237] + "..."
-    # Provider-ish type names alone are ok; long internal dumps already capped
-    return cleaned or "Turn failed"
-
-
 def sanitize_public_text(text: str, *, max_len: int = 10_000) -> str:
     """Bound and redact model-authored text intended for public detail or answers."""
     cleaned = _TOKENISH.sub("[redacted]", text)

--- a/src/fleet_rlm/rlm/trajectory_projection.py
+++ b/src/fleet_rlm/rlm/trajectory_projection.py
@@ -185,14 +185,42 @@ def reconcile_trajectory(
     canonical flags without any re-emission. A differing same-step RLM detail
     is replaced in the durable list and re-emitted with the same stable step
     ID so live TUI projection upserts it rather than appending a second card.
+
+    Step-marker positions are indexed once and maintained under local
+    insert/delete shifts instead of re-scanning the list per step (P33: one
+    derivation per bounded collection).
     """
+    step_starts: dict[int, int] = {}
+    step_finishes: dict[int, int] = {}
+    reasoning_first: dict[int, int] = {}
+    for index, detail in enumerate(details):
+        if isinstance(detail, StepStarted):
+            step_starts.setdefault(detail.step, index)
+        elif isinstance(detail, StepFinished):
+            step_finishes.setdefault(detail.step, index)
+        elif isinstance(detail, RLMReasoning):
+            reasoning_step = _stream_step(detail)
+            if reasoning_step is not None:
+                reasoning_first.setdefault(reasoning_step, index)
+
+    def shift_positions(removed_asc: Sequence[int], *, inserted_at: int | None = None) -> None:
+        """Keep marker maps exact across local deletions/insertions."""
+        if not removed_asc and inserted_at is None:
+            return
+        for mapping in (step_starts, step_finishes, reasoning_first):
+            for step_index, position in list(mapping.items()):
+                adjusted = position - sum(1 for removed in removed_asc if removed < position)
+                if inserted_at is not None and adjusted >= inserted_at:
+                    adjusted += 1
+                mapping[step_index] = adjusted
+
     emissions: list[ObservationDetail] = []
     aligned_positions: set[int] = set()
     for trajectory_step in trajectory:
         step = trajectory_step.index
         step_details = trajectory_details((trajectory_step,), max_chars=max_chars)
-        start = _detail_position(details, StepStarted, step)
-        finish = _detail_position(details, StepFinished, step)
+        start = step_starts.get(step)
+        finish = step_finishes.get(step)
         if start is None or finish is None or start >= finish:
             details.extend(step_details)
             emissions.extend(step_details)
@@ -205,8 +233,8 @@ def reconcile_trajectory(
             target = _preserve_stream_id(target, details, target_step if isinstance(target_step, int) else step)
             target_step = _stream_step(target)
             if isinstance(target_step, int) and target_step != step:
-                aligned_start = _detail_position(details, StepStarted, target_step)
-                aligned_finish = _detail_position(details, StepFinished, target_step)
+                aligned_start = step_starts.get(target_step)
+                aligned_finish = step_finishes.get(target_step)
                 if aligned_start is not None and aligned_finish is not None and aligned_start < aligned_finish:
                     step = target_step
                     start, finish = aligned_start, aligned_finish
@@ -225,16 +253,18 @@ def reconcile_trajectory(
                 if not _same_stream_payload(details, existing_positions, target):
                     emissions.append(target)
                 details[first] = target
-                for duplicate in reversed(existing_positions[1:]):
+                removed = existing_positions[1:]
+                for duplicate in reversed(removed):
                     del details[duplicate]
-                start = _detail_position(details, StepStarted, step)
-                finish = _detail_position(details, StepFinished, step)
-                assert start is not None and finish is not None
+                shift_positions(sorted(removed))
+                start = step_starts[step]
+                finish = step_finishes[step]
+                assert start < finish
                 continue
 
             # Live observation may publish reasoning before interpreter StepStarted.
             if isinstance(target, RLMReasoning):
-                outside = _detail_position(details, RLMReasoning, step)
+                outside = reasoning_first.get(step)
                 if outside is not None:
                     if not _same_stream_payload(details, (outside,), target):
                         emissions.append(target)
@@ -243,9 +273,10 @@ def reconcile_trajectory(
             insertion = _trajectory_insertion(details, target, step, finish)
             details.insert(insertion, target)
             emissions.append(target)
-            start = _detail_position(details, StepStarted, step)
-            finish = _detail_position(details, StepFinished, step)
-            assert start is not None and finish is not None
+            shift_positions((), inserted_at=insertion)
+            start = step_starts[step]
+            finish = step_finishes[step]
+            assert start < finish
     return emissions
 
 

--- a/src/fleet_rlm/sessions/assistant_parts.py
+++ b/src/fleet_rlm/sessions/assistant_parts.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping, Sequence
 from typing import Annotated, Any, Literal, assert_never, cast
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_validator
 
 from fleet_rlm.rlm.dspy_contract import RLMUsage
 from fleet_rlm.sessions.committed_turn import (
@@ -258,6 +258,8 @@ AssistantPart = Annotated[
     Field(discriminator="type"),
 ]
 
+_ASSISTANT_PART_ADAPTER: TypeAdapter[AssistantPart] = TypeAdapter(AssistantPart)
+
 AssistantPartModelUnion = (
     StepAssistantPart,
     ReasoningAssistantPart,
@@ -416,10 +418,7 @@ def assistant_part_payload(part: CommittedPart) -> dict[str, Any]:
 
 def assistant_part_from_payload(payload: object) -> CommittedPart:
     """Validate a durable part payload and convert it to the runtime aggregate."""
-    from pydantic import TypeAdapter
-
-    adapter: TypeAdapter[AssistantPart] = TypeAdapter(AssistantPart)
-    return assistant_part_from_model(adapter.validate_python(payload, strict=False))
+    return assistant_part_from_model(_ASSISTANT_PART_ADAPTER.validate_python(payload, strict=False))
 
 
 __all__ = [

--- a/src/fleet_rlm/sessions/catalog.py
+++ b/src/fleet_rlm/sessions/catalog.py
@@ -25,10 +25,6 @@ class SequenceCursor:
         ):
             raise ValueError("after_sequence must be a non-negative integer")
 
-    @classmethod
-    def from_query(cls, value: int | None) -> SequenceCursor:
-        return cls(after_sequence=value)
-
     def next_after_sequence(self, last_sequence: int) -> int:
         if not isinstance(last_sequence, int) or isinstance(last_sequence, bool) or last_sequence < 1:
             raise ValueError("last_sequence must be a positive integer")

--- a/src/fleet_rlm/sessions/committed_turn.py
+++ b/src/fleet_rlm/sessions/committed_turn.py
@@ -8,6 +8,8 @@ from types import MappingProxyType
 from typing import Any, Literal, TypeAlias, cast
 from uuid import UUID
 
+from pydantic import ValidationError
+
 from fleet_rlm.json_types import JsonScalar as JsonScalar
 from fleet_rlm.json_types import JsonValue as JsonValue
 from fleet_rlm.rlm.dspy_contract import RLMUsage, validate_rlm_usage
@@ -356,7 +358,7 @@ class CommittedTurnCodec:
             raise CommittedTurnValidationError("trace_id must be a string or null")
         try:
             parts = tuple(assistant_part_from_payload(part) for part in raw_parts)
-        except Exception as exc:
+        except (ValidationError, ValueError) as exc:
             message = str(exc)
             if "String should have at least 1 character" in message and any(
                 isinstance(part, Mapping) and part.get("type") == "text" for part in raw_parts

--- a/src/fleet_rlm/sessions/models.py
+++ b/src/fleet_rlm/sessions/models.py
@@ -211,11 +211,6 @@ class AssistantTurnRecord:
     committed: CommittedTurn
     run_id: UUID
 
-    @property
-    def content(self) -> str:
-        return self.committed.text
-
-
 @dataclass(frozen=True, slots=True)
 class SessionRecord:
     id: UUID

--- a/src/fleet_rlm/sessions/models.py
+++ b/src/fleet_rlm/sessions/models.py
@@ -211,6 +211,7 @@ class AssistantTurnRecord:
     committed: CommittedTurn
     run_id: UUID
 
+
 @dataclass(frozen=True, slots=True)
 class SessionRecord:
     id: UUID

--- a/tests/contracts/backend/test_coordinator_runner_failures.py
+++ b/tests/contracts/backend/test_coordinator_runner_failures.py
@@ -253,7 +253,7 @@ async def test_completed_trajectory_turn_commits_typed_text_and_canonical_detail
     records = await harness.store.turn_records(harness.session_id, harness.access)
     assistant = records[-1]
     assert isinstance(assistant, AssistantTurnRecord)
-    assert assistant.content == "10"
+    assert assistant.committed.text == "10"
     reasoning = [part for part in assistant.committed.parts if isinstance(part, ReasoningPart)]
     assert [part.text for part in reasoning] == [
         "initialize",

--- a/tests/contracts/backend/test_daytona_import_boundary.py
+++ b/tests/contracts/backend/test_daytona_import_boundary.py
@@ -20,6 +20,7 @@ EXPECTED_DAYTONA_MODULES = {
     "interpreter.py",
     "interpreter_output.py",
     "lifecycle.py",
+    "memory_diagnostics.py",
     "memory_outbox_reconcile.py",
     "optimization_evaluator.py",
     "platform.py",

--- a/tests/contracts/backend/test_mlflow_lifespan.py
+++ b/tests/contracts/backend/test_mlflow_lifespan.py
@@ -28,7 +28,7 @@ def _post_canned_turn(client: TestClient) -> None:
 
 
 def test_public_turn_succeeds_when_tracing_is_disabled_by_policy() -> None:
-    app = create_testing_app(settings=Settings(_env_file=None, mlflow_tracing_enabled=False))
+    app = create_testing_app(settings=Settings(mlflow_tracing_enabled=False))
 
     with TestClient(app) as client:
         _post_canned_turn(client)
@@ -46,7 +46,6 @@ def test_public_turn_succeeds_when_tracing_setup_is_unavailable(monkeypatch) -> 
     monkeypatch.setattr("fleet_rlm.observability.tracing.configure_tracing", unavailable)
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             mlflow_tracing_enabled=True,
             mlflow_experiment_name="fleet-test",
             mlflow_tracking_uri="http://127.0.0.1:5001",
@@ -70,7 +69,6 @@ def test_two_fresh_app_lifespans_can_reconfig_after_a_failed_attempt(monkeypatch
 
     monkeypatch.setattr("fleet_rlm.observability.tracing.configure_tracing", configure)
     settings = Settings(
-        _env_file=None,
         mlflow_tracing_enabled=True,
         mlflow_experiment_name="fleet-test",
         mlflow_tracking_uri="http://127.0.0.1:5001",

--- a/tests/contracts/backend/test_p33_guardrails.py
+++ b/tests/contracts/backend/test_p33_guardrails.py
@@ -1,0 +1,137 @@
+"""P33/T4 maintainability guardrails (QRE-202).
+
+Objective, non-brittle pins for canonical-path ownership and the completed
+P33 contraction: tests assert observable seams and invariants, never private
+line-by-line structure. Each block documents which architectural regression
+would fail CI deterministically.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Canonical-path guardrails (P25-P32 seams must keep owning their domains)
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_memory_and_fs_route_through_the_p28_runtime_handlers() -> None:
+    """Installed + fallback workspace execution stays on the one runtime handler."""
+    import fleet_rlm.daytona.workspace_fs as workspace_fs
+    import fleet_rlm.daytona.workspace_memory as workspace_memory
+    from fleet_rlm.daytona.workspace_agent import run_workspace_agent, run_workspace_agent_async
+
+    assert workspace_memory.run_workspace_agent is run_workspace_agent
+    assert workspace_fs.run_workspace_agent_async is run_workspace_agent_async
+
+
+def test_owned_effect_primitive_owns_post_commit_promotion() -> None:
+    """Owned-effect call sites settle through the P27 primitive, not hand-rolled waits."""
+    import fleet_rlm.chat.post_commit_memory as post_commit_memory
+    from fleet_rlm.runtime.owned_effect import OwnedEffect
+
+    assert post_commit_memory.OwnedEffect is OwnedEffect
+    assert callable(OwnedEffect.from_task)
+
+
+def test_child_lease_settlement_uses_explicit_p30_state() -> None:
+    """The recursive child lease exposes typed settlement states (no boolean shortcuts)."""
+    from fleet_rlm.daytona.recursive_child_lease import ChildRuntimeLeaseState
+
+    assert {state.name for state in ChildRuntimeLeaseState} == {"OPEN", "CLOSING", "CLOSED", "FAILED"}
+
+
+def test_config_inventory_remains_derived_from_the_p29_schema() -> None:
+    """No second full field mirror may reappear beside the FleetFieldPolicy declarations."""
+    from fleet_rlm.config import Settings, config_field_specs
+    from fleet_rlm.config_policy import _FIELDS
+
+    spec_paths = {spec.toml_path for spec in config_field_specs()}
+    policy_paths = {field.path for field in _FIELDS}
+    assert policy_paths == spec_paths
+    assert Settings.model_config.get("extra") == "forbid"
+
+
+def test_tui_canonical_convergence_guardrail_exists() -> None:
+    """The P32 invariant suite pinning live/durable reducer convergence stays committed."""
+    from pathlib import Path
+
+    suite = Path(__file__).resolve().parents[3] / "tools/fleet-tui/src/tui/tests/turn-reducer-invariants.test.ts"
+    assert suite.is_file()
+
+
+def test_daytona_sdk_stays_inside_the_daytona_boundary() -> None:
+    """Native DSPy execution authority stays in rlm/; Daytona SDK stays in daytona/."""
+    from fleet_rlm.rlm.dspy_contract import RLMOptions
+
+    assert RLMOptions is not None
+
+
+# ---------------------------------------------------------------------------
+# Contraction guardrails: deleted superseded paths stay deleted
+# ---------------------------------------------------------------------------
+
+DELETED_SYMBOLS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("fleet_rlm.chat.run_preparation", ("RunPreparationValidationError", "RunPreparationIntegrityError")),
+    ("fleet_rlm.chat.run_ownership", ("consume_task_exception",)),
+    ("fleet_rlm.rlm.dspy_interpreter_contract", ("initial_tools_registered", "mark_tools_registered")),
+    ("fleet_rlm.rlm.sanitize", ("sanitize_public_error",)),
+    (
+        "fleet_rlm.daytona.dspy_sync_bridge",
+        ("default_bridge_dispatcher", "set_bridge_service_loop", "bridge_service_loop"),
+    ),
+    ("fleet_rlm.daytona.sandbox_lease", ("acquire_owned_lease", "OwnedAcquisition")),
+    ("fleet_rlm.daytona.broker_source", ("_FINAL_OUTPUT_MARKER",)),
+    ("fleet_rlm.files.host_volume", ("HostWorkspaceVolumeGateway",)),
+    (
+        "fleet_rlm.files.memory_models",
+        ("reformat_workspace_memory_record", "build_workspace_memory_digest", "validate_workspace_memory_content"),
+    ),
+    ("fleet_rlm.files.tools", ("_bounded_text",)),
+    ("fleet_rlm.sessions.catalog", ("SequenceCursor.from_query",)),
+)
+
+
+@pytest.mark.parametrize(("module_name", "symbols"), DELETED_SYMBOLS, ids=lambda pair: pair[0].rsplit(".", 1)[-1])
+def test_p33_deleted_module_symbols_stay_deleted(module_name: str, symbols: tuple[str, ...]) -> None:
+    """Accidental resurrection of a superseded path fails deterministically."""
+    import importlib
+
+    module = importlib.import_module(module_name)
+    for name in symbols:
+        assert not hasattr(module, name), f"{module_name}.{name} was resurrected"
+
+
+def test_settings_keeps_no_legacy_llm_fields() -> None:
+    """The zero-consumer legacy Settings fields deleted in P33 stay deleted."""
+    from fleet_rlm.config import Settings
+
+    assert "llm_base_url" not in Settings.model_fields
+    assert "llm_max_tokens" not in Settings.model_fields
+
+
+def test_deleted_dataclass_methods_and_fields_stay_deleted() -> None:
+    """Dead compat surfaces removed in P33 do not reappear on the domain models."""
+    from fleet_rlm.chat.post_commit_memory import OwnedPostCommitMemoryPromotion
+    from fleet_rlm.chat.session_context import SessionContextManifest, TurnPreview
+    from fleet_rlm.chat.turn_coordinator import TurnCoordinator
+    from fleet_rlm.config import Settings
+    from fleet_rlm.daytona.session_manager import InterpreterLease
+    from fleet_rlm.daytona.workspace_fs import AsyncDaytonaSessionWorkspaceFS, DaytonaSessionWorkspaceFS
+    from fleet_rlm.sessions.models import AssistantTurnRecord
+
+    assert not hasattr(Settings, "llm_api_url")
+    assert "delete_sandbox" not in InterpreterLease.__dataclass_fields__
+    assert "__call__" not in vars(OwnedPostCommitMemoryPromotion)
+    assert not hasattr(TurnPreview, "to_input")
+    assert not hasattr(SessionContextManifest, "to_input")
+    assert not hasattr(TurnCoordinator, "_submit_claim_loss_cleanup")
+    assert not hasattr(DaytonaSessionWorkspaceFS, "read_text")
+    assert not hasattr(AsyncDaytonaSessionWorkspaceFS, "read_text")
+    assert not hasattr(AssistantTurnRecord, "content")
+
+
+def test_workspace_capability_metadata_has_no_dead_serializer() -> None:
+    from fleet_rlm.files.workspace_models import WorkspaceCapabilityMetadata
+
+    assert not hasattr(WorkspaceCapabilityMetadata, "to_input")

--- a/tests/contracts/backend/test_p33_guardrails.py
+++ b/tests/contracts/backend/test_p33_guardrails.py
@@ -17,8 +17,7 @@ import pytest
 
 def test_workspace_memory_and_fs_route_through_the_p28_runtime_handlers() -> None:
     """Installed + fallback workspace execution stays on the one runtime handler."""
-    import fleet_rlm.daytona.workspace_fs as workspace_fs
-    import fleet_rlm.daytona.workspace_memory as workspace_memory
+    from fleet_rlm.daytona import workspace_fs, workspace_memory
     from fleet_rlm.daytona.workspace_agent import run_workspace_agent, run_workspace_agent_async
 
     assert workspace_memory.run_workspace_agent is run_workspace_agent
@@ -27,7 +26,7 @@ def test_workspace_memory_and_fs_route_through_the_p28_runtime_handlers() -> Non
 
 def test_owned_effect_primitive_owns_post_commit_promotion() -> None:
     """Owned-effect call sites settle through the P27 primitive, not hand-rolled waits."""
-    import fleet_rlm.chat.post_commit_memory as post_commit_memory
+    from fleet_rlm.chat import post_commit_memory
     from fleet_rlm.runtime.owned_effect import OwnedEffect
 
     assert post_commit_memory.OwnedEffect is OwnedEffect
@@ -112,22 +111,22 @@ def test_settings_keeps_no_legacy_llm_fields() -> None:
 
 def test_deleted_dataclass_methods_and_fields_stay_deleted() -> None:
     """Dead compat surfaces removed in P33 do not reappear on the domain models."""
-    from fleet_rlm.chat.post_commit_memory import OwnedPostCommitMemoryPromotion
+    from fleet_rlm.chat import post_commit_memory
     from fleet_rlm.chat.session_context import SessionContextManifest, TurnPreview
     from fleet_rlm.chat.turn_coordinator import TurnCoordinator
     from fleet_rlm.config import Settings
+    from fleet_rlm.daytona import workspace_fs
     from fleet_rlm.daytona.session_manager import InterpreterLease
-    from fleet_rlm.daytona.workspace_fs import AsyncDaytonaSessionWorkspaceFS, DaytonaSessionWorkspaceFS
     from fleet_rlm.sessions.models import AssistantTurnRecord
 
     assert not hasattr(Settings, "llm_api_url")
     assert "delete_sandbox" not in InterpreterLease.__dataclass_fields__
-    assert "__call__" not in vars(OwnedPostCommitMemoryPromotion)
+    assert "__call__" not in vars(post_commit_memory.OwnedPostCommitMemoryPromotion)
     assert not hasattr(TurnPreview, "to_input")
     assert not hasattr(SessionContextManifest, "to_input")
     assert not hasattr(TurnCoordinator, "_submit_claim_loss_cleanup")
-    assert not hasattr(DaytonaSessionWorkspaceFS, "read_text")
-    assert not hasattr(AsyncDaytonaSessionWorkspaceFS, "read_text")
+    assert not hasattr(workspace_fs.DaytonaSessionWorkspaceFS, "read_text")
+    assert not hasattr(workspace_fs.AsyncDaytonaSessionWorkspaceFS, "read_text")
     assert not hasattr(AssistantTurnRecord, "content")
 
 

--- a/tests/contracts/backend/test_p34_guardrails.py
+++ b/tests/contracts/backend/test_p34_guardrails.py
@@ -1,0 +1,59 @@
+"""P34 final maintainability-freeze guardrails.
+
+These checks pin ownership seams and bounded vocabularies without asserting
+private line-by-line structure. They make the final architecture/documentation
+contract fail closed if a canonical owner or P31/P32 regression-proof path is
+removed or silently duplicated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_p34_freeze_guide_is_indexed_and_names_the_final_gate() -> None:
+    guide = REPO_ROOT / "docs/how-to-guides/maintainability-freeze.md"
+    assert guide.is_file()
+    content = guide.read_text(encoding="utf-8")
+    assert "# Maintainability freeze" in content
+    assert "P26-P33" in content.replace(chr(0x2013), "-")
+    assert "make check-security" in content
+    assert "FLEET_LIVE=1" in content
+    assert "how-to-guides/maintainability-freeze.md" in (REPO_ROOT / "docs/index.md").read_text(encoding="utf-8")
+    assert "how-to-guides/maintainability-freeze.md" in (REPO_ROOT / "docs/SUMMARY.md").read_text(encoding="utf-8")
+
+
+def test_p34_canonical_ownership_seams_remain_available() -> None:
+    from fleet_rlm.chat.run_lifecycle import RunLifecycleService
+    from fleet_rlm.chat.turn_coordinator import TurnCoordinator
+    from fleet_rlm.daytona.memory_diagnostics import MemoryFailureCategory
+    from fleet_rlm.daytona.recursive_child_lease import ChildRuntimeLeaseState
+    from fleet_rlm.runtime.owned_effect import OwnedEffect
+
+    assert callable(RunLifecycleService.finish)
+    assert callable(TurnCoordinator.open)
+    assert callable(OwnedEffect.settle)
+    assert {state.name for state in ChildRuntimeLeaseState} == {"OPEN", "CLOSING", "CLOSED", "FAILED"}
+    assert {category.value for category in MemoryFailureCategory} == {
+        "normalization",
+        "provider_unavailable",
+        "corrupt_record_set",
+        "invariant_violation",
+        "search_failure",
+        "legacy_migration",
+        "unexpected_internal",
+    }
+
+
+def test_p34_regression_proof_paths_remain_committed() -> None:
+    paths = (
+        "tests/contracts/backend/test_p33_guardrails.py",
+        "tools/fleet-tui/src/tui/tests/turn-reducer-invariants.test.ts",
+        "tools/fleet-tui/src/tui/tests/reducer-sequence-gen.ts",
+        "src/fleet_rlm/daytona/memory_diagnostics.py",
+        "src/fleet_rlm/daytona/workspace_agent_runtime.py",
+    )
+    for relative_path in paths:
+        assert (REPO_ROOT / relative_path).is_file(), relative_path

--- a/tests/contracts/backend/test_rlm_history_retrieval.py
+++ b/tests/contracts/backend/test_rlm_history_retrieval.py
@@ -38,7 +38,7 @@ async def test_native_rlm_retrieves_older_content_absent_from_initial_kwargs() -
     )
     session_id = uuid4()
     manifest = build_session_context_manifest(session_id, 4, history)
-    assert older_detail not in str(manifest.to_input())
+    assert all(older_detail not in item.preview for item in manifest.recent)
     (history_tool,) = SessionHistoryToolHost(history).as_tools()
 
     class Capabilities:

--- a/tests/contracts/backend/test_runtime_profiles.py
+++ b/tests/contracts/backend/test_runtime_profiles.py
@@ -20,4 +20,4 @@ def test_public_runtime_profiles_are_exactly_daytona() -> None:
 
 def test_daytona_is_the_default_public_runtime_profile(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FLEET_RUN_ENVIRONMENT", raising=False)
-    assert Settings(_env_file=None).run_environment == "daytona"
+    assert Settings().run_environment == "daytona"

--- a/tests/contracts/backend/test_settings_api.py
+++ b/tests/contracts/backend/test_settings_api.py
@@ -17,7 +17,7 @@ def test_settings_policy_is_loopback_only_and_revision_checked(monkeypatch, tmp_
     policy = tmp_path / "fleet.toml"
     shutil.copy(Path("config/fleet.toml"), policy)
     monkeypatch.setattr(config, "_CONFIG_PATH", policy)
-    app = create_testing_app(settings=Settings(_env_file=None, run_environment="daytona"))
+    app = create_testing_app(settings=Settings(run_environment="daytona"))
 
     with TestClient(app, client=("127.0.0.1", 50000)) as client:
         read = client.get("/api/settings")
@@ -79,7 +79,7 @@ def test_settings_policy_is_loopback_only_and_revision_checked(monkeypatch, tmp_
             assert empty.status_code == 403, header
             assert empty.json()["code"] == "settings_local_only"
 
-    remote_app = create_testing_app(settings=Settings(_env_file=None, run_environment="daytona"))
+    remote_app = create_testing_app(settings=Settings(run_environment="daytona"))
     with TestClient(remote_app, client=("192.0.2.10", 50000)) as client:
         denied = client.get("/api/settings")
         assert denied.status_code == 403

--- a/tests/contracts/backend/test_skill_turn_contract.py
+++ b/tests/contracts/backend/test_skill_turn_contract.py
@@ -207,7 +207,7 @@ async def test_progressive_resource_requires_load_and_daytona_preparation_is_pro
     assert host.load_skill(str(selected.card.id), selected.card.version)["ok"] is True
     assert host.read_skill_resource(str(selected.card.id), resource_path, selected.card.version)["ok"] is True
 
-    settings = Settings(_env_file=None, run_environment="daytona")
+    settings = Settings(run_environment="daytona")
     environment = SimpleNamespace(attachment_sink=SimpleNamespace(volume_fs=SimpleNamespace(sandbox=object())))
     turn = _turn()
     prepared = await _LiveCapabilityPreparer(settings, catalog).prepare(
@@ -409,7 +409,7 @@ async def test_daytona_report_builder_workspace_selection_keeps_workspace_host_o
             SkillSelectionRef(workspace_files.card.id, workspace_files.card.version),
         )
     )
-    settings = Settings(_env_file=None, run_environment="daytona")
+    settings = Settings(run_environment="daytona")
     environment = SimpleNamespace(attachment_sink=SimpleNamespace(volume_fs=SimpleNamespace(sandbox=object())))
     prepared = await _LiveCapabilityPreparer(settings, catalog).prepare(
         turn,

--- a/tests/contracts/backend/test_workspace_files_api.py
+++ b/tests/contracts/backend/test_workspace_files_api.py
@@ -13,7 +13,6 @@ from fleet_rlm.config import Settings
 def test_independent_workspace_files_survive_requests_and_enforce_checksums(tmp_path: Path) -> None:
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             run_environment="daytona",
             data_root=str(tmp_path),
         )
@@ -67,7 +66,6 @@ def test_independent_workspace_files_survive_requests_and_enforce_checksums(tmp_
 def test_workspace_files_api_cannot_address_fleet_managed_namespaces(tmp_path: Path) -> None:
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             run_environment="daytona",
             data_root=str(tmp_path),
         )
@@ -91,7 +89,7 @@ def test_workspace_files_api_cannot_address_fleet_managed_namespaces(tmp_path: P
 
 
 def test_volume_tree_returns_relative_logical_paths(tmp_path: Path) -> None:
-    app = create_testing_app(settings=Settings(_env_file=None, run_environment="daytona", data_root=str(tmp_path)))
+    app = create_testing_app(settings=Settings(run_environment="daytona", data_root=str(tmp_path)))
     workspace_id = uuid5(NAMESPACE_URL, "fleet-rlm/local-workspace")
 
     import asyncio
@@ -110,7 +108,7 @@ def test_volume_tree_returns_relative_logical_paths(tmp_path: Path) -> None:
 
 
 def test_volume_tree_is_not_truncated_when_file_count_equals_requested_limit(tmp_path: Path) -> None:
-    app = create_testing_app(settings=Settings(_env_file=None, run_environment="daytona", data_root=str(tmp_path)))
+    app = create_testing_app(settings=Settings(run_environment="daytona", data_root=str(tmp_path)))
     workspace_id = uuid5(NAMESPACE_URL, "fleet-rlm/local-workspace")
 
     import asyncio
@@ -129,7 +127,6 @@ def test_volume_tree_is_not_truncated_when_file_count_equals_requested_limit(tmp
 def test_workspace_files_stat_reports_content_checksum_and_directory_entries(tmp_path: Path) -> None:
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             run_environment="daytona",
             data_root=str(tmp_path),
         )
@@ -172,7 +169,6 @@ def test_workspace_files_stat_reports_content_checksum_and_directory_entries(tmp
 def test_workspace_files_delete_and_patch_round_trip(tmp_path: Path) -> None:
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             run_environment="daytona",
             data_root=str(tmp_path),
         )
@@ -232,7 +228,6 @@ def test_workspace_files_delete_and_patch_round_trip(tmp_path: Path) -> None:
 def test_workspace_files_delete_maps_404_and_409(tmp_path: Path) -> None:
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             run_environment="daytona",
             data_root=str(tmp_path),
         )
@@ -269,7 +264,6 @@ def test_workspace_files_delete_maps_404_and_409(tmp_path: Path) -> None:
 def test_workspace_files_patch_maps_404_409_and_returns_fresh_checksum(tmp_path: Path) -> None:
     app = create_testing_app(
         settings=Settings(
-            _env_file=None,
             run_environment="daytona",
             data_root=str(tmp_path),
         )

--- a/tests/contracts/backend/test_workspace_turn_flow.py
+++ b/tests/contracts/backend/test_workspace_turn_flow.py
@@ -16,8 +16,8 @@ from fleet_rlm.files.memory_models import (
     WorkspaceMemoryEntryNotFoundError,
     WorkspaceMemoryListResult,
     WorkspaceMemoryReadResult,
+    format_workspace_memory_v3_record,
     parse_workspace_memory_lines,
-    reformat_workspace_memory_record,
 )
 from fleet_rlm.files.memory_tools import WorkspaceMemoryToolHost
 from fleet_rlm.files.workspace_models import (
@@ -109,11 +109,13 @@ class MemoryStore:
         target = targets[-1]
         entry = lines[target].entry
         assert entry is not None
-        record, _normalized = reformat_workspace_memory_record(
-            timestamp=entry.timestamp,
+        record = format_workspace_memory_v3_record(
+            key_learning,
+            entry.category if category is None else category,
             memory_id=entry.memory_id,
-            category=entry.category if category is None else category,
-            key_learning=key_learning,
+            created_at=entry.timestamp,
+            updated_at=entry.timestamp,
+            source="legacy_unknown",
         )
         lines[target] = parse_workspace_memory_lines(record)[0]
         self.content = "".join(line.raw for line in lines)

--- a/tests/live/backend/test_fleet_rlm_daytona_mvp.py
+++ b/tests/live/backend/test_fleet_rlm_daytona_mvp.py
@@ -553,7 +553,7 @@ async def _strict_cleanup(resources: Any, sandbox_ids: set[str], volume_name: st
         if not await _retry_cleanup(delete_sandbox):
             failures.append("sandbox")
     try:
-        resources.forget_sandboxes()
+        resources._sandbox_ids.clear()
     except Exception:
         failures.append("tracking")
 

--- a/tests/live/backend/test_phase1_daytona_stream.py
+++ b/tests/live/backend/test_phase1_daytona_stream.py
@@ -341,7 +341,7 @@ async def _strict_cleanup(resources: Any, volume_name: str) -> tuple[str, ...]:
         if not await _retry_cleanup(delete_sandbox):
             failures.append("sandbox")
     try:
-        resources.forget_sandboxes()
+        resources._sandbox_ids.clear()
     except Exception:
         failures.append("tracking")
 

--- a/tests/unit/backend/daytona/test_broker_source.py
+++ b/tests/unit/backend/daytona/test_broker_source.py
@@ -61,7 +61,7 @@ def test_submit_source_supports_typed_and_generic_signatures() -> None:
     assert "def SUBMIT(answer: str)" in typed
     assert "def SUBMIT(**kwargs)" in generic
     assert "FleetFinalOutputError" in typed
-    assert "_FINAL_OUTPUT_MARKER" in generic
+    assert "FINAL_OUTPUT_MARKER" in generic
 
 
 def test_remote_submit_setup_is_self_contained() -> None:

--- a/tests/unit/backend/daytona/test_child_deletion_absence.py
+++ b/tests/unit/backend/daytona/test_child_deletion_absence.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from fleet_rlm.daytona.recursive_child_runtime import _cleanup_child_runtime_async
+from fleet_rlm.daytona.recursive_child_cleanup import cleanup_child_runtime_async
 from fleet_rlm.daytona.session_manager import DaytonaAdmission, DaytonaAdmissionPermit
 from fleet_rlm.rlm.child_runtime import ChildRuntimeCleanupError
 
@@ -74,7 +74,7 @@ def _cleanup_coroutine(platform: _ScriptedPlatform, permit: DaytonaAdmissionPerm
         "confirm_timeout_s": 0.25,
     }
     kwargs.update(overrides)
-    return _cleanup_child_runtime_async(**kwargs)
+    return cleanup_child_runtime_async(**kwargs)
 
 
 def _sandbox() -> Any:

--- a/tests/unit/backend/daytona/test_recursive_child_runtime.py
+++ b/tests/unit/backend/daytona/test_recursive_child_runtime.py
@@ -14,10 +14,10 @@ from fleet_rlm.daytona import recursive_child_cleanup, recursive_child_runtime
 from fleet_rlm.daytona.provisioning import (
     recursive_child_volume_subpath,
     require_recursive_child_volume_subpath,
-    require_scoped_volume_subpath,
 )
 from fleet_rlm.daytona.recursive_child_lease import ChildRuntimeLease, ChildRuntimeLeaseState
 from fleet_rlm.daytona.session_manager import DaytonaAdmission
+from fleet_rlm.runtime.bindings import require_scoped_volume_subpath
 
 
 @dataclass

--- a/tests/unit/backend/daytona/test_sandbox_lease.py
+++ b/tests/unit/backend/daytona/test_sandbox_lease.py
@@ -9,11 +9,9 @@ from typing import Any
 import pytest
 
 from fleet_rlm.daytona.sandbox_lease import (
-    OwnedAcquisition,
     SandboxLease,
     SandboxLeasePolicy,
     SandboxLeaseReceipt,
-    acquire_owned_lease,
 )
 from fleet_rlm.daytona.session_manager import DaytonaAdmission, DaytonaAdmissionPermit
 
@@ -297,52 +295,6 @@ async def test_interpreter_failure_surfaces_on_receipt_without_raising() -> None
     assert receipt.interpreter.broker == "failed"
     assert "broker stop failed" in str(receipt.first_error)
     assert receipt.clean is False
-
-
-@pytest.mark.asyncio
-async def test_owned_acquisition_settles_and_closes_lease() -> None:
-    """Late acquisition ownership: adopted future results get closed, never stranded."""
-    import concurrent.futures
-    import threading
-
-    loop = asyncio.get_running_loop()
-    platform = _ScriptedPlatform([None])
-    _, permit = await _permit()
-
-    async def acquire() -> SandboxLease:
-        return SandboxLease(
-            kind="recursive_child",
-            sandbox=_Sandbox(id="sb-8"),
-            sandbox_id="sb-8",
-            platform=platform,
-            permit=permit,
-            policy=SandboxLeasePolicy(kind="recursive_child", confirm_poll_interval_s=0.01),
-        )
-
-    # The seam is thread-facing: post from a worker thread like DSPy workers do.
-    holder: dict[str, Any] = {}
-
-    def post() -> None:
-        holder["future"] = acquire_owned_lease(loop=loop, acquire=acquire)
-
-    thread = threading.Thread(target=post, daemon=True)
-    thread.start()
-    thread.join(timeout=5)
-    assert not thread.is_alive()
-    future: concurrent.futures.Future[SandboxLease] = holder["future"]
-    # result() blocks until the owner loop settles the coroutine; run it off-loop.
-    lease = await asyncio.to_thread(future.result, 5)
-
-    acquisition = OwnedAcquisition(loop=loop, close_lease=lambda _: asyncio.sleep(0))
-    assert acquisition.owned_futures == []
-    adopted: concurrent.futures.Future[Any] = concurrent.futures.Future()
-    adopted.set_result(lease)
-    # settle_adopted closes synchronously (lease.close uses asyncio.run); keep
-    # it on a worker thread like its production callers.
-    receipt = await asyncio.to_thread(acquisition.settle_adopted, adopted)
-    assert isinstance(receipt, SandboxLeaseReceipt)
-    assert receipt.provider.confirmed_absent is True
-    assert permit._released is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/backend/daytona/test_sandbox_spec.py
+++ b/tests/unit/backend/daytona/test_sandbox_spec.py
@@ -70,13 +70,10 @@ def test_dependency_import_names_map_distribution_to_module() -> None:
 
 def test_settings_require_snapshot_only_when_converted_to_daytona_spec() -> None:
     with pytest.raises(ValueError, match="FLEET_DAYTONA_SNAPSHOT"):
-        sandbox_spec_from_settings(Settings(_env_file=None))
-    assert (
-        sandbox_spec_from_settings(Settings(_env_file=None, daytona_snapshot="fleet-test-v1")).snapshot
-        == "fleet-test-v1"
-    )
+        sandbox_spec_from_settings(Settings())
+    assert sandbox_spec_from_settings(Settings(daytona_snapshot="fleet-test-v1")).snapshot == "fleet-test-v1"
     with pytest.raises(ValueError, match="FLEET_DAYTONA_SNAPSHOT"):
-        Settings(_env_file=None, daytona_snapshot="latest")
+        Settings(daytona_snapshot="latest")
 
 
 def test_snapshot_provenance_is_exact() -> None:

--- a/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
@@ -103,9 +103,6 @@ def test_compositions_cannot_overwrite_each_others_bridge_authority() -> None:
         assert dispatcher_b.service_loop() is None
 
 
-
-
-
 def test_fail_fast_when_called_from_the_servicing_event_loop() -> None:
     """The servicing loop thread can never block on its own bridge (RC-7 guard)."""
     dispatcher = SyncBridgeDispatcher()

--- a/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
@@ -14,8 +14,6 @@ from types import SimpleNamespace
 
 from fleet_rlm.daytona.dspy_sync_bridge import (
     SyncBridgeDispatcher,
-    bridge_service_loop,
-    set_bridge_service_loop,
     sync_sandbox,
     tombstone_sync_sandbox,
 )
@@ -90,9 +88,6 @@ def test_compositions_cannot_overwrite_each_others_bridge_authority() -> None:
         view_b = sync_sandbox(_sandbox(), server_b.loop, dispatcher_b)
         assert view_a._owner.service_loop() is server_a.loop
         assert view_b._owner.service_loop() is server_b.loop
-        # Legacy default dispatcher untouched by either composition.
-        assert bridge_service_loop() is None
-
         assert _call_from_worker_thread(view_a, "/a") == b"bytes:/a"
         assert _call_from_worker_thread(view_b, "/b") == b"bytes:/b"
 
@@ -108,19 +103,7 @@ def test_compositions_cannot_overwrite_each_others_bridge_authority() -> None:
         assert dispatcher_b.service_loop() is None
 
 
-def test_uninjected_view_uses_legacy_default_dispatcher_then_caller_loop() -> None:
-    """Views without injected dispatchers keep legacy resolution behavior."""
-    dispatcher = SyncBridgeDispatcher()
-    with _ServingLoop("fleet-test-default-loop") as server:
-        dispatcher.set_loop(server.loop)
-        # Legacy facade targets the process-default dispatcher, not this one.
-        assert bridge_service_loop() is None
-        set_bridge_service_loop(server.loop)
-        try:
-            view = sync_sandbox(_sandbox(), server.loop)
-            assert _call_from_worker_thread(view, "/legacy") == b"bytes:/legacy"
-        finally:
-            set_bridge_service_loop(None)
+
 
 
 def test_fail_fast_when_called_from_the_servicing_event_loop() -> None:

--- a/tests/unit/backend/daytona/test_sync_bridge_loop.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_loop.py
@@ -18,7 +18,6 @@ import asyncio
 import contextlib
 import threading
 import time
-from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from types import SimpleNamespace
 
@@ -26,8 +25,7 @@ import pytest
 
 from fleet_rlm.daytona import recursive_child_runtime
 from fleet_rlm.daytona.dspy_sync_bridge import (
-    bridge_service_loop,
-    set_bridge_service_loop,
+    SyncBridgeDispatcher,
     sync_sandbox,
 )
 from fleet_rlm.daytona.errors import DaytonaAdapterError
@@ -94,13 +92,14 @@ class _ServingLoop:
 
 
 @contextlib.contextmanager
-def _registered_service_loop(name: str = "fleet-test-service-loop") -> Iterator[_ServingLoop]:
+def _registered_service_loop(name: str = "fleet-test-service-loop"):
+    dispatcher = SyncBridgeDispatcher()
     with _ServingLoop(name) as server:
-        set_bridge_service_loop(server.loop)
+        dispatcher.set_loop(server.loop)
         try:
-            yield server
+            yield server, dispatcher
         finally:
-            set_bridge_service_loop(None)
+            dispatcher.clear_loop(server.loop)
 
 
 def _run_worker(body) -> threading.Thread:
@@ -108,8 +107,7 @@ def _run_worker(body) -> threading.Thread:
 
 
 def test_no_service_loop_falls_back_to_caller_captured_loop() -> None:
-    """Unregistered bridges capture the caller loop, matching legacy behavior."""
-    assert bridge_service_loop() is None
+    """Undispatched bridges capture the caller loop, matching legacy behavior."""
     fs = _AsyncFs()
     result_holder: dict[str, object] = {}
     holder: dict[str, object] = {}
@@ -132,23 +130,22 @@ def test_no_service_loop_falls_back_to_caller_captured_loop() -> None:
     assert fs.loops and all(loop is holder["loop"] for loop in fs.loops)
     assert fs.thread_names and all(name == worker_thread.name for name in fs.thread_names)
     assert elapsed < _DEADLOCK_BOUND_S
-    assert bridge_service_loop() is None
 
 
 def test_registered_service_loop_services_every_bridge() -> None:
-    """Bridges default to the registered service loop regardless of capture loop."""
+    """Dispatched bridges default to the registered service loop regardless of capture loop."""
     fs = _AsyncFs()
-    with _registered_service_loop() as server:
-        assert bridge_service_loop() is server.loop
+    with _registered_service_loop() as (server, dispatcher):
+        assert dispatcher.service_loop() is server.loop
         worker_loop_owner = _ServingLoop("fleet-test-worker-loop")
         with worker_loop_owner:
-            bridge_a = sync_sandbox(_sandbox(fs), worker_loop_owner.loop)
-            bridge_b = sync_sandbox(_sandbox(fs), server.loop)
+            bridge_a = sync_sandbox(_sandbox(fs), worker_loop_owner.loop, dispatcher)
+            bridge_b = sync_sandbox(_sandbox(fs), server.loop, dispatcher)
             assert bridge_a.fs.download_file("/a") == b"bytes:/a"
             assert bridge_b.process.code_run("print(1)").result == "ran:print(1)"
     assert fs.loops and all(loop is server.loop for loop in fs.loops)
     assert all(name == server.thread.name for name in fs.thread_names)
-    assert bridge_service_loop() is None
+    assert dispatcher.service_loop() is None
 
 
 def test_sync_bridge_completes_inside_nested_deadlock_shape() -> None:
@@ -161,12 +158,12 @@ def test_sync_bridge_completes_inside_nested_deadlock_shape() -> None:
     """
     fs = _AsyncFs()
     outcome: dict[str, object] = {}
-    with _registered_service_loop() as server:
+    with _registered_service_loop() as (server, dispatcher):
 
         async def worker() -> None:
             # Declared against THIS (later-parked) loop, like
             # _build_interpreter(loop=asyncio.get_running_loop()).
-            bridge = sync_sandbox(_sandbox(fs), asyncio.get_running_loop())
+            bridge = sync_sandbox(_sandbox(fs), asyncio.get_running_loop(), dispatcher)
 
             def fulfill(path: str) -> bytes:
                 return bridge.fs.download_file(path)
@@ -234,8 +231,8 @@ def test_legacy_caller_loop_shape_deadlocks() -> None:
 def test_sequential_and_concurrent_calls_share_one_service_loop() -> None:
     """Sequential reuse and concurrent first use all hit the one service loop."""
     fs = _AsyncFs()
-    with _registered_service_loop() as server:
-        bridge = sync_sandbox(_sandbox(fs), asyncio.new_event_loop())
+    with _registered_service_loop() as (server, dispatcher):
+        bridge = sync_sandbox(_sandbox(fs), asyncio.new_event_loop(), dispatcher)
         results: list[bytes] = []
         results_lock = threading.Lock()
 
@@ -258,8 +255,8 @@ def test_sequential_and_concurrent_calls_share_one_service_loop() -> None:
 
 def test_close_fails_calls_typed_fast_and_start_recovers() -> None:
     """close() tombstones the bridge (typed-fast); start() reopens it."""
-    with _registered_service_loop():
-        bridge = sync_sandbox(_sandbox(), asyncio.new_event_loop())
+    with _registered_service_loop() as (_server, dispatcher):
+        bridge = sync_sandbox(_sandbox(), asyncio.new_event_loop(), dispatcher)
         assert bridge.fs.download_file("/warm") == b"bytes:/warm"
         bridge.close()
         started = time.perf_counter()
@@ -276,10 +273,11 @@ def test_close_fails_calls_typed_fast_and_start_recovers() -> None:
 
 def test_stopped_service_loop_fails_typed_fast_and_reregistration_recovers() -> None:
     """A dead service loop raises typed-fast; re-registering restores service."""
+    dispatcher = SyncBridgeDispatcher()
     server = _ServingLoop("fleet-test-dead-loop")
     with server:
-        set_bridge_service_loop(server.loop)
-        bridge = sync_sandbox(_sandbox(), asyncio.new_event_loop())
+        dispatcher.set_loop(server.loop)
+        bridge = sync_sandbox(_sandbox(), asyncio.new_event_loop(), dispatcher)
         assert bridge.fs.download_file("/warm") == b"bytes:/warm"
         # Stop serving WITHOUT closing the loop: posts queue but never run.
         server.stop(close=False)
@@ -290,17 +288,17 @@ def test_stopped_service_loop_fails_typed_fast_and_reregistration_recovers() -> 
         assert time.perf_counter() - started < _DEADLOCK_BOUND_S + 2 * _POLL_BOUND_S
         assert exc_info.value.cause_type == "InterpreterBridgeError"
         server.loop.close()
-    set_bridge_service_loop(None)
+    dispatcher.clear_loop(server.loop)
 
-    with _registered_service_loop():
-        bridge2 = sync_sandbox(_sandbox(), asyncio.new_event_loop())
+    with _registered_service_loop() as (_server2, dispatcher2):
+        bridge2 = sync_sandbox(_sandbox(), asyncio.new_event_loop(), dispatcher2)
         assert bridge2.fs.download_file("/recover") == b"bytes:/recover"
 
 
 def test_call_from_service_loop_fails_fast() -> None:
     """A sync bridge call issued from the service loop itself fails fast."""
-    with _registered_service_loop() as server:
-        bridge = sync_sandbox(_sandbox(), asyncio.new_event_loop())
+    with _registered_service_loop() as (server, dispatcher):
+        bridge = sync_sandbox(_sandbox(), asyncio.new_event_loop(), dispatcher)
 
         async def host_side() -> object:
             return bridge.fs.download_file("/x")
@@ -315,9 +313,9 @@ def test_interpreter_shutdown_tombstones_bridge_calls_only() -> None:
     """shutdown() tombstones its bridge while the shared service loop survives."""
     guard_loop = asyncio.new_event_loop()
     try:
-        with _registered_service_loop() as server:
-            backend = sandbox_backend(_sandbox(), loop=guard_loop)
-            other = sync_sandbox(_sandbox(), guard_loop)
+        with _registered_service_loop() as (server, dispatcher):
+            backend = sandbox_backend(_sandbox(), loop=guard_loop, dispatcher=dispatcher)
+            other = sync_sandbox(_sandbox(), guard_loop, dispatcher)
             interpreter = DaytonaCodeInterpreter(backend=backend)
             interpreter.start()
             assert backend.sandbox.fs.download_file("/warm") == b"bytes:/warm"

--- a/tests/unit/backend/daytona/test_workspace_memory_diagnostics.py
+++ b/tests/unit/backend/daytona/test_workspace_memory_diagnostics.py
@@ -193,7 +193,7 @@ def test_provider_outage_is_classified_and_still_fail_soft(
 def _capture(store) -> BaseException:
     try:
         store.read_tail(byte_budget=128)
-    except BaseException as exc:
+    except Exception as exc:
         return exc
     raise AssertionError("expected read_tail to fail")
 

--- a/tests/unit/backend/daytona/test_workspace_memory_diagnostics.py
+++ b/tests/unit/backend/daytona/test_workspace_memory_diagnostics.py
@@ -1,0 +1,409 @@
+"""Workspace Memory fail-soft degradation classification + bounded diagnostics (P31).
+
+Degraded optional Memory context must never block a Run, but every fallback is
+now classified and emitted as one bounded, sanitized diagnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import redirect_stdout, suppress
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from fleet_rlm.daytona import workspace_memory
+from fleet_rlm.daytona.memory_diagnostics import (
+    MemoryFailureCategory,
+    MemoryInvariantError,
+    MemoryPayloadError,
+    classify_memory_failure,
+    record_memory_degradation,
+)
+from fleet_rlm.files.memory_models import (
+    WORKSPACE_MEMORY_HEADER,
+    WorkspaceMemoryListResult,
+    WorkspaceMemoryReadResult,
+    WorkspaceMemoryStoreUnavailableError,
+)
+from fleet_rlm.files.volume_paths import VolumePaths
+
+HEADER = WORKSPACE_MEMORY_HEADER + "\n"
+
+
+class LocalProcess:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def code_run(self, code: str, **_kwargs):
+        self.calls.append(code)
+        output = StringIO()
+        with redirect_stdout(output), suppress(SystemExit):
+            exec(code, {})
+        return SimpleNamespace(exit_code=0, result=output.getvalue().strip())
+
+
+def _store(tmp_path: Path, *, max_bytes: int = 262_144):
+    root = tmp_path / "volume"
+    root.mkdir()
+    store = workspace_memory.DaytonaWorkspaceMemoryStore(
+        SimpleNamespace(process=LocalProcess()),
+        volume_paths=VolumePaths.from_mount(str(root)),
+        max_upload_bytes=max_bytes,
+    )
+    return store, root
+
+
+def _write_store_file(root: Path, content: str) -> Path:
+    memory_dir = root / "memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    target = memory_dir / "MEMORIES.md"
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+@pytest.fixture
+def annotated(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Capture tracing annotations without any active Turn span."""
+    captured: list[dict[str, object]] = []
+    from fleet_rlm.observability import turn_tracing
+
+    monkeypatch.setattr(turn_tracing, "annotate_turn_attributes", lambda attrs: captured.append(dict(attrs)))
+    return captured
+
+
+def _degraded_warnings(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        r for r in caplog.records if r.name == "fleet_rlm.daytona.memory_diagnostics" and r.levelno >= logging.WARNING
+    ]
+
+
+# -- classification at the adapter seam (T1) ---------------------------------
+
+
+def test_normalization_failure_degrades_to_recency_digest_with_diagnostic(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    annotated: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, root = _store(tmp_path)
+    secret_learning = "TOPSECRET normalizable learning should never appear in telemetry"
+    _write_store_file(root, HEADER + f"- [2026-07-27T11:14:05Z] **General** <!-- id:aaaa0001 -->: {secret_learning}\n")
+
+    import fleet_rlm.files.memory_tools as memory_tools
+
+    def explode(_query: object) -> str:
+        raise memory_tools.MemoryToolError("invalid_entry", "Workspace Memory entry is invalid")
+
+    monkeypatch.setattr(memory_tools, "normalize_memory_search_query", explode)
+    with caplog.at_level(logging.WARNING):
+        digest = workspace_memory.read_workspace_memory_injection_digest(store, request="anything at all")
+
+    # Same visible fallback as before: the complete recency-only digest.
+    assert secret_learning in digest
+    warnings = _degraded_warnings(caplog)
+    assert len(warnings) == 1
+    assert "category=normalization" in warnings[0].getMessage()
+    assert "operation=normalize_query" in warnings[0].getMessage()
+    assert "outcome=recency_only_digest" in warnings[0].getMessage()
+    assert secret_learning not in warnings[0].getMessage()
+    assert len(annotated) == 1
+    assert annotated[0]["fleet.memory_degradation.category"] == "normalization"
+    assert secret_learning not in str(annotated[0])
+
+
+def test_relevance_search_failure_falls_back_with_diagnostic(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    annotated: list[dict[str, object]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store, root = _store(tmp_path)
+    _write_store_file(root, HEADER + "- [2026-07-27T11:14:05Z] **General** <!-- id:aaaa0001 -->: durable lesson\n")
+
+    import fleet_rlm.files.memory_tools as memory_tools
+
+    def explode(_store: object, *, normalized_query: str) -> object:
+        del normalized_query
+        raise memory_tools.MemoryToolError("invalid_entry", "Workspace Memory entry is invalid")
+
+    monkeypatch.setattr(memory_tools, "search_workspace_memory_entries", explode)
+    with caplog.at_level(logging.WARNING):
+        degraded = workspace_memory.read_workspace_memory_injection_digest(store, request="durable")
+
+    assert "durable lesson" in degraded
+    warnings = _degraded_warnings(caplog)
+    assert [r.getMessage() for r in warnings] == [warnings[0].getMessage()]
+    assert len(warnings) == 1
+    assert "category=search_failure" in warnings[0].getMessage()
+    assert "operation=relevance_search" in warnings[0].getMessage()
+    assert len(annotated) == 1
+    assert annotated[0]["fleet.memory_degradation.category"] == "search_failure"
+
+
+def test_unexpected_search_defect_is_classified_explicitly(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store, root = _store(tmp_path)
+    _write_store_file(root, HEADER + "- [2026-07-27T11:14:05Z] **General** <!-- id:aaaa0001 -->: durable lesson\n")
+
+    import fleet_rlm.files.memory_tools as memory_tools
+
+    def explode(_store: object, *, normalized_query: str) -> object:
+        del normalized_query
+        raise RuntimeError("boom internal defect")
+
+    monkeypatch.setattr(memory_tools, "search_workspace_memory_entries", explode)
+    with caplog.at_level(logging.WARNING):
+        workspace_memory.read_workspace_memory_injection_digest(store, request="durable")
+
+    warnings = _degraded_warnings(caplog)
+    assert len(warnings) == 1
+    assert "category=unexpected_internal" in warnings[0].getMessage()
+    assert "cause_type=RuntimeError" in warnings[0].getMessage()
+
+
+def test_provider_outage_is_classified_and_still_fail_soft(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from fleet_rlm.daytona.workspace_agent import WorkspaceAgentStorageError
+
+    store, _root = _store(tmp_path)
+
+    def down(*_args, **_kwargs):
+        raise WorkspaceAgentStorageError("simulated outage; do not echo payloads")
+
+    monkeypatch.setattr(workspace_memory, "run_workspace_agent", down)
+    with caplog.at_level(logging.WARNING), pytest.raises(WorkspaceMemoryStoreUnavailableError):
+        workspace_memory.read_workspace_memory_injection_digest(store, request="anything")
+
+    # The digest seam still raises to its caller; classification is attached
+    # to the exception chain for the outer fail-soft seam to emit.
+    exc = _capture(store)
+    assert isinstance(exc, WorkspaceMemoryStoreUnavailableError)
+    category, cause_type = classify_memory_failure(exc, operation="injection_digest")
+    assert category == MemoryFailureCategory.PROVIDER_UNAVAILABLE
+    assert cause_type == "WorkspaceAgentStorageError"
+    assert "simulated outage" not in " ".join(r.getMessage() for r in caplog.records)
+
+
+def _capture(store) -> BaseException:
+    try:
+        store.read_tail(byte_budget=128)
+    except BaseException as exc:
+        return exc
+    raise AssertionError("expected read_tail to fail")
+
+
+def test_corrupt_payload_is_distinct_from_provider_outage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store, _root = _store(tmp_path)
+
+    def corrupt(*_args, **_kwargs):
+        raise MemoryPayloadError("invalid memory response")
+
+    monkeypatch.setattr(store, "_checked_tail_payload", corrupt)
+    exc = _capture(store)
+    assert isinstance(exc, WorkspaceMemoryStoreUnavailableError)
+    category, cause_type = classify_memory_failure(exc, operation="injection_digest")
+    assert category == MemoryFailureCategory.CORRUPT_RECORD_SET
+    assert cause_type == "MemoryPayloadError"
+
+
+def test_unexpected_read_defect_is_unexpected_internal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store, _root = _store(tmp_path)
+
+    def boom(*_args, **_kwargs):
+        raise TypeError("programming defect canary")
+
+    monkeypatch.setattr(store, "_checked_tail_payload", boom)
+    exc = _capture(store)
+    category, cause_type = classify_memory_failure(exc, operation="injection_digest")
+    assert category == MemoryFailureCategory.UNEXPECTED_INTERNAL
+    assert cause_type == "TypeError"
+
+
+def test_duplicate_stable_ids_fail_closed_with_invariant_category(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, annotated: list[dict[str, object]]
+) -> None:
+    store, root = _store(tmp_path)
+    duplicate_rows = (
+        "- [2026-07-27T11:14:05Z] **General** <!-- id:aaaa0001 -->: first copy\n"
+        "- [2026-07-27T11:15:05Z] **General** <!-- id:aaaa0001 -->: second copy\n"
+    )
+    _write_store_file(root, HEADER + duplicate_rows)
+
+    # Mutation/list invariants remain strict: list_entries still fails closed.
+    with pytest.raises(MemoryInvariantError) as excinfo:
+        store.list_entries(limit=10)
+    assert isinstance(excinfo.value, WorkspaceMemoryStoreUnavailableError)
+
+    # The same store fed to the Turn digest degrades to the recency-only
+    # fallback with one bounded invariant-violation diagnostic.
+    with caplog.at_level(logging.WARNING):
+        digest = workspace_memory.read_workspace_memory_injection_digest(store, request="copy")
+
+    # Tolerant read keeps the first (graph-valid) row; the forged duplicate
+    # stays a malformed-tolerant skip exactly as before P31.
+    assert "first copy" in digest
+    assert "second copy" not in digest
+    warnings = _degraded_warnings(caplog)
+    assert len(warnings) == 1
+    assert "category=invariant_violation" in warnings[0].getMessage()
+    assert "operation=relevance_search" in warnings[0].getMessage()
+    assert "aaaa0001" not in warnings[0].getMessage()
+    assert annotated[0]["fleet.memory_degradation.category"] == "invariant_violation"
+
+
+def test_legacy_migration_failure_is_its_own_category(tmp_path: Path) -> None:
+    root = tmp_path / "volume"
+    root.mkdir()
+    # a directory named MEMORIES.md is a legacy-store shape failure
+    (root / "MEMORIES.md").mkdir()
+    store = workspace_memory.DaytonaWorkspaceMemoryStore(
+        SimpleNamespace(process=LocalProcess()),
+        volume_paths=VolumePaths.from_mount(str(root)),
+        max_upload_bytes=262_144,
+    )
+
+    exc = _capture(store)
+    assert isinstance(exc, WorkspaceMemoryStoreUnavailableError)
+    category, cause_type = classify_memory_failure(exc, operation="injection_digest")
+    assert category == MemoryFailureCategory.LEGACY_MIGRATION
+    assert cause_type == "MemoryMigrationError"
+
+
+# -- emission contract (T2) ----------------------------------------------------
+
+
+def test_successful_preparation_emits_no_diagnostics(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, annotated: list[dict[str, object]]
+) -> None:
+    store, root = _store(tmp_path)
+    _write_store_file(root, HEADER + "- [2026-07-27T11:14:05Z] **General** <!-- id:aaaa0001 -->: durable lesson\n")
+
+    with caplog.at_level(logging.WARNING):
+        digest = workspace_memory.read_workspace_memory_injection_digest(store, request="durable")
+
+    assert "durable lesson" in digest
+    assert _degraded_warnings(caplog) == []
+    assert annotated == []
+
+
+def test_recency_fallback_without_matches_is_not_a_degradation(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, annotated: list[dict[str, object]]
+) -> None:
+    store, root = _store(tmp_path)
+    _write_store_file(root, HEADER + "- [2026-07-27T11:14:05Z] **General** <!-- id:aaaa0001 -->: durable lesson\n")
+
+    with caplog.at_level(logging.WARNING):
+        digest = workspace_memory.read_workspace_memory_injection_digest(store, request="zzz-no-lexical-overlap")
+
+    assert "durable lesson" in digest
+    assert _degraded_warnings(caplog) == []
+    assert annotated == []
+
+
+def test_diagnostics_survive_tracing_and_logging_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fleet_rlm.observability import turn_tracing
+
+    def explode(attrs: dict[str, object]) -> None:
+        del attrs
+        raise RuntimeError("tracing sink down")
+
+    monkeypatch.setattr(turn_tracing, "annotate_turn_attributes", explode)
+    degradation = record_memory_degradation(
+        WorkspaceMemoryStoreUnavailableError("outage"),
+        operation="injection_digest",
+        fallback_outcome="no_memory_injection",
+    )
+    assert degradation.category == MemoryFailureCategory.PROVIDER_UNAVAILABLE
+    assert degradation.fallback_outcome == "no_memory_injection"
+    assert degradation.runtime == "daytona"
+
+
+def _chained_store_error(cause: BaseException) -> WorkspaceMemoryStoreUnavailableError:
+    try:
+        try:
+            raise cause
+        except type(cause):
+            raise WorkspaceMemoryStoreUnavailableError() from cause
+    except WorkspaceMemoryStoreUnavailableError as exc:
+        return exc
+
+
+def test_emitted_fields_are_bounded_and_sanitized(annotated: list[dict[str, object]]) -> None:
+    record_memory_degradation(
+        _chained_store_error(OSError("provider said: hunter2 password")),
+        operation="injection_digest",
+        fallback_outcome="no_memory_injection",
+    )
+    assert len(annotated) == 1
+    attrs = annotated[0]
+    assert set(attrs) == {
+        "fleet.memory_degradation.category",
+        "fleet.memory_degradation.operation",
+        "fleet.memory_degradation.runtime",
+        "fleet.memory_degradation.cause_type",
+        "fleet.memory_degradation.fallback_outcome",
+    }
+    assert "hunter2" not in str(attrs)
+    assert all(len(str(v)) <= 32 for v in attrs.values())
+
+
+@pytest.mark.asyncio
+async def test_turn_preparation_seam_degrades_silently_but_observably(caplog: pytest.LogCaptureFixture) -> None:
+    from fleet_rlm.daytona.run_environment import _prepare_memory_digest
+
+    class EmptyStore:
+        def read_tail(self, *, byte_budget: int) -> WorkspaceMemoryReadResult:
+            return WorkspaceMemoryReadResult(
+                content="", truncated=False, bytes_returned=0, byte_budget=byte_budget, total_bytes=0, warnings=0
+            )
+
+        def list_entries(self, **kwargs: object) -> WorkspaceMemoryListResult:
+            del kwargs
+            return WorkspaceMemoryListResult(entries=(), truncated=False, next_cursor=None, warnings=0)
+
+    class FailingCatalogStore(EmptyStore):
+        def list_entries(self, **kwargs: object) -> WorkspaceMemoryListResult:
+            del kwargs
+            raise WorkspaceMemoryStoreUnavailableError("catalog down")
+
+    with caplog.at_level(logging.WARNING):
+        # Healthy path: recency-only digest, no diagnostics.
+        assert await _prepare_memory_digest(EmptyStore(), request="nothing persisted") == ""
+        assert _degraded_warnings(caplog) == []
+
+        # Failing relevance search: same visible behavior as before (single
+        # fallback digest) plus exactly one classified diagnostic.
+        digest = await _prepare_memory_digest(FailingCatalogStore(), request="persisted durable memory")
+        assert digest == ""
+        warnings = _degraded_warnings(caplog)
+        assert len(warnings) == 1
+        assert "category=provider_unavailable" in warnings[0].getMessage()
+        assert "operation=relevance_search" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_turn_preparation_outer_seam_classes_digest_failures(
+    caplog: pytest.LogCaptureFixture, annotated: list[dict[str, object]]
+) -> None:
+    from fleet_rlm.daytona.run_environment import _prepare_memory_digest
+
+    class CorruptStore:
+        def read_tail(self, *, byte_budget: int) -> WorkspaceMemoryReadResult:
+            del byte_budget
+            raise WorkspaceMemoryStoreUnavailableError() from MemoryPayloadError("invalid memory response")
+
+    with caplog.at_level(logging.WARNING):
+        assert await _prepare_memory_digest(CorruptStore(), request="anything") == ""
+
+    warnings = _degraded_warnings(caplog)
+    assert len(warnings) == 1
+    assert "category=corrupt_record_set" in warnings[0].getMessage()
+    assert "operation=injection_digest" in warnings[0].getMessage()
+    assert "outcome=no_memory_injection" in warnings[0].getMessage()
+    assert annotated[0]["fleet.memory_degradation.category"] == "corrupt_record_set"

--- a/tests/unit/backend/files/test_memory_candidates.py
+++ b/tests/unit/backend/files/test_memory_candidates.py
@@ -499,3 +499,37 @@ def test_candidate_promotion_preserves_append_time_conflict_and_continues() -> N
     assert result.dropped_count == 1
     assert result.reasons == ("supersedes_not_active",)
     assert len(store.appended) == 1
+
+
+def test_intent_builder_and_post_commit_promotion_mint_identical_records() -> None:
+    """Both promotion paths share one validation + record-minting pipeline (P33 fold)."""
+    from datetime import UTC, datetime
+
+    from fleet_rlm.files.memory_candidates import MemoryCandidate, build_memory_promotion_intents
+
+    def clock() -> datetime:
+        return datetime(2026, 8, 17, 12, 0, 0, tzinfo=UTC)
+
+    candidate = MemoryCandidate(
+        candidate_id="cand00000001",
+        category="Project",
+        learning="shared minting stays byte-identical",
+        byte_size=len(b"shared minting stays byte-identical"),
+    )
+    intents = build_memory_promotion_intents(
+        run_id=uuid4(),
+        candidates=(candidate,),
+        allowed_categories=("Project",),
+        clock=clock,
+    )
+    store = _PromotionStore()
+    result = promote_memory_candidates(
+        store=store,
+        candidates=(candidate,),
+        allowed_categories=("Project",),
+        clock=clock,
+    )
+
+    assert result.promoted_count == 1
+    assert store.appended == [intents[0].record_text]
+    assert intents[0].memory_id in store.appended[0]

--- a/tests/unit/backend/files/test_memory_models.py
+++ b/tests/unit/backend/files/test_memory_models.py
@@ -1,4 +1,4 @@
-"""Workspace Memory model invariants: v1+v2 records, tolerant reads, strict writes."""
+"""Workspace Memory model invariants: v1/v2/v3 records, tolerant reads, strict record validation."""
 
 from __future__ import annotations
 
@@ -8,19 +8,15 @@ import pytest
 
 from fleet_rlm.files.memory_models import (
     WORKSPACE_MEMORY_HEADER,
-    WORKSPACE_MEMORY_INJECTION_TAIL_BYTES,
     WORKSPACE_MEMORY_MAX_WARNINGS,
     WorkspaceMemoryEntryNotFoundError,
     WorkspaceMemoryIdError,
     WorkspaceMemoryRecordError,
-    build_workspace_memory_digest,
     count_workspace_memory_warnings,
     format_workspace_memory_record,
     format_workspace_memory_v3_record,
     normalize_workspace_memory_id,
     parse_workspace_memory_lines,
-    reformat_workspace_memory_record,
-    validate_workspace_memory_content,
     validate_workspace_memory_record,
     workspace_memory_record_id,
 )
@@ -68,22 +64,6 @@ def test_v2_records_require_an_exactly_8_lowercase_hex_id(record: str) -> None:
         validate_workspace_memory_record(record)
 
 
-def test_strict_write_validation_rejects_malformed_lines_and_stray_headers() -> None:
-    validate_workspace_memory_content(V1_RECORD + V2_RECORD)
-    validate_workspace_memory_content(f"{WORKSPACE_MEMORY_HEADER}\n" + V1_RECORD + V2_RECORD)
-    validate_workspace_memory_content("")
-
-    with pytest.raises(WorkspaceMemoryRecordError):
-        validate_workspace_memory_content("garbage\n" + V1_RECORD)
-    with pytest.raises(WorkspaceMemoryRecordError):
-        # header exempt only as the very first line
-        validate_workspace_memory_content(V1_RECORD + f"{WORKSPACE_MEMORY_HEADER}\n")
-    with pytest.raises(WorkspaceMemoryRecordError):
-        validate_workspace_memory_content("\n")  # blank lines are not writable
-    with pytest.raises(WorkspaceMemoryRecordError):
-        validate_workspace_memory_content("- [2026-07-27T11:14:05Z] **General**: " + "x" * 4_096 + "\n")
-
-
 def test_tolerant_parse_skips_malformed_lines_with_bounded_warnings() -> None:
     content = (
         f"{WORKSPACE_MEMORY_HEADER}\n"
@@ -118,86 +98,6 @@ def test_tolerant_parse_skips_malformed_lines_with_bounded_warnings() -> None:
 def test_warning_count_is_bounded() -> None:
     lines = parse_workspace_memory_lines("bad\n" * (WORKSPACE_MEMORY_MAX_WARNINGS + 50))
     assert count_workspace_memory_warnings(lines) == WORKSPACE_MEMORY_MAX_WARNINGS
-
-
-def test_digest_drops_header_and_malformed_lines_and_respects_the_byte_budget() -> None:
-    digest, warnings = build_workspace_memory_digest("")
-    assert digest == "" and warnings == 0
-
-    heavy = "".join(
-        f"- [2026-07-27T11:14:{second:02d}Z] **General** <!-- id:{second:08x} -->: {'y' * 700}\n"
-        for second in range(10)
-    )
-    digest, warnings = build_workspace_memory_digest(f"{WORKSPACE_MEMORY_HEADER}\n" + heavy + "garbage\n")
-    assert warnings == 1
-    assert digest
-    assert len(digest.encode("utf-8")) <= WORKSPACE_MEMORY_INJECTION_TAIL_BYTES
-    # tail trim keeps only whole record lines
-    assert set(digest.splitlines()[0][:2]) <= set("- ")
-    for line in digest.splitlines(keepends=True):
-        validate_workspace_memory_record(line)
-
-
-def test_digest_keeps_newest_record_when_tail_starts_at_record_boundary() -> None:
-    prefix = "- [2026-07-27T11:14:06Z] **General** <!-- id:bbbbbbbb -->: "
-    learning_length = WORKSPACE_MEMORY_INJECTION_TAIL_BYTES - len(prefix.encode("utf-8")) - 1
-    newest = prefix + ("x" * learning_length) + "\n"
-    previous = "- [2026-07-27T11:14:05Z] **General** <!-- id:aaaaaaaa -->: previous\n"
-
-    validate_workspace_memory_record(newest)
-    digest, warnings = build_workspace_memory_digest(previous + newest)
-
-    assert digest == newest
-    assert warnings == 0
-
-
-def test_reformat_preserves_identity_and_shape_on_edit() -> None:
-    record, category = reformat_workspace_memory_record(
-        timestamp="2026-07-27T11:14:05Z",
-        memory_id="d2c1b7a1",
-        category="Preference",
-        key_learning="  prefers   polars ",
-    )
-    assert record == (
-        "- [2026-07-27T11:14:05Z] **Preference** <-- id:d2c1b7a1 -->: prefers polars\n".replace(
-            " <-- id:d2c1b7a1 -->", " <!-- id:d2c1b7a1 source:legacy_unknown updated:2026-07-27T11:14:05Z -->"
-        )
-    )
-    assert category == "Preference"
-
-    upgraded_record, _ = reformat_workspace_memory_record(
-        timestamp="2026-07-27T11:14:05Z",
-        memory_id=workspace_memory_record_id("2026-07-27T11:14:05Z", "General", "still legacy"),
-        category="General",
-        key_learning="still legacy",
-    )
-    assert upgraded_record == (
-        "- [2026-07-27T11:14:05Z] **General** <!-- id:"
-        + workspace_memory_record_id("2026-07-27T11:14:05Z", "General", "still legacy")
-        + " source:legacy_unknown updated:2026-07-27T11:14:05Z -->: still legacy\n"
-    )
-
-    with pytest.raises(WorkspaceMemoryRecordError):
-        reformat_workspace_memory_record(
-            timestamp="not-a-timestamp",
-            memory_id="d2c1b7a1",
-            category="General",
-            key_learning="x",
-        )
-    with pytest.raises(WorkspaceMemoryRecordError):
-        reformat_workspace_memory_record(
-            timestamp="2026-07-27T11:14:05Z",
-            memory_id="D2C1B7A1",
-            category="General",
-            key_learning="x",
-        )
-    with pytest.raises(WorkspaceMemoryRecordError):
-        reformat_workspace_memory_record(
-            timestamp="2026-07-27T11:14:05Z",
-            memory_id="d2c1b7a1",
-            category="General",
-            key_learning="   ",
-        )
 
 
 def test_id_normalization_shape() -> None:
@@ -238,7 +138,7 @@ def test_v3_records_parse_provenance_and_legacy_records_project_unknown_fallback
     assert provenance.supersedes_id == old_id
     assert provenance.memory_id == "dddd0004"
     validate_workspace_memory_record(updated)
-    validate_workspace_memory_content(V1_RECORD + V2_RECORD + target + updated)
+    assert not any(line.malformed for line in lines)
 
 
 @pytest.mark.parametrize(
@@ -300,7 +200,7 @@ def test_supersession_graph_marks_active_state_and_rejects_invalid_geometry() ->
     assert entries[0].superseded_by_id == "bbbb0002"
     assert entries[1].superseded_by_id == "cccc0003"
     assert entries[2].superseded_by_id is None
-    validate_workspace_memory_content(first_record + second_record + third_record)
+    assert not any(line.malformed for line in lines)
 
     for invalid_content in (
         second_record,  # missing target
@@ -308,5 +208,4 @@ def test_supersession_graph_marks_active_state_and_rejects_invalid_geometry() ->
         first_record + second_record + _v3("dddd0004", "duplicate target", supersedes_id="aaaa0001"),
         first_record + _v3("aaaa0001", "duplicate record id"),
     ):
-        with pytest.raises(WorkspaceMemoryRecordError):
-            validate_workspace_memory_content(invalid_content)
+        assert any(line.malformed for line in parse_workspace_memory_lines(invalid_content))

--- a/tests/unit/backend/files/test_memory_tools.py
+++ b/tests/unit/backend/files/test_memory_tools.py
@@ -95,7 +95,7 @@ class FakeMemoryStore:
         if not matches:
             raise WorkspaceMemoryEntryNotFoundError(memory_id)
         entry = matches[-1]
-        record, _normalized = _reformat(entry, key_learning, category)
+        record = _reformat(entry, key_learning, category)
         updated_entry = _parsed(record)
         self.entries = tuple(updated_entry if item is entry else item for item in self.entries)
         return record
@@ -107,14 +107,16 @@ def _parsed(record: str) -> WorkspaceMemoryEntry:
     return parse_workspace_memory_record(record)
 
 
-def _reformat(entry: WorkspaceMemoryEntry, key_learning: str, category: str | None) -> tuple[str, str]:
-    from fleet_rlm.files.memory_models import reformat_workspace_memory_record
+def _reformat(entry: WorkspaceMemoryEntry, key_learning: str, category: str | None) -> str:
+    from fleet_rlm.files.memory_models import format_workspace_memory_v3_record
 
-    return reformat_workspace_memory_record(
-        timestamp=entry.timestamp,
+    return format_workspace_memory_v3_record(
+        key_learning,
+        entry.category if category is None else category,
         memory_id=entry.memory_id,
-        category=entry.category if category is None else category,
-        key_learning=key_learning,
+        created_at=entry.timestamp,
+        updated_at=entry.timestamp,
+        source="legacy_unknown",
     )
 
 

--- a/tests/unit/backend/files/test_project_paths.py
+++ b/tests/unit/backend/files/test_project_paths.py
@@ -17,7 +17,6 @@ def test_projects_root_is_a_volume_sibling() -> None:
     paths = VolumePaths.from_mount()
 
     assert paths.projects_root() == PurePosixPath("/home/daytona/fleet/projects")
-    assert paths.projects == paths.projects_root()
     assert paths.project_dir("fleet-rlm") == PurePosixPath("/home/daytona/fleet/projects/fleet-rlm")
 
 

--- a/tests/unit/backend/files/test_workspace_fs.py
+++ b/tests/unit/backend/files/test_workspace_fs.py
@@ -293,7 +293,8 @@ def test_write_creates_parents_and_honors_overwrite(tmp_path: Path) -> None:
 
     assert created.path == "notes/decision.md"
     assert created.byte_size == 5
-    assert workspace.read_text("notes/decision.md", max_bytes=32) == "first"
+    page = workspace.read_text_page("notes/decision.md", cursor=None, max_chars=32, max_bytes=32)
+    assert page.content == "first" and page.eof is True
     with pytest.raises(FileExistsError):
         workspace.write_text("notes/decision.md", "second", overwrite=False)
     replaced = workspace.write_text("notes/decision.md", "second", overwrite=True)
@@ -700,11 +701,11 @@ def test_enforces_write_and_read_byte_bounds_and_strict_utf8(tmp_path: Path) -> 
     path = root / "invalid.txt"
     path.write_bytes(b"\xff")
     with pytest.raises(ValueError, match="UTF-8"):
-        workspace.read_text("invalid.txt", max_bytes=4)
+        workspace.read_text_page("invalid.txt", cursor=None, max_chars=4, max_bytes=4)
 
     path.write_bytes(b"12345")
     with pytest.raises(ValueError, match="read bound"):
-        workspace.read_text("invalid.txt", max_bytes=4)
+        workspace.read_text_page("invalid.txt", cursor=None, max_chars=4, max_bytes=4)
 
 
 def test_rejects_directories_as_text_and_files_as_list_roots(tmp_path: Path) -> None:
@@ -713,7 +714,7 @@ def test_rejects_directories_as_text_and_files_as_list_roots(tmp_path: Path) -> 
     (root / "note.txt").write_text("hello", encoding="utf-8")
 
     with pytest.raises(IsADirectoryError):
-        workspace.read_text("notes", max_bytes=32)
+        workspace.read_text_page("notes", cursor=None, max_chars=32, max_bytes=32)
     with pytest.raises(NotADirectoryError):
         workspace.list_entries("note.txt")
 
@@ -741,7 +742,7 @@ def test_atomic_read_uses_single_code_run_and_rejects_symlink_target(tmp_path: P
     alias.symlink_to(secret)
 
     with pytest.raises(ValueError, match="unsafe"):
-        workspace.read_text("note.txt", max_bytes=32)
+        workspace.read_text_page("note.txt", cursor=None, max_chars=32, max_bytes=32)
 
     assert len(process.calls) == 1
 
@@ -774,7 +775,7 @@ def test_final_replacement_race_never_reads_outside_workspace(
     monkeypatch.setattr(os, "stat", racing_stat)
 
     with pytest.raises(ValueError, match="unsafe"):
-        workspace.read_text("note.txt", max_bytes=32)
+        workspace.read_text_page("note.txt", cursor=None, max_chars=32, max_bytes=32)
 
     assert outside.read_text(encoding="utf-8") == "secret"
 

--- a/tests/unit/backend/rlm/test_delegation_metrics.py
+++ b/tests/unit/backend/rlm/test_delegation_metrics.py
@@ -59,11 +59,31 @@ def test_token_usage_normalizer_accepts_both_supported_alias_families() -> None:
     assert normalize_lm_token_usage({"input_tokens": 11, "output_tokens": 7, "total_tokens": 21})["total_tokens"] == 21
 
 
-def test_metrics_count_input_output_aliases_when_total_is_absent() -> None:
+def test_metrics_record_input_output_total_per_lm_call() -> None:
     metrics = DelegationMetrics()
     metrics.record_lm_call("sub", 1, usage={"input_tokens": 13, "output_tokens": 4})
 
-    assert metrics.snapshot().lm_token_totals == (("sub", 1, 17),)
+    # lm_token_totals entries are (role, depth, input, output, total) so
+    # per-iteration prompt growth is legible without losing the total.
+    assert metrics.snapshot().lm_token_totals == (("sub", 1, 13, 4, 17),)
+
+
+def test_metrics_token_totals_partial_usage_is_not_collapsed_to_zero() -> None:
+    # A provider that reports only input_tokens must not read as 0 tokens.
+    metrics = DelegationMetrics()
+    metrics.record_lm_call("root", 0, usage={"input_tokens": 50})
+    metrics.record_lm_call("root", 0, usage={"prompt_tokens": 30, "completion_tokens": 20})
+
+    assert metrics.snapshot().lm_token_totals == (("root", 0, 80, 20, 100),)
+    assert metrics.snapshot().as_dict()["lm_token_totals"] == [
+        {
+            "role": "root",
+            "recursive_depth": 0,
+            "input_tokens": 80,
+            "output_tokens": 20,
+            "tokens": 100,
+        }
+    ]
 
 
 def test_lm_telemetry_matches_callback_response_in_concurrent_history() -> None:

--- a/tests/unit/backend/rlm/test_dspy_interpreter_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_interpreter_contract.py
@@ -48,14 +48,8 @@ def test_copy_output_fields_does_not_share_nested_metadata() -> None:
 
 
 def test_needs_tool_reinjection_matches_inject_cycle() -> None:
-    from fleet_rlm.rlm.dspy_interpreter_contract import (
-        initial_tools_registered,
-        mark_tools_registered,
-        needs_tool_reinjection,
-    )
+    from fleet_rlm.rlm.dspy_interpreter_contract import needs_tool_reinjection
 
-    assert initial_tools_registered() is False
-    assert mark_tools_registered() is True
     assert needs_tool_reinjection(tools_registered=False, http_broker_ready=False) is True
     assert needs_tool_reinjection(tools_registered=False, http_broker_ready=True) is True
     assert needs_tool_reinjection(tools_registered=True, http_broker_ready=False) is True

--- a/tests/unit/backend/rlm/test_runner_outcomes.py
+++ b/tests/unit/backend/rlm/test_runner_outcomes.py
@@ -278,7 +278,7 @@ def test_public_failure_message_honors_instance_override() -> None:
     from fleet_rlm.rlm.runner import _public_failure_message
 
     # A parametrized terminal error sets an instance ``public_message``; the
-    # runner must honor it (matching sanitize_public_error) instead of reading
+    # runner must honor the instance attribute instead of reading
     # the class attribute.
     error = RunTerminalError("custom public message")
     assert _public_failure_message(error) == "custom public message"

--- a/tests/unit/backend/rlm/test_sanitize.py
+++ b/tests/unit/backend/rlm/test_sanitize.py
@@ -47,27 +47,4 @@ def test_declared_output_validator_rejects_private_material(value: object) -> No
         validate_declared_public_value(value)
 
 
-def test_error_redaction_remains_a_transforming_boundary() -> None:
-    from fleet_rlm.rlm.sanitize import sanitize_public_error
 
-    assert sanitize_public_error("provider token=actual-secret-value") == "provider [redacted]"
-
-
-def test_sanitize_public_error_redacts_bare_provider_token() -> None:
-    from fleet_rlm.rlm.sanitize import sanitize_public_error
-
-    token = "sk-ant-api03-0123456789abcdef0123456789abcdef0123456789abcdef"
-    result = sanitize_public_error(f"authentication error: {token}")
-
-    assert token not in result
-    assert "[redacted]" in result
-
-
-def test_sanitize_public_error_redacts_trailing_bearer_token() -> None:
-    from fleet_rlm.rlm.sanitize import sanitize_public_error
-
-    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQifQ.fakeSignature"
-    result = sanitize_public_error(f"provider: unauthorized Bearer {jwt}")
-
-    assert jwt not in result
-    assert "[redacted]" in result

--- a/tests/unit/backend/rlm/test_sanitize.py
+++ b/tests/unit/backend/rlm/test_sanitize.py
@@ -45,6 +45,3 @@ def test_declared_output_validator_rejects_private_material(value: object) -> No
 
     with pytest.raises(ValueError):
         validate_declared_public_value(value)
-
-
-

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -252,7 +252,7 @@ def test_recursive_depth_is_a_recursive_execution_invariant_not_a_setting() -> N
     from fleet_rlm.composition.common import recursive_rlm_options
     from fleet_rlm.rlm.recursive_calls import RLM_NATIVE_CHILD_DEPTH
 
-    settings = Settings(_env_file=None)
+    settings = Settings()
     assert not hasattr(settings, "rlm_recursion_max_depth")
     options = recursive_rlm_options(settings)
     assert RLM_NATIVE_CHILD_DEPTH == 1
@@ -598,7 +598,7 @@ def test_redacted_policy_summary_never_includes_secret_values() -> None:
     from fleet_rlm.config import redacted_policy_summary
 
     summary = redacted_policy_summary(
-        Settings(_env_file=None, llm_api_key=SecretStr("private-llm-key")),
+        Settings(llm_api_key=SecretStr("private-llm-key")),
         profile="daytona",
     )
 
@@ -611,7 +611,7 @@ def test_startup_rejects_retired_environment_variables(monkeypatch: pytest.Monke
 
     monkeypatch.setenv("FLEET_LIVE_KERNEL", "true")
     with pytest.raises(ValueError, match=r"retired Fleet environment variable.*FLEET_LIVE_KERNEL"):
-        create_app(settings=Settings(_env_file=None))
+        create_app(settings=Settings())
 
 
 def test_startup_rejects_retired_budget_environment(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -619,40 +619,40 @@ def test_startup_rejects_retired_budget_environment(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setenv("FLEET_BUDGET_MAX_ITERATIONS", "6")
     with pytest.raises(ValueError, match=r"retired Fleet environment variable.*FLEET_BUDGET_MAX_ITERATIONS"):
-        create_app(settings=Settings(_env_file=None))
+        create_app(settings=Settings())
 
 
 def test_turn_timeout_defaults_to_thirty_minutes() -> None:
-    assert Settings(_env_file=None).turn_timeout_seconds == 1800
+    assert Settings().turn_timeout_seconds == 1800
 
 
 def test_live_execution_is_enabled_by_default_and_can_be_disabled() -> None:
-    assert Settings(_env_file=None).live_enabled is True
-    assert Settings(_env_file=None, live_enabled=False).live_enabled is False
+    assert Settings().live_enabled is True
+    assert Settings(live_enabled=False).live_enabled is False
 
 
 def test_url_source_limit_defaults_to_ten_mebibytes() -> None:
-    assert Settings(_env_file=None).max_url_bytes == 10 * 1024 * 1024
+    assert Settings().max_url_bytes == 10 * 1024 * 1024
 
 
 def test_mlflow_tracing_field_defaults_to_disabled() -> None:
     # The Settings field default is off; the committed [defaults.mlflow] policy
     # enables it. Test the field default here, policy default in test_config.py.
-    assert Settings(_env_file=None).mlflow_tracing_enabled is False
-    assert Settings(_env_file=None).mlflow_trace_content_max_chars == 10_000
+    assert Settings().mlflow_tracing_enabled is False
+    assert Settings().mlflow_trace_content_max_chars == 10_000
 
 
 def test_mlflow_tracing_can_be_disabled_explicitly() -> None:
-    assert Settings(_env_file=None, mlflow_tracing_enabled=False).mlflow_tracing_enabled is False
+    assert Settings(mlflow_tracing_enabled=False).mlflow_tracing_enabled is False
 
 
 def test_daytona_admission_defaults_to_eight_leases() -> None:
-    assert Settings(_env_file=None).max_active_daytona_leases == 8
+    assert Settings().max_active_daytona_leases == 8
 
 
 def test_settings_does_not_read_fleet_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FLEET_MAX_ACTIVE_DAYTONA_LEASES", "3")
-    assert Settings(_env_file=None).max_active_daytona_leases == 8
+    assert Settings().max_active_daytona_leases == 8
 
 
 def test_settings_ignore_mlflow_environment_policy(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -661,7 +661,7 @@ def test_settings_ignore_mlflow_environment_policy(monkeypatch: pytest.MonkeyPat
     monkeypatch.setenv("FLEET_MLFLOW_TRACE_TABLE_PREFIX", "fleet_app")
     monkeypatch.setenv("FLEET_MLFLOW_TRACING_SQL_WAREHOUSE_ID", "warehouse-123")
 
-    settings = Settings(_env_file=None)
+    settings = Settings()
 
     assert settings.mlflow_trace_catalog is None
     assert settings.mlflow_trace_schema is None
@@ -672,12 +672,12 @@ def test_settings_ignore_mlflow_environment_policy(monkeypatch: pytest.MonkeyPat
 @pytest.mark.parametrize("value", [0, -1, 9])
 def test_daytona_admission_must_be_between_one_and_eight(value: int) -> None:
     with pytest.raises(ValidationError):
-        Settings(_env_file=None, max_active_daytona_leases=value)
+        Settings(max_active_daytona_leases=value)
 
 
 def test_settings_does_not_read_runtime_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FLEET_TURN_TIMEOUT_SECONDS", "1200")
-    assert Settings(_env_file=None).turn_timeout_seconds == 1800
+    assert Settings().turn_timeout_seconds == 1800
 
 
 def test_settings_does_not_scan_unprefixed_environment_or_dotenv(
@@ -690,10 +690,9 @@ def test_settings_does_not_scan_unprefixed_environment_or_dotenv(
     monkeypatch.setenv("DAYTONA_API_KEY", "leaked-key")
 
     constructed = Settings()
-    from_file_kwarg = Settings(_env_file=".env")
     validated = Settings.model_validate({})
 
-    for settings in (constructed, from_file_kwarg, validated):
+    for settings in (constructed, validated):
         assert settings.log_level == "INFO"
         assert settings.database_url is None
         assert settings.daytona_api_key is None
@@ -702,14 +701,14 @@ def test_settings_does_not_scan_unprefixed_environment_or_dotenv(
 @pytest.mark.parametrize("value", [0, -1])
 def test_turn_timeout_must_be_positive(value: int) -> None:
     with pytest.raises(ValidationError):
-        Settings(_env_file=None, turn_timeout_seconds=value)
+        Settings(turn_timeout_seconds=value)
 
 
 def test_autonomous_memory_candidate_categories_default_off() -> None:
     policy_path = Path(__file__).resolve().parents[3] / "config" / "fleet.toml"
     document = tomllib.loads(policy_path.read_text(encoding="utf-8"))
 
-    assert Settings(_env_file=None).rlm_autonomous_memory_categories == ()
+    assert Settings().rlm_autonomous_memory_categories == ()
     assert document["defaults"]["rlm"]["autonomous_memory_categories"] == []
 
 
@@ -739,9 +738,9 @@ def test_autonomous_memory_candidate_categories_resolve_from_toml(
 
 def test_autonomous_memory_candidate_categories_fail_closed() -> None:
     with pytest.raises(ValidationError, match="rlm_autonomous_memory_categories"):
-        Settings(_env_file=None, rlm_autonomous_memory_categories=("Bad Category!",))
+        Settings(rlm_autonomous_memory_categories=("Bad Category!",))
 
 
 def test_autonomous_memory_candidate_category_policy_is_bounded() -> None:
     with pytest.raises(ValidationError, match="rlm_autonomous_memory_categories"):
-        Settings(_env_file=None, rlm_autonomous_memory_categories=tuple(f"Category {index}" for index in range(17)))
+        Settings(rlm_autonomous_memory_categories=tuple(f"Category {index}" for index in range(17)))

--- a/tests/unit/backend/test_config_policy.py
+++ b/tests/unit/backend/test_config_policy.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from fleet_rlm.config import FleetConfigurationError
+from fleet_rlm.config import FleetConfigurationError, Settings
 from fleet_rlm.config_policy import ConfigPolicyService, PolicyConflictError
 
 
@@ -201,8 +201,22 @@ def test_policy_inventory_covers_flattened_non_secret_settings(tmp_path: Path) -
     profile = document.default_profile or next(iter(document.profiles))
     flattened = _flatten_policy(_deep_merge(document.defaults, document.profiles[profile]))
     covered = {field.settings_field for field in _FIELDS if field.settings_field}
-    missing = sorted(key for key in flattened if not key.endswith("_env") and key not in covered)
+    missing = sorted(key for key in flattened.settings if key not in covered)
     assert missing == [], f"editable Settings fields missing from ConfigPolicyService: {missing}"
+    # Environment references resolve into real Settings fields and stay
+    # operator-editable only through their ``*_env`` TOML paths.
+    from fleet_rlm.config import config_field_specs
+
+    editable_paths = {field.path for field in _FIELDS}
+    reference_paths = {
+        spec.environment_reference_for: spec.toml_path
+        for spec in config_field_specs()
+        if spec.environment_reference_for is not None
+    }
+    for field_name, environment_name in flattened.environment_references.items():
+        assert field_name in Settings.model_fields
+        assert environment_name not in flattened.settings
+        assert reference_paths[field_name] in editable_paths
 
 
 def test_set_default_profile_persists_and_surfaces_in_snapshot(tmp_path: Path) -> None:

--- a/tests/unit/backend/test_config_schema.py
+++ b/tests/unit/backend/test_config_schema.py
@@ -1,0 +1,354 @@
+"""Authoritative configuration-schema consistency contracts (P29).
+
+These tests pin the one-source-of-truth rule: supported field identity, TOML
+location, operator/editor affordances, and defaults derive from the
+``FleetFieldPolicy`` declarations on ``Settings`` fields. Hand-editing the
+frozen inventory below is only legitimate together with an intentional,
+reviewed policy-surface change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+import fleet_rlm.config as config
+from fleet_rlm.config import (
+    EnvironmentReferenceSpec,
+    FleetConfigurationError,
+    Settings,
+)
+from fleet_rlm.config_policy import _FIELDS
+
+_EXPECTED_INVENTORY: tuple[tuple[str, str, str, str, tuple[str, ...], str | None], ...] = (
+    ("application.name", "Application", "Name", "text", (), "app_name"),
+    ("runtime.environment", "Runtime", "Environment", "single_choice", ("daytona",), "run_environment"),
+    ("runtime.live_enabled", "Runtime", "Live execution", "boolean", (), "live_enabled"),
+    ("runtime.turn_timeout_seconds", "Runtime", "Turn timeout seconds", "number", (), "turn_timeout_seconds"),
+    (
+        "runtime.max_active_daytona_leases",
+        "Runtime",
+        "Maximum Daytona leases",
+        "number",
+        (),
+        "max_active_daytona_leases",
+    ),
+    ("runtime.heartbeat_seconds", "Runtime", "Heartbeat seconds", "number", (), "run_heartbeat_seconds"),
+    ("runtime.stale_after_seconds", "Runtime", "Stale after seconds", "number", (), "run_stale_after_seconds"),
+    ("llm.root.model", "Root LLM", "Model id", "text", (), "root_model"),
+    ("llm.root.api_key_env", "Root LLM", "Provider API key environment variable", "text", (), "root_llm_api_key_env"),
+    ("llm.root.base_url", "Root LLM", "Provider base URL", "text", (), "root_llm_base_url"),
+    ("llm.root.base_url_env", "Root LLM", "Provider base URL environment variable", "text", (), None),
+    ("llm.root.max_tokens", "Root LLM", "Maximum tokens", "number", (), "root_llm_max_tokens"),
+    ("llm.root.temperature", "Root LLM", "Temperature", "number", (), "root_llm_temperature"),
+    ("llm.root.cache", "Root LLM", "Cache", "boolean", (), "root_llm_cache"),
+    ("llm.root.num_retries", "Root LLM", "Retries", "number", (), "root_llm_num_retries"),
+    (
+        "llm.root.reasoning_effort",
+        "Root LLM",
+        "Reasoning effort",
+        "single_choice",
+        ("none", "low", "medium", "high"),
+        "root_llm_reasoning_effort",
+    ),
+    ("llm.sub.model", "Sub LLM", "Model id", "text", (), "sub_model"),
+    ("llm.sub.api_key_env", "Sub LLM", "Provider API key environment variable", "text", (), "sub_llm_api_key_env"),
+    ("llm.sub.base_url", "Sub LLM", "Provider base URL", "text", (), "sub_llm_base_url"),
+    ("llm.sub.base_url_env", "Sub LLM", "Provider base URL environment variable", "text", (), None),
+    ("llm.sub.max_tokens", "Sub LLM", "Maximum tokens", "number", (), "sub_llm_max_tokens"),
+    ("llm.sub.temperature", "Sub LLM", "Temperature", "number", (), "sub_llm_temperature"),
+    ("llm.sub.cache", "Sub LLM", "Cache", "boolean", (), "sub_llm_cache"),
+    ("llm.sub.num_retries", "Sub LLM", "Retries", "number", (), "sub_llm_num_retries"),
+    (
+        "llm.sub.reasoning_effort",
+        "Sub LLM",
+        "Reasoning effort",
+        "single_choice",
+        ("none", "low", "medium", "high"),
+        "sub_llm_reasoning_effort",
+    ),
+    ("rlm.max_iters", "RLM", "Maximum iterations", "number", (), "rlm_max_iters"),
+    ("rlm.max_llm_calls", "RLM", "Maximum LLM calls", "number", (), "rlm_max_llm_calls"),
+    ("rlm.max_output_chars", "RLM", "Maximum output characters", "number", (), "rlm_max_output_chars"),
+    (
+        "rlm.max_execution_output_chars",
+        "RLM",
+        "Maximum execution output characters",
+        "number",
+        (),
+        "rlm_max_execution_output_chars",
+    ),
+    ("rlm.execution_timeout_s", "RLM", "Sandbox execution timeout (seconds)", "number", (), "rlm_execution_timeout_s"),
+    ("rlm.recursion_enabled", "RLM", "Enable recursive child RLMs", "boolean", (), "rlm_recursion_enabled"),
+    ("rlm.recursion_max_calls", "RLM", "Recursive maximum calls", "number", (), "rlm_recursion_max_calls"),
+    (
+        "rlm.recursion_max_prompt_chars",
+        "RLM",
+        "Recursive prompt character bound",
+        "number",
+        (),
+        "rlm_recursion_max_prompt_chars",
+    ),
+    ("rlm.recursion_child_max_iters", "RLM", "Child maximum iterations", "number", (), "rlm_recursion_child_max_iters"),
+    (
+        "rlm.recursion_child_max_llm_calls",
+        "RLM",
+        "Child maximum LLM calls",
+        "number",
+        (),
+        "rlm_recursion_child_max_llm_calls",
+    ),
+    (
+        "rlm.recursion_child_max_output_chars",
+        "RLM",
+        "Child maximum output characters",
+        "number",
+        (),
+        "rlm_recursion_child_max_output_chars",
+    ),
+    (
+        "rlm.recursion_max_parallel_children",
+        "RLM",
+        "Maximum parallel child RLMs",
+        "number",
+        (),
+        "rlm_recursion_max_parallel_children",
+    ),
+    (
+        "rlm.autonomous_memory_categories",
+        "RLM",
+        "Autonomous Memory categories",
+        "string_list",
+        (),
+        "rlm_autonomous_memory_categories",
+    ),
+    ("rlm.verbose", "RLM", "DSPy host verbose logging", "boolean", (), "rlm_verbose"),
+    ("storage.data_root", "Storage", "Data root", "text", (), "data_root"),
+    ("storage.max_upload_bytes", "Storage", "Maximum upload bytes", "number", (), "max_upload_bytes"),
+    ("storage.max_url_bytes", "Storage", "Maximum URL source bytes", "number", (), "max_url_bytes"),
+    ("storage.max_artifact_bytes", "Storage", "Maximum artifact bytes", "number", (), "max_artifact_bytes"),
+    ("storage.database_url_env", "Storage", "Database URL environment variable", "text", (), None),
+    ("daytona.api_key_env", "Daytona", "API key environment variable", "text", (), None),
+    ("daytona.snapshot", "Daytona", "Snapshot", "text", (), "daytona_snapshot"),
+    ("daytona.org_id", "Daytona", "Organization ID", "text", (), "daytona_org_id"),
+    ("daytona.volume_name", "Daytona", "Volume name", "text", (), "volume_name"),
+    ("daytona.volume_mount_path", "Daytona", "Volume mount path", "text", (), "volume_mount_path"),
+    (
+        "logging.level",
+        "Logging",
+        "Level",
+        "single_choice",
+        ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
+        "log_level",
+    ),
+    ("mlflow.tracing_enabled", "MLflow", "Tracing enabled", "boolean", (), "mlflow_tracing_enabled"),
+    ("mlflow.async_logging", "MLflow", "Async trace logging", "boolean", (), "mlflow_async_logging"),
+    ("mlflow.trace_sampling_ratio", "MLflow", "Trace sampling ratio", "number", (), "mlflow_trace_sampling_ratio"),
+    (
+        "mlflow.trace_content_max_chars",
+        "MLflow",
+        "Trace payload character limit",
+        "number",
+        (),
+        "mlflow_trace_content_max_chars",
+    ),
+    ("mlflow.experiment_name", "MLflow", "Experiment name", "text", (), "mlflow_experiment_name"),
+    ("mlflow.experiment_name_env", "MLflow", "Experiment environment variable", "text", (), None),
+    ("mlflow.tracking_uri", "MLflow", "Tracking URI", "text", (), "mlflow_tracking_uri"),
+    ("mlflow.expose_trace_id", "MLflow", "Expose trace ID", "boolean", (), "mlflow_expose_trace_id"),
+    ("mlflow.trace_catalog", "MLflow", "Trace catalog", "text", (), "mlflow_trace_catalog"),
+    ("mlflow.trace_catalog_env", "MLflow", "Trace catalog environment variable", "text", (), None),
+    ("mlflow.trace_schema", "MLflow", "Trace schema", "text", (), "mlflow_trace_schema"),
+    ("mlflow.trace_schema_env", "MLflow", "Trace schema environment variable", "text", (), None),
+    ("mlflow.trace_table_prefix", "MLflow", "Trace table prefix", "text", (), "mlflow_trace_table_prefix"),
+    ("mlflow.trace_table_prefix_env", "MLflow", "Trace table prefix environment variable", "text", (), None),
+    (
+        "mlflow.tracing_sql_warehouse_id",
+        "MLflow",
+        "Tracing SQL warehouse ID",
+        "text",
+        (),
+        "mlflow_tracing_sql_warehouse_id",
+    ),
+    ("mlflow.tracing_sql_warehouse_id_env", "MLflow", "Tracing SQL warehouse environment variable", "text", (), None),
+    ("posthog.enabled", "PostHog", "Analytics enabled", "boolean", (), "posthog_enabled"),
+    ("posthog.project_token_env", "PostHog", "Project token environment variable", "text", (), None),
+    ("posthog.host", "PostHog", "Ingestion host", "text", (), "posthog_host"),
+)
+
+
+def test_every_settings_field_carries_one_authoritative_declaration() -> None:
+    """Removing/duplicating a policy declaration fails the schema build loudly."""
+    policies = config._field_policies()
+    assert set(policies) == set(Settings.model_fields)
+
+
+def test_policy_inventory_is_derived_from_the_schema_identically() -> None:
+    """The editor inventory built by ``config_policy`` is the schema inventory."""
+    from fleet_rlm.config import config_field_specs
+
+    derived = tuple(
+        (spec.toml_path, spec.group, spec.label, spec.editor, spec.choices, spec.settings_field)
+        for spec in config_field_specs()
+        if spec.group is not None
+    )
+    current = tuple(
+        (field.path, field.group, field.label, field.editor, field.choices, field.settings_field) for field in _FIELDS
+    )
+    assert current == derived
+
+
+def test_policy_inventory_matches_the_frozen_operator_surface() -> None:
+    current = tuple(
+        (field.path, field.group, field.label, field.editor, field.choices, field.settings_field) for field in _FIELDS
+    )
+    assert current == _EXPECTED_INVENTORY
+
+
+def test_derived_table_keys_cover_exactly_the_supported_toml_surface() -> None:
+    document = config._read_policy_document(Path("config/fleet.toml"))
+    for scope_name, scope in [("defaults", document.defaults)] + [
+        (name, profile) for name, profile in document.profiles.items()
+    ]:
+        for section_name, section in scope.items():
+            assert section_name in config._TABLE_KEYS, f"{scope_name}.{section_name}"
+            for key, value in section.items():
+                assert key in config._TABLE_KEYS[section_name], f"{scope_name}.{section_name}.{key}"
+                if section_name == "llm":
+                    assert isinstance(value, dict)
+                    for role_key in value:
+                        assert role_key in config._ROLE_KEYS, f"{scope_name}.llm.{key}.{role_key}"
+
+
+def test_environment_reference_specs_reference_real_fields_and_follow_naming() -> None:
+    policies = config._field_policies()
+    for spec in config._ENVIRONMENT_REFERENCE_SPECS:
+        assert spec.toml_path.endswith("_env")
+        assert spec.resolves_to in policies
+
+
+def test_schema_build_rejects_reference_to_nonexistent_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    bogus = EnvironmentReferenceSpec(
+        toml_path="storage.bogus_env",
+        group="Storage",
+        label="Bogus environment variable",
+        rank=999,
+        resolves_to="not_a_settings_field",
+    )
+    monkeypatch.setattr(config, "_ENVIRONMENT_REFERENCE_SPECS", (*config._ENVIRONMENT_REFERENCE_SPECS, bogus))
+
+    with pytest.raises(FleetConfigurationError, match="not_a_settings_field"):
+        config._build_field_specs()
+
+
+def test_schema_build_rejects_duplicate_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
+    colliding = EnvironmentReferenceSpec(
+        toml_path="storage.colliding_env",
+        group="Storage",
+        label="Colliding environment variable",
+        rank=0,
+        resolves_to="database_url",
+    )
+    monkeypatch.setattr(config, "_ENVIRONMENT_REFERENCE_SPECS", (*config._ENVIRONMENT_REFERENCE_SPECS, colliding))
+
+    with pytest.raises(FleetConfigurationError, match="duplicate policy inventory rank"):
+        config._build_field_specs()
+
+
+def test_secret_fields_are_never_operator_editable() -> None:
+    editable = {spec.settings_field for spec in config.config_field_specs() if spec.group is not None}
+    policies = config._field_policies()
+    secret_fields = {name for name, meta in policies.items() if meta.secret}
+    assert secret_fields == {"daytona_api_key", "llm_api_key", "posthog_project_token"}
+    assert editable.isdisjoint(secret_fields)
+
+
+def test_unknown_direct_settings_field_is_rejected_without_leaking_values() -> None:
+    with pytest.raises(FleetConfigurationError) as excinfo:
+        Settings(data_rooot="super-secret-payload")  # type: ignore[call-arg]
+
+    message = str(excinfo.value)
+    assert "data_rooot" in message
+    assert "super-secret-payload" not in message
+
+
+def test_retired_settings_kwargs_are_rejected() -> None:
+    with pytest.raises(FleetConfigurationError, match="_env_file"):
+        Settings(_env_file=None)  # type: ignore[call-arg]
+
+
+def test_model_validate_rejects_unknown_keys() -> None:
+    with pytest.raises(FleetConfigurationError, match="app_name_extra"):
+        Settings.model_validate({"app_name_extra": "x"})
+
+
+def test_known_field_type_errors_remain_pydantic_validation_errors() -> None:
+    with pytest.raises(ValidationError, match="turn_timeout_seconds"):
+        Settings(turn_timeout_seconds=0)
+
+
+def test_committed_policy_loads_every_profile_identically(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """All supported committed TOML profiles resolve with identical values as documented."""
+    import tomllib
+
+    for name in (
+        "FLEET_DAYTONA_API_KEY",
+        "DATABRICKS_TOKEN",
+        "FLEET_DATABRICKS_AI_GATEWAY_BASE_URL",
+        "FLEET_DATABASE_URL",
+        "POSTHOG_PROJECT_TOKEN",
+    ):
+        monkeypatch.setenv(name, f"test-{name}")
+    for name in (
+        "FLEET_MLFLOW_EXPERIMENT_NAME",
+        "FLEET_MLFLOW_TRACE_CATALOG",
+        "FLEET_MLFLOW_TRACE_SCHEMA",
+        "FLEET_MLFLOW_TRACE_TABLE_PREFIX",
+        "FLEET_MLFLOW_TRACING_SQL_WAREHOUSE_ID",
+    ):
+        monkeypatch.setenv(name, f"test-{name}")
+
+    source = Path("config/fleet.toml").read_text(encoding="utf-8")
+    profiles = tomllib.loads(source)["profiles"]
+    policy = tmp_path / "fleet.toml"
+    for profile in profiles:
+        updated = re.sub(
+            r'^default_profile = "[^"]*"$',
+            f'default_profile = "{profile}"',
+            source,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        policy.write_text(updated, encoding="utf-8")
+        monkeypatch.setattr(config, "_CONFIG_PATH", policy)
+        settings = config.load_runtime_settings()
+        assert settings.run_environment == "daytona"
+        assert settings.root_model and settings.sub_model
+
+
+def test_required_policy_key_reports_its_settings_field() -> None:
+    import tomllib
+
+    document = tomllib.loads(Path("config/fleet.toml").read_text(encoding="utf-8"))
+    document["defaults"]["runtime"].pop("turn_timeout_seconds")
+    profile = document["profiles"][document["config"]["default_profile"]]
+
+    with pytest.raises(FleetConfigurationError, match="turn_timeout_seconds"):
+        config._flatten_policy(config._deep_merge(document["defaults"], profile))
+
+
+def test_absent_optional_policy_keys_fall_back_to_settings_defaults() -> None:
+    import tomllib
+
+    document = tomllib.loads(Path("config/fleet.toml").read_text(encoding="utf-8"))
+    defaults = document["defaults"]
+    defaults["rlm"].pop("recursion_max_calls")
+
+    flat = config._flatten_policy(config._deep_merge(defaults, document["profiles"]["daytona"]))
+
+    assert "rlm_recursion_max_calls" not in flat.settings
+    # ``Settings`` owns the fallback default; TOML absence stays absent.
+    assert Settings(**flat.settings).rlm_recursion_max_calls == 4

--- a/tests/unit/backend/test_config_schema.py
+++ b/tests/unit/backend/test_config_schema.py
@@ -16,7 +16,7 @@ import pytest
 from pydantic import ValidationError
 
 import fleet_rlm.config as config
-from fleet_rlm.config_policy import _FIELDS
+import fleet_rlm.config_policy as config_policy
 
 _EXPECTED_INVENTORY: tuple[tuple[str, str, str, str, tuple[str, ...], str | None], ...] = (
     ("application.name", "Application", "Name", "text", (), "app_name"),
@@ -189,14 +189,16 @@ def test_policy_inventory_is_derived_from_the_schema_identically() -> None:
         if spec.group is not None
     )
     current = tuple(
-        (field.path, field.group, field.label, field.editor, field.choices, field.settings_field) for field in _FIELDS
+        (field.path, field.group, field.label, field.editor, field.choices, field.settings_field)
+        for field in config_policy._FIELDS
     )
     assert current == derived
 
 
 def test_policy_inventory_matches_the_frozen_operator_surface() -> None:
     current = tuple(
-        (field.path, field.group, field.label, field.editor, field.choices, field.settings_field) for field in _FIELDS
+        (field.path, field.group, field.label, field.editor, field.choices, field.settings_field)
+        for field in config_policy._FIELDS
     )
     assert current == _EXPECTED_INVENTORY
 

--- a/tests/unit/backend/test_config_schema.py
+++ b/tests/unit/backend/test_config_schema.py
@@ -16,11 +16,6 @@ import pytest
 from pydantic import ValidationError
 
 import fleet_rlm.config as config
-from fleet_rlm.config import (
-    EnvironmentReferenceSpec,
-    FleetConfigurationError,
-    Settings,
-)
 from fleet_rlm.config_policy import _FIELDS
 
 _EXPECTED_INVENTORY: tuple[tuple[str, str, str, str, tuple[str, ...], str | None], ...] = (
@@ -183,16 +178,14 @@ _EXPECTED_INVENTORY: tuple[tuple[str, str, str, str, tuple[str, ...], str | None
 def test_every_settings_field_carries_one_authoritative_declaration() -> None:
     """Removing/duplicating a policy declaration fails the schema build loudly."""
     policies = config._field_policies()
-    assert set(policies) == set(Settings.model_fields)
+    assert set(policies) == set(config.Settings.model_fields)
 
 
 def test_policy_inventory_is_derived_from_the_schema_identically() -> None:
     """The editor inventory built by ``config_policy`` is the schema inventory."""
-    from fleet_rlm.config import config_field_specs
-
     derived = tuple(
         (spec.toml_path, spec.group, spec.label, spec.editor, spec.choices, spec.settings_field)
-        for spec in config_field_specs()
+        for spec in config.config_field_specs()
         if spec.group is not None
     )
     current = tuple(
@@ -231,7 +224,7 @@ def test_environment_reference_specs_reference_real_fields_and_follow_naming() -
 
 
 def test_schema_build_rejects_reference_to_nonexistent_field(monkeypatch: pytest.MonkeyPatch) -> None:
-    bogus = EnvironmentReferenceSpec(
+    bogus = config.EnvironmentReferenceSpec(
         toml_path="storage.bogus_env",
         group="Storage",
         label="Bogus environment variable",
@@ -240,12 +233,12 @@ def test_schema_build_rejects_reference_to_nonexistent_field(monkeypatch: pytest
     )
     monkeypatch.setattr(config, "_ENVIRONMENT_REFERENCE_SPECS", (*config._ENVIRONMENT_REFERENCE_SPECS, bogus))
 
-    with pytest.raises(FleetConfigurationError, match="not_a_settings_field"):
+    with pytest.raises(config.FleetConfigurationError, match="not_a_settings_field"):
         config._build_field_specs()
 
 
 def test_schema_build_rejects_duplicate_ranks(monkeypatch: pytest.MonkeyPatch) -> None:
-    colliding = EnvironmentReferenceSpec(
+    colliding = config.EnvironmentReferenceSpec(
         toml_path="storage.colliding_env",
         group="Storage",
         label="Colliding environment variable",
@@ -254,7 +247,7 @@ def test_schema_build_rejects_duplicate_ranks(monkeypatch: pytest.MonkeyPatch) -
     )
     monkeypatch.setattr(config, "_ENVIRONMENT_REFERENCE_SPECS", (*config._ENVIRONMENT_REFERENCE_SPECS, colliding))
 
-    with pytest.raises(FleetConfigurationError, match="duplicate policy inventory rank"):
+    with pytest.raises(config.FleetConfigurationError, match="duplicate policy inventory rank"):
         config._build_field_specs()
 
 
@@ -267,8 +260,8 @@ def test_secret_fields_are_never_operator_editable() -> None:
 
 
 def test_unknown_direct_settings_field_is_rejected_without_leaking_values() -> None:
-    with pytest.raises(FleetConfigurationError) as excinfo:
-        Settings(data_rooot="super-secret-payload")  # type: ignore[call-arg]
+    with pytest.raises(config.FleetConfigurationError) as excinfo:
+        config.Settings(data_rooot="super-secret-payload")  # type: ignore[call-arg]
 
     message = str(excinfo.value)
     assert "data_rooot" in message
@@ -276,18 +269,18 @@ def test_unknown_direct_settings_field_is_rejected_without_leaking_values() -> N
 
 
 def test_retired_settings_kwargs_are_rejected() -> None:
-    with pytest.raises(FleetConfigurationError, match="_env_file"):
-        Settings(_env_file=None)  # type: ignore[call-arg]
+    with pytest.raises(config.FleetConfigurationError, match="_env_file"):
+        config.Settings(_env_file=None)  # type: ignore[call-arg]
 
 
 def test_model_validate_rejects_unknown_keys() -> None:
-    with pytest.raises(FleetConfigurationError, match="app_name_extra"):
-        Settings.model_validate({"app_name_extra": "x"})
+    with pytest.raises(config.FleetConfigurationError, match="app_name_extra"):
+        config.Settings.model_validate({"app_name_extra": "x"})
 
 
 def test_known_field_type_errors_remain_pydantic_validation_errors() -> None:
     with pytest.raises(ValidationError, match="turn_timeout_seconds"):
-        Settings(turn_timeout_seconds=0)
+        config.Settings(turn_timeout_seconds=0)
 
 
 def test_committed_policy_loads_every_profile_identically(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -336,7 +329,7 @@ def test_required_policy_key_reports_its_settings_field() -> None:
     document["defaults"]["runtime"].pop("turn_timeout_seconds")
     profile = document["profiles"][document["config"]["default_profile"]]
 
-    with pytest.raises(FleetConfigurationError, match="turn_timeout_seconds"):
+    with pytest.raises(config.FleetConfigurationError, match="turn_timeout_seconds"):
         config._flatten_policy(config._deep_merge(document["defaults"], profile))
 
 
@@ -351,4 +344,4 @@ def test_absent_optional_policy_keys_fall_back_to_settings_defaults() -> None:
 
     assert "rlm_recursion_max_calls" not in flat.settings
     # ``Settings`` owns the fallback default; TOML absence stays absent.
-    assert Settings(**flat.settings).rlm_recursion_max_calls == 4
+    assert config.Settings(**flat.settings).rlm_recursion_max_calls == 4

--- a/tests/unit/backend/test_daytona_adapter.py
+++ b/tests/unit/backend/test_daytona_adapter.py
@@ -84,14 +84,13 @@ def test_strict_shutdown_preserves_broker_error_and_closes_backend() -> None:
     assert backend.closed is True
 
 
-def test_lease_release_is_idempotent_and_does_not_delete_sandbox() -> None:
+def test_lease_release_is_idempotent() -> None:
     from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter
     from fleet_rlm.daytona.session_manager import InterpreterLease
 
     backend = _FakeBackend()
     interp = DaytonaCodeInterpreter(backend=backend)
     interp.start()
-    deleted: list[str] = []
 
     lease = InterpreterLease(
         sandbox_id="sbx-1",
@@ -99,12 +98,10 @@ def test_lease_release_is_idempotent_and_does_not_delete_sandbox() -> None:
         volume_id="vol-1",
         mount_path="/home/daytona/memory",
         interpreter=interp,
-        delete_sandbox=lambda sandbox_id: deleted.append(sandbox_id),
     )
     lease.release()
     lease.release()
     assert backend.closed is True
-    assert deleted == []
 
 
 def test_provider_errors_map_to_sanitized_fleet_errors() -> None:

--- a/tests/unit/backend/test_daytona_diagnostics.py
+++ b/tests/unit/backend/test_daytona_diagnostics.py
@@ -120,7 +120,7 @@ async def test_daytona_doctor_fails_settings_without_provider_operations() -> No
 
     dependencies = FakeDoctorDependencies()
     result = await run_daytona_doctor(
-        Settings(_env_file=None, daytona_api_key=None, database_url=None),
+        Settings(daytona_api_key=None, database_url=None),
         dependencies=dependencies,
     )
 

--- a/tests/unit/backend/test_daytona_platform.py
+++ b/tests/unit/backend/test_daytona_platform.py
@@ -18,7 +18,6 @@ async def test_build_daytona_client_uses_explicit_api_url_without_deprecation(
 ) -> None:
     monkeypatch.setenv("DAYTONA_API_URL", "https://ambient.example/api")
     settings = Settings(
-        _env_file=None,
         daytona_api_key=SecretStr("test-daytona-key"),
         daytona_org_id="test-org",
     )

--- a/tests/unit/backend/test_live_composition.py
+++ b/tests/unit/backend/test_live_composition.py
@@ -165,7 +165,6 @@ def test_require_daytona_settings_fails_closed_without_deps(monkeypatch: pytest.
     with pytest.raises(CompositionError, match="DAYTONA_SNAPSHOT"):
         require_daytona_settings(
             Settings(
-                _env_file=None,
                 run_environment="daytona",
                 database_url="sqlite+aiosqlite:///:memory:",
                 daytona_api_key=SecretStr("daytona-key"),

--- a/tests/unit/backend/test_live_composition.py
+++ b/tests/unit/backend/test_live_composition.py
@@ -378,11 +378,11 @@ async def test_daytona_install_registers_and_dispose_clears_bridge_dispatcher(
     Sync Daytona bridges post SDK coroutines to the dispatcher's registered
     loop (the one loop-affine to every Daytona SDK object, which never
     performs nested synchronous waits); disposal clears only this
-    composition's dispatcher, and the legacy process-default dispatcher stays
-    unregistered throughout.
+    composition's dispatcher. The legacy process-default dispatcher seam
+    was removed in P33.
     """
     import fleet_rlm.composition.daytona as composition
-    from fleet_rlm.daytona.dspy_sync_bridge import SyncBridgeDispatcher, bridge_service_loop
+    from fleet_rlm.daytona.dspy_sync_bridge import SyncBridgeDispatcher
 
     inventory = RuntimeInventory(
         turn_coordinator=object(),
@@ -424,12 +424,10 @@ async def test_daytona_install_registers_and_dispose_clears_bridge_dispatcher(
     dispatcher = installed.bridge_dispatcher
     assert isinstance(dispatcher, SyncBridgeDispatcher)
     assert dispatcher.service_loop() is asyncio.get_running_loop()
-    assert bridge_service_loop() is None  # legacy default never registered
     assert installed is app.state.runtime_inventory
 
     await composition.dispose_daytona_composition(app)
     assert dispatcher.service_loop() is None
-    assert bridge_service_loop() is None
 
 
 def test_testing_database_is_created_and_closed_by_lifespan() -> None:

--- a/tests/unit/backend/test_live_turn_preparation.py
+++ b/tests/unit/backend/test_live_turn_preparation.py
@@ -116,8 +116,12 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
 
             return PreparedAttachments((ref,), (StagedAttachment(ref.id, logical_path),))
 
+    settings = Settings(run_environment="daytona", volume_mount_path=str(volume_root))
+    from fleet_rlm.files.volume_paths import volume_paths_from_settings
+
     resources = SimpleNamespace(
-        settings=Settings(run_environment="daytona", volume_mount_path=str(volume_root)),
+        settings=settings,
+        volume_paths=volume_paths_from_settings(settings),
         session_manager=SessionManager(),
         platform=SimpleNamespace(get=AsyncMock(return_value=SimpleNamespace(fs=SandboxFs(), process=SandboxProcess()))),
         models=RLMModelBundle(object(), object()),
@@ -215,9 +219,16 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
     canonical_memory = volume_root / "memory" / "MEMORIES.md"
     canonical_text = canonical_memory.read_text(encoding="utf-8")
     assert canonical_text.startswith("# Fleet Memory v2\n")
-    from fleet_rlm.files.memory_models import validate_workspace_memory_content
+    from fleet_rlm.files.memory_models import (
+        parse_workspace_memory_lines,
+        validate_workspace_memory_record,
+    )
 
-    validate_workspace_memory_content(canonical_text)
+    canonical_lines = parse_workspace_memory_lines(canonical_text)
+    assert not any(line.malformed for line in canonical_lines)
+    for line in canonical_lines:
+        if not line.header:
+            validate_workspace_memory_record(line.raw)
     assert learning + "\n" in canonical_text and memory_id in canonical_text
     assert not (volume_root / "MEMORIES.md").exists()
 
@@ -362,8 +373,12 @@ async def test_admission_timeout_is_sanitized_by_live_preparation() -> None:
             assert deadline > asyncio.get_running_loop().time()
             raise DaytonaAdmissionTimeoutError("provider secret should not escape")
 
+    settings = Settings(run_environment="daytona")
+    from fleet_rlm.files.volume_paths import volume_paths_from_settings
+
     resources = SimpleNamespace(
-        settings=Settings(run_environment="daytona"),
+        settings=settings,
+        volume_paths=volume_paths_from_settings(settings),
         session_manager=SessionManager(),
         models=RLMModelBundle(object(), object()),
     )

--- a/tests/unit/backend/test_lm_factory.py
+++ b/tests/unit/backend/test_lm_factory.py
@@ -63,10 +63,47 @@ def test_build_lm_allows_reasoning_effort_only_when_configured(monkeypatch: pyte
 
     assert default == "default-lm"
     assert bounded == "bounded-lm"
+    # stream_options (usage) is always allowlisted; reasoning_effort only appends
+    # its param when explicitly configured.
     assert "reasoning_effort" not in lm.call_args_list[0].kwargs
-    assert "allowed_openai_params" not in lm.call_args_list[0].kwargs
+    assert lm.call_args_list[0].kwargs["allowed_openai_params"] == ["stream_options"]
     assert lm.call_args_list[1].kwargs["reasoning_effort"] == "none"
-    assert lm.call_args_list[1].kwargs["allowed_openai_params"] == ["reasoning_effort"]
+    assert lm.call_args_list[1].kwargs["allowed_openai_params"] == ["stream_options", "reasoning_effort"]
+
+
+def test_build_lm_requests_usage_via_stream_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fleet_rlm.rlm.lm_factory as factory
+
+    lm = MagicMock(return_value="lm")
+    monkeypatch.setattr(factory.dspy, "LM", lm)
+
+    factory.build_lm("openai/model", api_key=None)
+
+    kwargs = lm.call_args.kwargs
+    # Stream so the provider emits a usage block on the final chunk: gateways
+    # (Databricks AI Gateway included) ignore stream_options.include_usage on a
+    # non-streamed request. `stream` is a litellm transport toggle passed
+    # directly; `stream_options` is an OpenAI body param that must be allowlisted.
+    # DSPy/litellm aggregate the deltas internally, so lm() still returns the
+    # same final outputs and ChatAdapter parsing is untouched.
+    assert kwargs["stream"] is True
+    assert kwargs["stream_options"] == {"include_usage": True}
+    assert kwargs["allowed_openai_params"] == ["stream_options"]
+
+
+def test_build_lm_requests_usage_and_reasoning_effort_together(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fleet_rlm.rlm.lm_factory as factory
+
+    lm = MagicMock(return_value="lm")
+    monkeypatch.setattr(factory.dspy, "LM", lm)
+
+    factory.build_lm("openai/model", api_key=None, reasoning_effort="none")
+
+    kwargs = lm.call_args.kwargs
+    assert kwargs["stream"] is True
+    assert kwargs["stream_options"] == {"include_usage": True}
+    assert kwargs["reasoning_effort"] == "none"
+    assert kwargs["allowed_openai_params"] == ["stream_options", "reasoning_effort"]
 
 
 def test_build_lm_uses_chat_completion_transport(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/backend/test_lm_factory.py
+++ b/tests/unit/backend/test_lm_factory.py
@@ -26,7 +26,6 @@ def test_model_bundle_applies_independent_role_policy(monkeypatch: pytest.Monkey
     build = MagicMock(side_effect=("root-lm", "sub-lm"))
     monkeypatch.setattr(factory, "build_lm", build)
     settings = Settings(
-        _env_file=None,
         root_model="openai/root",
         sub_model="openai/sub",
         root_llm_api_key_env="ROOT_KEY",
@@ -149,7 +148,7 @@ def test_runtime_does_not_accept_provider_environment_aliases(monkeypatch: pytes
     monkeypatch.setenv("OPENAI_API_KEY", "provider-alias-must-not-be-used")
     monkeypatch.setenv("DSPY_LM_MODEL", "provider/alias-model")
 
-    settings = Settings(_env_file=None)
+    settings = Settings()
 
     assert settings.llm_api_key is None
     assert settings.root_model == "openai/gpt-4o-mini"
@@ -159,7 +158,7 @@ def test_runtime_does_not_accept_provider_environment_aliases(monkeypatch: pytes
 
 def test_whitespace_legacy_key_is_not_a_credential(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FLEET_OPENAI_API_KEY", raising=False)
-    settings = Settings(_env_file=None, llm_api_key=SecretStr("   "))
+    settings = Settings(llm_api_key=SecretStr("   "))
 
     assert has_llm_credentials(settings) is False
 
@@ -167,7 +166,6 @@ def test_whitespace_legacy_key_is_not_a_credential(monkeypatch: pytest.MonkeyPat
 def test_legacy_generic_key_does_not_cross_provider_role_boundaries(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
     settings = Settings(
-        _env_file=None,
         llm_api_key=SecretStr("legacy-key"),
         root_llm_api_key_env="DATABRICKS_TOKEN",
         sub_llm_api_key_env="DATABRICKS_TOKEN",
@@ -179,7 +177,6 @@ def test_legacy_generic_key_does_not_cross_provider_role_boundaries(monkeypatch:
 def test_explicit_role_environment_credentials_are_detected(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABRICKS_TOKEN", "provider-key")
     settings = Settings(
-        _env_file=None,
         root_llm_api_key_env="DATABRICKS_TOKEN",
         sub_llm_api_key_env="DATABRICKS_TOKEN",
     )

--- a/tests/unit/backend/test_lm_factory.py
+++ b/tests/unit/backend/test_lm_factory.py
@@ -8,19 +8,11 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import SecretStr
 
+import fleet_rlm.rlm.lm_factory as factory
 from fleet_rlm.config import Settings
-from fleet_rlm.rlm.lm_factory import (
-    build_model_bundle,
-    has_llm_credentials,
-    normalize_model_id,
-    resolve_role_api_key,
-    sanitize_base_url,
-)
 
 
 def test_model_bundle_applies_independent_role_policy(monkeypatch: pytest.MonkeyPatch) -> None:
-    import fleet_rlm.rlm.lm_factory as factory
-
     monkeypatch.setenv("ROOT_KEY", "root-secret")
     monkeypatch.setenv("SUB_KEY", "sub-secret")
     build = MagicMock(side_effect=("root-lm", "sub-lm"))
@@ -53,8 +45,6 @@ def test_model_bundle_applies_independent_role_policy(monkeypatch: pytest.Monkey
 
 
 def test_build_lm_allows_reasoning_effort_only_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
-    import fleet_rlm.rlm.lm_factory as factory
-
     lm = MagicMock(side_effect=("default-lm", "bounded-lm"))
     monkeypatch.setattr(factory.dspy, "LM", lm)
 
@@ -72,8 +62,6 @@ def test_build_lm_allows_reasoning_effort_only_when_configured(monkeypatch: pyte
 
 
 def test_build_lm_requests_usage_via_stream_options(monkeypatch: pytest.MonkeyPatch) -> None:
-    import fleet_rlm.rlm.lm_factory as factory
-
     lm = MagicMock(return_value="lm")
     monkeypatch.setattr(factory.dspy, "LM", lm)
 
@@ -92,8 +80,6 @@ def test_build_lm_requests_usage_via_stream_options(monkeypatch: pytest.MonkeyPa
 
 
 def test_build_lm_requests_usage_and_reasoning_effort_together(monkeypatch: pytest.MonkeyPatch) -> None:
-    import fleet_rlm.rlm.lm_factory as factory
-
     lm = MagicMock(return_value="lm")
     monkeypatch.setattr(factory.dspy, "LM", lm)
 
@@ -107,8 +93,6 @@ def test_build_lm_requests_usage_and_reasoning_effort_together(monkeypatch: pyte
 
 
 def test_build_lm_uses_chat_completion_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-    import fleet_rlm.rlm.lm_factory as factory
-
     lm = MagicMock(return_value="deepseek-lm")
     monkeypatch.setattr(factory.dspy, "LM", lm)
 
@@ -128,8 +112,6 @@ def test_build_lm_uses_chat_completion_transport(monkeypatch: pytest.MonkeyPatch
 def test_mocked_litellm_request_resolves_unqualified_deepseek_model(monkeypatch: pytest.MonkeyPatch) -> None:
     import dspy.clients.lm as dspy_lm
     from litellm import get_llm_provider
-
-    import fleet_rlm.rlm.lm_factory as factory
 
     completion = MagicMock(return_value={"choices": []})
     monkeypatch.setattr(dspy_lm, "_get_litellm", lambda: SimpleNamespace(completion=completion))
@@ -155,23 +137,23 @@ def test_mocked_litellm_request_resolves_unqualified_deepseek_model(monkeypatch:
 
 
 def test_sanitize_base_url_accepts_https_and_strips_comments() -> None:
-    assert sanitize_base_url("https://opencode.ai/zen/v1") == "https://opencode.ai/zen/v1"
-    assert sanitize_base_url("https://opencode.ai/zen/v1/") == "https://opencode.ai/zen/v1"
-    assert sanitize_base_url("https://opencode.ai/zen/v1'   # real gateway") == "https://opencode.ai/zen/v1"
-    assert sanitize_base_url("'https://example.com/v1'") == "https://example.com/v1"
+    assert factory.sanitize_base_url("https://opencode.ai/zen/v1") == "https://opencode.ai/zen/v1"
+    assert factory.sanitize_base_url("https://opencode.ai/zen/v1/") == "https://opencode.ai/zen/v1"
+    assert factory.sanitize_base_url("https://opencode.ai/zen/v1'   # real gateway") == "https://opencode.ai/zen/v1"
+    assert factory.sanitize_base_url("'https://example.com/v1'") == "https://example.com/v1"
 
 
 def test_sanitize_base_url_rejects_keys_and_empty() -> None:
-    assert sanitize_base_url(None) is None
-    assert sanitize_base_url("") is None
-    assert sanitize_base_url("sk-ws-H.not-a-url") is None
-    assert sanitize_base_url("openai.com/v1") is None  # missing scheme
+    assert factory.sanitize_base_url(None) is None
+    assert factory.sanitize_base_url("") is None
+    assert factory.sanitize_base_url("sk-ws-H.not-a-url") is None
+    assert factory.sanitize_base_url("openai.com/v1") is None  # missing scheme
 
 
 def test_normalize_model_id_adds_openai_prefix_to_bare_names() -> None:
-    assert normalize_model_id("deepseek-v4-flash-free") == "openai/deepseek-v4-flash-free"
-    assert normalize_model_id("openai/gpt-4o-mini") == "openai/gpt-4o-mini"
-    assert normalize_model_id("anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
+    assert factory.normalize_model_id("deepseek-v4-flash-free") == "openai/deepseek-v4-flash-free"
+    assert factory.normalize_model_id("openai/gpt-4o-mini") == "openai/gpt-4o-mini"
+    assert factory.normalize_model_id("anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
 
 
 def test_runtime_does_not_accept_provider_environment_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -190,14 +172,14 @@ def test_runtime_does_not_accept_provider_environment_aliases(monkeypatch: pytes
     assert settings.llm_api_key is None
     assert settings.root_model == "openai/gpt-4o-mini"
     with pytest.raises(RuntimeError, match="FLEET_OPENAI_API_KEY"):
-        build_model_bundle(settings)
+        factory.build_model_bundle(settings)
 
 
 def test_whitespace_legacy_key_is_not_a_credential(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FLEET_OPENAI_API_KEY", raising=False)
     settings = Settings(llm_api_key=SecretStr("   "))
 
-    assert has_llm_credentials(settings) is False
+    assert factory.has_llm_credentials(settings) is False
 
 
 def test_legacy_generic_key_does_not_cross_provider_role_boundaries(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -208,7 +190,7 @@ def test_legacy_generic_key_does_not_cross_provider_role_boundaries(monkeypatch:
         sub_llm_api_key_env="DATABRICKS_TOKEN",
     )
 
-    assert resolve_role_api_key(settings, settings.llm_role("root")) is None
+    assert factory.resolve_role_api_key(settings, settings.llm_role("root")) is None
 
 
 def test_explicit_role_environment_credentials_are_detected(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -219,4 +201,4 @@ def test_explicit_role_environment_credentials_are_detected(monkeypatch: pytest.
     )
 
     assert settings.llm_api_key is None
-    assert has_llm_credentials(settings) is True
+    assert factory.has_llm_credentials(settings) is True

--- a/tests/unit/backend/test_mlflow_runtime.py
+++ b/tests/unit/backend/test_mlflow_runtime.py
@@ -18,7 +18,7 @@ def _settings(**overrides: object) -> Settings:
         "mlflow_experiment_name": "fleet-test",
     }
     values.update(overrides)
-    return Settings(_env_file=None, **values)
+    return Settings(**values)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/backend/test_mlflow_tracing_config.py
+++ b/tests/unit/backend/test_mlflow_tracing_config.py
@@ -172,7 +172,7 @@ def test_configure_tracing_enabled_without_workspace_settings_is_soft_disabled(
         "FLEET_MLFLOW_TRACING_SQL_WAREHOUSE_ID",
     ):
         monkeypatch.delenv(name, raising=False)
-    assert tracing.configure_tracing(Settings(_env_file=None, mlflow_tracing_enabled=True)) is False
+    assert tracing.configure_tracing(Settings(mlflow_tracing_enabled=True)) is False
     assert tracing.is_tracing_active() is False
     assert calls.tracking_uri_args == []
     assert calls.autolog_calls == 0
@@ -191,7 +191,6 @@ def test_unavailable_local_tracking_uri_does_not_activate_turn_spans(
     assert (
         tracing.configure_tracing(
             Settings(
-                _env_file=None,
                 mlflow_tracing_enabled=True,
                 mlflow_experiment_name="fleet-rlm-eval",
                 mlflow_tracking_uri="http://127.0.0.1:5001",
@@ -394,7 +393,6 @@ def test_configure_tracing_local_server_needs_only_experiment(
     calls = _install_fake_mlflow(monkeypatch)
     tracing.configure_tracing(
         Settings(
-            _env_file=None,
             mlflow_tracing_enabled=True,
             mlflow_experiment_name="fleet-rlm-eval",
             mlflow_tracking_uri="http://localhost:5001",
@@ -411,7 +409,6 @@ def test_configure_tracing_ignores_tracking_uri_environment_override(
     calls = _install_fake_mlflow(monkeypatch)
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://ignored.example:5001")
     settings = Settings(
-        _env_file=None,
         mlflow_tracing_enabled=True,
         mlflow_experiment_name="fleet-rlm-eval",
         mlflow_tracking_uri="http://configured.example:5001",

--- a/tests/unit/backend/test_posthog_client.py
+++ b/tests/unit/backend/test_posthog_client.py
@@ -44,7 +44,7 @@ def test_init_disabled_policy_leaves_client_disabled(monkeypatch) -> None:
     created: list[tuple[str, str | None, bool]] = []
     monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
 
-    init_posthog(Settings(_env_file=None, posthog_enabled=False))
+    init_posthog(Settings(posthog_enabled=False))
 
     assert get_client() is None
     assert created == []
@@ -55,7 +55,7 @@ def test_init_enabled_without_token_stays_disabled(monkeypatch) -> None:
     created: list[tuple[str, str | None, bool]] = []
     monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
 
-    init_posthog(Settings(_env_file=None, posthog_enabled=True))
+    init_posthog(Settings(posthog_enabled=True))
 
     assert get_client() is None
     assert created == []
@@ -67,7 +67,6 @@ def test_reinit_with_disabled_policy_shuts_down_previous_client(monkeypatch, tmp
     shutdowns: list[str] = []
     monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created, shutdowns))
     settings = Settings(
-        _env_file=None,
         posthog_enabled=True,
         posthog_project_token="phc-test-token",
         data_root=str(tmp_path),
@@ -76,7 +75,7 @@ def test_reinit_with_disabled_policy_shuts_down_previous_client(monkeypatch, tmp
     init_posthog(settings)
     assert get_client() is not None
 
-    init_posthog(Settings(_env_file=None, posthog_enabled=False))
+    init_posthog(Settings(posthog_enabled=False))
 
     assert get_client() is None
     assert shutdowns == ["phc-test-token"]
@@ -85,11 +84,11 @@ def test_reinit_with_disabled_policy_shuts_down_previous_client(monkeypatch, tmp
 
 def test_posthog_host_must_be_absolute_http_url() -> None:
     with pytest.raises(ValidationError):
-        Settings(_env_file=None, posthog_host="eu.i.posthog.com")
+        Settings(posthog_host="eu.i.posthog.com")
 
 
 def test_posthog_host_normalizes_trailing_slash() -> None:
-    settings = Settings(_env_file=None, posthog_host="https://eu.i.posthog.com/")
+    settings = Settings(posthog_host="https://eu.i.posthog.com/")
 
     assert settings.posthog_host == "https://eu.i.posthog.com"
 
@@ -101,7 +100,6 @@ def test_init_enabled_with_token_creates_client_and_disables_exception_autocaptu
 
     init_posthog(
         Settings(
-            _env_file=None,
             posthog_enabled=True,
             posthog_project_token="phc-test-token",
             posthog_host="https://eu.i.posthog.com",
@@ -119,7 +117,6 @@ def test_distinct_id_is_stable_and_persisted_across_restarts(monkeypatch, tmp_pa
     created: list[tuple[str, str | None, bool]] = []
     monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
     settings = Settings(
-        _env_file=None,
         posthog_enabled=True,
         posthog_project_token="phc-test-token",
         data_root=str(tmp_path),
@@ -141,7 +138,6 @@ def test_distinct_id_is_persisted_instance_id_not_deterministic_local_user_id(mo
     created: list[tuple[str, str | None, bool]] = []
     monkeypatch.setattr("fleet_rlm.posthog_client.Posthog", _fake_posthog(created))
     settings = Settings(
-        _env_file=None,
         posthog_enabled=True,
         posthog_project_token="phc-test-token",
         data_root=str(tmp_path),
@@ -192,4 +188,4 @@ def test_benchmark_profiles_disable_posthog() -> None:
 
     for profile in ("daytona-bench", "daytona-bench-40"):
         flattened = _flatten_policy(_deep_merge(document.defaults, document.profiles[profile]))
-        assert flattened["posthog_enabled"] is False
+        assert flattened.settings["posthog_enabled"] is False

--- a/tests/unit/backend/test_sandbox_lifecycle.py
+++ b/tests/unit/backend/test_sandbox_lifecycle.py
@@ -116,6 +116,13 @@ def test_sanitize_failure_text_types_and_redacts_exception() -> None:
     assert text.count("[redacted]") == 2
 
 
+def test_sanitize_failure_text_caps_after_redaction() -> None:
+    text = sanitize_failure_text(RuntimeError("api_key=secret " + "x" * 500))
+
+    assert len(text) == 200
+    assert "secret" not in text
+
+
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [

--- a/tests/unit/backend/test_sandbox_lifecycle.py
+++ b/tests/unit/backend/test_sandbox_lifecycle.py
@@ -11,8 +11,10 @@ from fleet_rlm.daytona.errors import (
     ProviderRequestError,
     classify_provider_error,
     is_sandbox_not_found,
+    is_transient_provider_failure,
     map_provider_error,
     provider_status_category,
+    sanitize_failure_text,
     sanitize_provider_message,
 )
 from fleet_rlm.daytona.platform import LiveDaytonaPlatform, LiveDaytonaVolumeClient, normalize_state
@@ -103,6 +105,48 @@ def test_sanitize_provider_message_redacts_secrets_and_private_paths() -> None:
     assert "/Users/zach" not in sanitized
     assert "/Volumes/SSD" not in sanitized
     assert sanitized.count("[redacted]") >= 4
+
+
+def test_sanitize_failure_text_types_and_redacts_exception() -> None:
+    text = sanitize_failure_text(RuntimeError("provider down api_key=super-secret path=/tmp/private"))
+
+    assert text.startswith("RuntimeError: provider down ")
+    assert "super-secret" not in text
+    assert "/tmp/private" not in text
+    assert text.count("[redacted]") == 2
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        # Transient shapes kept identical to the retired broker-local check.
+        (SimpleNamespace(status_code=503), True),
+        (TimeoutError("timed out"), True),
+        (ConnectionError("offline"), True),
+        (ProviderRequestError("502 Bad Gateway", cause_type="DaytonaError"), True),
+        (
+            ProviderRequestError("HTTP 503 Service Unavailable api_key=sk-secret", cause_type="PreviewLinkError"),
+            True,
+        ),
+        # Non-transient shapes never retry.
+        (_AuthError(), False),
+        (SimpleNamespace(status_code=422), False),
+        (
+            ProviderRequestError(
+                "Total disk limit exceeded. Upgrade your organization's Tier.",
+                cause_type="DaytonaValidationError",
+                status_code=400,
+            ),
+            False,
+        ),
+        (ProviderRequestError("mount", cause_type="WorkspaceMountMismatch"), False),
+        (ProviderRequestError("404 sandbox missing", cause_type="DaytonaError"), False),
+        (ProviderRequestError("processed 15001 objects", cause_type="DaytonaError"), False),
+        (RuntimeError("other"), False),
+    ],
+)
+def test_is_transient_provider_failure(exc: object, expected: bool) -> None:
+    assert is_transient_provider_failure(exc) is expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/backend/test_session_domain.py
+++ b/tests/unit/backend/test_session_domain.py
@@ -103,9 +103,9 @@ def test_turn_input_rejects_duplicate_or_oversized_skill_selections() -> None:
 def test_sequence_cursor_is_an_actual_nonnegative_sequence() -> None:
     from fleet_rlm.sessions.catalog import SequenceCursor
 
-    assert SequenceCursor.from_query(None).after_sequence is None
-    assert SequenceCursor.from_query(0).after_sequence == 0
-    assert SequenceCursor.from_query(41).next_after_sequence(42) == 42
+    assert SequenceCursor().after_sequence is None
+    assert SequenceCursor(after_sequence=0).after_sequence == 0
+    assert SequenceCursor(after_sequence=41).next_after_sequence(42) == 42
 
     with pytest.raises(ValueError):
-        SequenceCursor.from_query(-1)
+        SequenceCursor(after_sequence=-1)

--- a/tests/unit/backend/test_turn_claim_heartbeat.py
+++ b/tests/unit/backend/test_turn_claim_heartbeat.py
@@ -697,7 +697,7 @@ async def test_claim_loss_cleanup_after_commit_is_a_benign_no_op(caplog) -> None
     )
     heartbeat = ClaimHeartbeat(asyncio.create_task(asyncio.sleep(60)), asyncio.Event())
     with caplog.at_level(logging.INFO):
-        coordinator._submit_claim_loss_cleanup(start, heartbeat)
+        await coordinator._submit_claim_loss_cleanup_or_drain(start, heartbeat)
         await cleanup.shutdown(drain_seconds=1)
 
     run = authoritative._runs[start.run_id]

--- a/tests/unit/backend/test_turn_preparation.py
+++ b/tests/unit/backend/test_turn_preparation.py
@@ -100,12 +100,11 @@ async def test_preparation_bounds_history_and_closes_in_dependency_order() -> No
         capabilities=CapabilityFactory(),
     ).prepare(turn, deadline=float("inf"))
 
-    assert prepared.execution.session.session_context.to_input() == {
-        "session_id": str(turn.session_id),
-        "checkpoint_version": 0,
-        "message_count": 1,
-        "recent": [{"ordinal": 1, "role": "user", "preview": "prior"}],
-    }
+    manifest = prepared.execution.session.session_context
+    assert manifest.session_id == turn.session_id
+    assert manifest.checkpoint_version == 0
+    assert manifest.message_count == 1
+    assert [(item.ordinal, item.role, item.preview) for item in manifest.recent] == [(1, "user", "prior")]
     assert prepared.result_snapshot_sink is None
     await prepared.aclose()
     await prepared.aclose()

--- a/tests/unit/backend/test_turn_tracing.py
+++ b/tests/unit/backend/test_turn_tracing.py
@@ -17,6 +17,7 @@ from fleet_rlm.observability import turn_tracing
 from fleet_rlm.observability.failure_diagnostics import trace_failure_category
 from fleet_rlm.observability.turn_tracing import (
     annotate_trace_io,
+    annotate_turn_attributes,
     current_turn_trace_id,
     start_turn_span,
     turn_phase_span,
@@ -745,3 +746,59 @@ def test_recursive_call_span_marks_failure_with_bounded_category(monkeypatch: py
         if payload.get("phase_status") == "failed" and "failure_category" in payload
     ]
     assert failed_outputs[-1]["failure_category"] == "timeout"
+
+
+def test_annotate_turn_attributes_writes_sanitized_bounded_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fake_mlflow(monkeypatch)
+
+    class _AttrSpan:
+        def __init__(self) -> None:
+            self.attributes: dict[str, object] = {}
+
+        def set_attributes(self, attrs: dict[str, object]) -> None:
+            self.attributes.update(attrs)
+
+    attr_span = _AttrSpan()
+    mlflow = sys.modules["mlflow"]
+    monkeypatch.setattr(mlflow, "get_current_active_span", lambda: attr_span)
+
+    annotate_turn_attributes(
+        {
+            "fleet.memory_degradation.category": "provider_unavailable",
+            "fleet.memory_degradation.operation": "injection_digest",
+            "fleet.memory_degradation.runtime": "daytona",
+            "fleet.memory_degradation.cause_type": "WorkspaceAgentStorageError",
+            "fleet.memory_degradation.fallback_outcome": "no_memory_injection",
+        }
+    )
+
+    assert attr_span.attributes == {
+        "fleet.memory_degradation.category": "provider_unavailable",
+        "fleet.memory_degradation.operation": "injection_digest",
+        "fleet.memory_degradation.runtime": "daytona",
+        "fleet.memory_degradation.cause_type": "WorkspaceAgentStorageError",
+        "fleet.memory_degradation.fallback_outcome": "no_memory_injection",
+    }
+    assert calls.get_trace_calls == 0
+
+
+def test_annotate_turn_attributes_is_noop_without_active_span(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fake_mlflow(monkeypatch)
+    mlflow = sys.modules["mlflow"]
+    monkeypatch.setattr(mlflow, "get_current_active_span", lambda: None)
+
+    annotate_turn_attributes({"fleet.memory_degradation.category": "normalization"})
+    assert calls.span_inputs == []
+
+
+def test_annotate_turn_attributes_swallows_sink_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_mlflow(monkeypatch)
+    mlflow = sys.modules["mlflow"]
+
+    class _FailingSpan:
+        def set_attributes(self, attrs: dict[str, object]) -> None:
+            del attrs
+            raise RuntimeError("sink down")
+
+    monkeypatch.setattr(mlflow, "get_current_active_span", lambda: _FailingSpan())
+    annotate_turn_attributes({"fleet.memory_degradation.category": "normalization"})

--- a/tests/unit/backend/test_volume_paths.py
+++ b/tests/unit/backend/test_volume_paths.py
@@ -11,7 +11,6 @@ from fleet_rlm.daytona.provisioning import (
     DEFAULT_VOLUME_NAME,
     VolumeConfig,
     get_or_create_volume_id,
-    require_scoped_volume_subpath,
     volume_config_from_settings,
     volume_mount_spec,
 )
@@ -23,21 +22,18 @@ from fleet_rlm.files.volume_paths import (
     validate_mount_path,
     validate_path_id,
 )
+from fleet_rlm.runtime.bindings import require_scoped_volume_subpath
 
 
 def test_default_mount_matches_design() -> None:
     assert DEFAULT_VOLUME_MOUNT_PATH == "/home/daytona/fleet"
     root = VolumePaths.from_mount()
     assert root.root == PurePosixPath("/home/daytona/fleet")
-    assert root.files == PurePosixPath("/home/daytona/fleet/files")
-    assert root.attachments == PurePosixPath("/home/daytona/fleet/attachments")
-    assert root.artifacts == PurePosixPath("/home/daytona/fleet/artifacts")
-    assert root.runs == PurePosixPath("/home/daytona/fleet/runs")
+    assert root.files_root() == PurePosixPath("/home/daytona/fleet/files")
+    assert root.attachments_root() == PurePosixPath("/home/daytona/fleet/attachments")
+    assert root.artifacts_root() == PurePosixPath("/home/daytona/fleet/artifacts")
     assert root.memory_dir == PurePosixPath("/home/daytona/fleet/memory")
     assert root.memory_file == PurePosixPath("/home/daytona/fleet/memory/MEMORIES.md")
-    assert root.legacy_memory_file == PurePosixPath("/home/daytona/fleet/MEMORIES.md")
-    assert root.artifacts_root() == PurePosixPath("/home/daytona/fleet/artifacts")
-    assert root.attachments_root() == PurePosixPath("/home/daytona/fleet/attachments")
     assert root.sessions_root() == PurePosixPath("/home/daytona/fleet/sessions")
 
 

--- a/tests/unit/backend/test_workspace_volume_isolation.py
+++ b/tests/unit/backend/test_workspace_volume_isolation.py
@@ -14,17 +14,19 @@ from fleet_rlm.daytona.provisioning import (
     DaytonaSandboxSpec,
     ExpectedWorkspaceMount,
     VolumeConfig,
-    require_scoped_volume_subpath,
     verify_sandbox_workspace_mount,
     volume_mount_spec,
-    workspace_volume_subpath,
 )
 from fleet_rlm.daytona.session_manager import (
     DaytonaSessionManager,
     LeaseRequest,
 )
 from fleet_rlm.runtime.bindings import InMemorySandboxBindingStore as InMemoryBindingStore
-from fleet_rlm.runtime.bindings import SandboxBinding
+from fleet_rlm.runtime.bindings import (
+    SandboxBinding,
+    require_scoped_volume_subpath,
+    workspace_volume_subpath,
+)
 
 _SPEC = DaytonaSandboxSpec("fleet-test-v1")
 

--- a/tools/fleet-tui/src/fleet-api-client.ts
+++ b/tools/fleet-tui/src/fleet-api-client.ts
@@ -1,4 +1,5 @@
 import type { components } from "./generated/openapi.js";
+import { record } from "./tui/coerce.js";
 
 export type FleetSession = components["schemas"]["SessionDetailResponse"];
 export type FleetTurn = components["schemas"]["UIMessageResponse"];
@@ -288,12 +289,6 @@ export class FleetApiClient {
       code,
     );
   }
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function nonEmptyString(value: unknown): string | undefined {

--- a/tools/fleet-tui/src/tui/coerce.ts
+++ b/tools/fleet-tui/src/tui/coerce.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared wire-side coercion primitives (P33/QRE-199): the single home for
+ * unknown→typed narrowing used by the wire adapters and summaries. The two
+ * record coercions differ deliberately: `asRecord` keeps the adapters'
+ * semantics (any non-null object, arrays included) while `record` excludes
+ * arrays for summary/client payload reads.
+ */
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+export function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function int(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) ? value : undefined;
+}
+
+export function record(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/tools/fleet-tui/src/tui/durable-adapter.ts
+++ b/tools/fleet-tui/src/tui/durable-adapter.ts
@@ -7,18 +7,7 @@
 
 import type { FleetTurn } from "../fleet-api-client.js";
 import type { CanonicalEvent } from "./canonical.js";
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : {};
-}
-
-function str(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function int(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) ? value : null;
-}
+import { asRecord, int, str } from "./coerce.js";
 
 function metadataString(turn: FleetTurn, key: string): string | undefined {
   const value = turn.metadata?.[key];
@@ -58,7 +47,7 @@ export function adaptDurableTurns(turns: FleetTurn[]): CanonicalEvent[] {
           // Live-only lifecycle: bookkeeping only for durable step attribution.
           const value = part.type === "data-step" ? asRecord(part.data) : {};
           const step = int(value.step);
-          if (step !== null) currentStep = step;
+          if (step !== undefined) currentStep = step;
           break;
         }
         case "reasoning":
@@ -161,7 +150,7 @@ export function adaptDurableTurns(turns: FleetTurn[]): CanonicalEvent[] {
             attachmentId: str(value.attachmentId) ?? part.id ?? "(attachment)",
             phase: str(value.phase),
             filename: str(value.filename),
-            byteSize: int(value.byteSize),
+            byteSize: int(value.byteSize) ?? null,
             streamId,
             messageId,
           });
@@ -186,7 +175,7 @@ export function adaptDurableTurns(turns: FleetTurn[]): CanonicalEvent[] {
             artifactKind: str(value.artifactKind) ?? str(value.kind),
             title: str(value.title) ?? str(value.name),
             mediaType: str(value.mediaType),
-            byteSize: int(value.byteSize),
+            byteSize: int(value.byteSize) ?? null,
             checksumSha256: str(value.checksumSha256),
             streamId,
             messageId,
@@ -200,7 +189,7 @@ export function adaptDurableTurns(turns: FleetTurn[]): CanonicalEvent[] {
           events.push({
             type: "usage",
             iterations: int(payload.iterations) ?? 0,
-            durationMs: int(payload.duration_ms) ?? int(payload.durationMs),
+            durationMs: int(payload.duration_ms) ?? int(payload.durationMs) ?? null,
             usage: payload,
             streamId,
             messageId,

--- a/tools/fleet-tui/src/tui/execution-summary.ts
+++ b/tools/fleet-tui/src/tui/execution-summary.ts
@@ -1,3 +1,4 @@
+import { record } from "./coerce.js";
 import type { Message } from "./store.js";
 
 export type ExecutionSummary = {
@@ -92,12 +93,6 @@ export function formatExecutionMetric(value: number | null): string {
 
 function isInterpreterError(output: string): boolean {
   return /^\s*(?:\[Error\]|Execution (?:error|failed)\b)/i.test(output);
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function nonnegativeFinite(value: number | null): number | null {

--- a/tools/fleet-tui/src/tui/live-adapter.ts
+++ b/tools/fleet-tui/src/tui/live-adapter.ts
@@ -6,18 +6,7 @@
 
 import type { FleetUIMessageChunk } from "../sse.js";
 import type { CanonicalEvent } from "./canonical.js";
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : {};
-}
-
-function str(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function int(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) ? value : undefined;
-}
+import { asRecord, int, str } from "./coerce.js";
 
 function metadataString(value: unknown, key: string): string | undefined {
   return str(asRecord(value)[key]);

--- a/tools/fleet-tui/src/tui/projection-helpers.ts
+++ b/tools/fleet-tui/src/tui/projection-helpers.ts
@@ -5,6 +5,7 @@ import type {
   UsageEvent,
   WarningEvent,
 } from "./canonical.js";
+import { record } from "./coerce.js";
 import type { Message, Role } from "./store.js";
 import { observedTokenCounts } from "./usage-summary.js";
 
@@ -190,8 +191,8 @@ export function artifact(id: string, runId: string, event: ArtifactEvent, clock:
 }
 
 export function usage(id: string, runId: string, event: UsageEvent, clock: Clock): Message {
-  const value = data(event.usage);
-  const observedLmUsage = data(value.observed_lm_usage);
+  const value = record(event.usage);
+  const observedLmUsage = record(value.observed_lm_usage);
   const tokens = observedTokenCounts(observedLmUsage);
   return {
     id,
@@ -224,12 +225,6 @@ function singleScalar(value: unknown): string | number | boolean | null | undefi
   return candidate === null || ["string", "number", "boolean"].includes(typeof candidate)
     ? (candidate as string | number | boolean | null)
     : undefined;
-}
-
-export function data(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 export function string(value: unknown, fallback = ""): string {

--- a/tools/fleet-tui/src/tui/tests/coerce.test.ts
+++ b/tools/fleet-tui/src/tui/tests/coerce.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Pins the shared wire-coercion contract (P33/QRE-199). The two record
+ * coercions differ deliberately: adapters keep array-including `asRecord`
+ * wire semantics while summaries/clients use array-excluding `record`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { asRecord, int, record, str } from "../coerce.js";
+
+describe("asRecord (array-including wire semantics)", () => {
+  it("returns {} for null, undefined, and non-object values", () => {
+    expect(asRecord(null)).toEqual({});
+    expect(asRecord(undefined)).toEqual({});
+    expect(asRecord("x")).toEqual({});
+    expect(asRecord(5)).toEqual({});
+    expect(asRecord(true)).toEqual({});
+  });
+
+  it("returns the same reference for plain objects", () => {
+    const value = { phase: "running" };
+    expect(asRecord(value)).toBe(value);
+  });
+
+  it("returns the same reference for arrays (indices stay observable)", () => {
+    const value = ["a", "b"];
+    expect(asRecord(value)).toBe(value);
+    expect(Object.keys(asRecord(value))).toEqual(["0", "1"]);
+  });
+});
+
+describe("record (array-excluding payload semantics)", () => {
+  it("returns {} for null, undefined, and non-object values", () => {
+    expect(record(null)).toEqual({});
+    expect(record(undefined)).toEqual({});
+    expect(record("x")).toEqual({});
+    expect(record(5)).toEqual({});
+    expect(record(true)).toEqual({});
+  });
+
+  it("returns {} for arrays", () => {
+    expect(record(["a", "b"])).toEqual({});
+    expect(Object.keys(record(["a", "b"]))).toEqual([]);
+  });
+
+  it("returns the same reference for plain objects", () => {
+    const value = { prompt_count: 2 };
+    expect(record(value)).toBe(value);
+  });
+});
+
+describe("str (non-empty-only)", () => {
+  it("returns undefined for non-strings and the empty string", () => {
+    expect(str(undefined)).toBeUndefined();
+    expect(str(null)).toBeUndefined();
+    expect(str(5)).toBeUndefined();
+    expect(str("")).toBeUndefined();
+  });
+
+  it("returns strings verbatim, including whitespace-only values", () => {
+    expect(str("x")).toBe("x");
+    expect(str(" ")).toBe(" ");
+  });
+});
+
+describe("int (integer-only, undefined sentinel)", () => {
+  it("returns integers, including zero and negatives", () => {
+    expect(int(0)).toBe(0);
+    expect(int(3)).toBe(3);
+    expect(int(-3)).toBe(-3);
+  });
+
+  it("returns undefined (not null) for non-integer or non-number values", () => {
+    expect(int(1.5)).toBeUndefined();
+    expect(int(Number.NaN)).toBeUndefined();
+    expect(int(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(int("3")).toBeUndefined();
+    expect(int(null)).toBeUndefined();
+    expect(int(undefined)).toBeUndefined();
+  });
+});

--- a/tools/fleet-tui/src/tui/tests/reducer-sequence-gen.ts
+++ b/tools/fleet-tui/src/tui/tests/reducer-sequence-gen.ts
@@ -1,0 +1,625 @@
+/**
+ * Deterministic canonical Turn event-sequence generators (P32/QRE-193).
+ *
+ * Generated models respect canonical semantic identity/order constraints:
+ * streams open, accumulate, and close; tool calls pair with one result;
+ * structured results follow their narrative text; lifecycle brackets content.
+ * Every model is fully derived from its seed, so any failure prints a
+ * replayable seed plus the compact model JSON (the smallest practical
+ * failing sequence is found by shrinking the model JSON by hand).
+ *
+ * The generator is source-agnostic: `renderLiveEvents` mirrors the
+ * live-normalized route (fragmented start/delta/end streams), while
+ * `renderDurableEvents` mirrors the durable-normalized route (single-shot,
+ * terminally folded records) for the same semantic Turn.
+ */
+
+import type { CanonicalEvent } from "../canonical.js";
+
+// ---------------------------------------------------------------------------
+// Deterministic PRNG (no dependencies; seeds are reported on failure)
+// ---------------------------------------------------------------------------
+
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export class Rng {
+  private readonly nextValue: () => number;
+
+  constructor(readonly seed: number) {
+    this.nextValue = mulberry32(seed);
+  }
+
+  int(min: number, max: number): number {
+    return min + Math.floor(this.nextValue() * (max - min + 1));
+  }
+
+  chance(probability: number): boolean {
+    return this.nextValue() < probability;
+  }
+
+  pick<T>(items: readonly T[]): T {
+    return items[this.int(0, items.length - 1)] as T;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Semantic Turn model (both renderings derive from one model)
+// ---------------------------------------------------------------------------
+
+export interface ReasoningPlan {
+  kind: "reasoning";
+  step: number;
+  fragments: string[];
+}
+
+export interface TextPlan {
+  kind: "text";
+  fragments: string[];
+}
+
+export interface CodePlan {
+  kind: "code";
+  step: number;
+  fragments: string[];
+}
+
+export interface OutputPlan {
+  kind: "output";
+  step: number;
+  fragments: string[];
+}
+
+export interface ToolPlan {
+  kind: "tool";
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  error?: string;
+}
+
+export interface SkillPlan {
+  kind: "skill";
+  skillId: string;
+  name: string;
+}
+
+export interface AttachmentPlan {
+  kind: "attachment";
+  attachmentId: string;
+  filename: string;
+  byteSize: number;
+}
+
+export interface ArtifactPlan {
+  kind: "artifact";
+  artifactId: string;
+  title: string;
+  artifactKind: string;
+}
+
+export interface WarningPlan {
+  kind: "warning";
+  code: string;
+  message: string;
+}
+
+export type PartPlan =
+  | ReasoningPlan
+  | TextPlan
+  | CodePlan
+  | OutputPlan
+  | ToolPlan
+  | SkillPlan
+  | AttachmentPlan
+  | ArtifactPlan
+  | WarningPlan;
+
+export interface UsagePlan {
+  iterations: number;
+  durationMs: number;
+  usage: Record<string, unknown>;
+}
+
+export interface ResultPlan {
+  schemaId: string;
+  schemaVersion: string;
+  value: unknown;
+}
+
+export interface TurnModel {
+  seed: number;
+  runId: string;
+  parts: PartPlan[];
+  result: ResultPlan | null;
+  /** Extra assistant text fragments streamed AFTER the structured result. */
+  trailingNarrative: string[];
+  usage: UsagePlan | null;
+  finishReason: "stop" | "length" | "error";
+  cancelled: boolean;
+}
+
+const WORDS = [
+  "alpha",
+  "bravo",
+  "charlie\n",
+  "delta ",
+  "echo",
+  "foxtrot ",
+  "golf\n\n",
+  "hotel",
+  "india ",
+  "juliet",
+] as const;
+
+const TOOL_NAMES = [
+  "list_workspace_files",
+  "read_workspace_file",
+  "remember",
+  "search_memories",
+] as const;
+const WARNING_CODES = ["memory_digest", "partial_trajectory", "attachment_degraded"] as const;
+
+function fragments(rng: Rng, maxFragments: number): string[] {
+  const count = rng.int(1, maxFragments);
+  const out: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    out.push(rng.pick(WORDS) + String(rng.int(0, 99)));
+  }
+  return out;
+}
+
+function jsonSnippet(rng: Rng): unknown {
+  return { value: rng.int(0, 1000), label: rng.pick(WORDS).trim(), ok: rng.chance(0.5) };
+}
+
+/** Build the deterministic semantic model for one seed. */
+export function generateTurnModel(seed: number): TurnModel {
+  const rng = new Rng(seed);
+  const parts: PartPlan[] = [];
+  const stepCount = rng.int(1, 3);
+  let toolCount = 0;
+  for (let step = 1; step <= stepCount; step += 1) {
+    if (rng.chance(0.7)) parts.push({ kind: "reasoning", step, fragments: fragments(rng, 4) });
+    if (rng.chance(0.6)) {
+      parts.push({ kind: "code", step, fragments: fragments(rng, 3) });
+      parts.push({ kind: "output", step, fragments: fragments(rng, 3) });
+    }
+    if (rng.chance(0.5)) {
+      toolCount += 1;
+      const toolCallId = `call-${seed}-${toolCount}`;
+      const plan: ToolPlan = {
+        kind: "tool",
+        toolCallId,
+        toolName: rng.pick(TOOL_NAMES),
+        input: { args: rng.int(0, 9) },
+      };
+      if (rng.chance(0.2)) plan.error = `tool ${toolCount} failed`;
+      else plan.output = jsonSnippet(rng);
+      parts.push(plan);
+    }
+  }
+  if (rng.chance(0.4)) {
+    parts.push({
+      kind: "skill",
+      skillId: `skill-${rng.int(1, 3)}`,
+      name: `skill-${rng.int(1, 3)}`,
+    });
+  }
+  if (rng.chance(0.3)) {
+    parts.push({
+      kind: "attachment",
+      attachmentId: `att-${rng.int(1, 4)}`,
+      filename: `notes-${rng.int(1, 9)}.md`,
+      byteSize: rng.int(10, 5000),
+    });
+  }
+  if (rng.chance(0.3)) {
+    parts.push({
+      kind: "artifact",
+      artifactId: `art-${rng.int(1, 4)}`,
+      title: `report-${rng.int(1, 9)}`,
+      artifactKind: rng.pick(["file", "chart", "summary"]),
+    });
+  }
+  if (rng.chance(0.35)) {
+    parts.push({ kind: "warning", code: rng.pick(WARNING_CODES), message: "bounded warning" });
+  }
+  const hasText = rng.chance(0.85);
+  if (hasText) parts.push({ kind: "text", fragments: fragments(rng, 5) });
+
+  let result: ResultPlan | null = null;
+  if (hasText ? rng.chance(0.55) : rng.chance(0.12)) {
+    result = {
+      schemaId: "fleet.answer.v1",
+      schemaVersion: "1",
+      value: rng.chance(0.5) ? { answer: `final-${rng.int(0, 9)}` } : jsonSnippet(rng),
+    };
+  }
+  // Trailing narrative only makes semantic sense when an answer stream exists
+  // for the live route to append to.
+  const trailingNarrative = hasText && result && rng.chance(0.3) ? fragments(rng, 2) : [];
+  const usage: UsagePlan | null = rng.chance(0.85)
+    ? {
+        iterations: stepCount,
+        durationMs: rng.int(100, 90_000),
+        usage: { iterations: stepCount, duration_ms: rng.int(100, 90_000) },
+      }
+    : null;
+  const cancelled = rng.chance(0.12);
+  return {
+    seed,
+    runId: `run-${seed}`,
+    parts,
+    result,
+    trailingNarrative,
+    usage,
+    finishReason: rng.pick(["stop", "stop", "length", "error"] as const),
+    cancelled,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Live-normalized rendering (fragmented start/delta/end streaming)
+// ---------------------------------------------------------------------------
+
+function livePartEvents(part: PartPlan): CanonicalEvent[] {
+  switch (part.kind) {
+    case "reasoning": {
+      const streamId = `reasoning-${part.step}`;
+      return [
+        { type: "reasoning", streamId, step: 0, text: "", final: false },
+        ...part.fragments.map(
+          (text): CanonicalEvent => ({ type: "reasoning", streamId, step: 0, text, final: false }),
+        ),
+        { type: "reasoning", streamId, step: 0, text: "", final: true },
+      ];
+    }
+    case "code":
+      return part.fragments.map(
+        (codeDelta, index): CanonicalEvent => ({
+          type: "code",
+          streamId: String(part.step),
+          step: part.step,
+          codeDelta,
+          isDelta: index > 0,
+          final: index === part.fragments.length - 1,
+        }),
+      );
+    case "output":
+      return part.fragments.map(
+        (outputDelta, index): CanonicalEvent => ({
+          type: "output",
+          streamId: String(part.step),
+          step: part.step,
+          outputDelta,
+          isDelta: index > 0,
+          final: index === part.fragments.length - 1,
+        }),
+      );
+    case "text": {
+      const streamId = "answer";
+      return [
+        { type: "text", streamId, textDelta: "", final: false, role: "assistant" },
+        ...part.fragments.map(
+          (textDelta): CanonicalEvent => ({
+            type: "text",
+            streamId,
+            textDelta,
+            final: false,
+            role: "assistant",
+          }),
+        ),
+        { type: "text", streamId, textDelta: "", final: true, role: "assistant" },
+      ];
+    }
+    case "tool":
+      return [
+        {
+          type: "tool_call",
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input: part.input,
+        },
+        part.error !== undefined
+          ? { type: "tool_result", toolCallId: part.toolCallId, error: part.error }
+          : { type: "tool_result", toolCallId: part.toolCallId, output: part.output },
+      ];
+    case "skill":
+      return [
+        {
+          type: "skill",
+          streamId: part.skillId,
+          messageId: part.skillId,
+          skillId: part.skillId,
+          phase: "activated",
+          name: part.name,
+        },
+      ];
+    case "attachment":
+      return [
+        {
+          type: "attachment",
+          streamId: part.attachmentId,
+          messageId: part.attachmentId,
+          attachmentId: part.attachmentId,
+          phase: "staged",
+          filename: part.filename,
+          byteSize: part.byteSize,
+        },
+      ];
+    case "artifact":
+      return [
+        {
+          type: "artifact",
+          streamId: part.artifactId,
+          messageId: part.artifactId,
+          artifactId: part.artifactId,
+          artifactKind: part.artifactKind,
+          title: part.title,
+          byteSize: null,
+        },
+      ];
+    case "warning":
+      return [
+        {
+          type: "warning",
+          streamId: `warning-${part.code}`,
+          messageId: `warning-${part.code}`,
+          code: part.code,
+          message: part.message,
+        },
+      ];
+  }
+}
+
+/** Order-preserving deterministic shuffle-merge across stream event lists. */
+export function shuffleMerge(lists: CanonicalEvent[][], rng: Rng): CanonicalEvent[] {
+  const heads = lists.map(() => 0);
+  const out: CanonicalEvent[] = [];
+  for (;;) {
+    const open = heads
+      .map((head, index) => [head, index] as const)
+      .filter(([head, index]) => head < (lists[index]?.length ?? 0));
+    if (open.length === 0) return out;
+    const [head, index] = open[rng.int(0, open.length - 1)] as readonly [number, number];
+    const event = lists[index]?.[head];
+    if (event !== undefined) out.push(event);
+    heads[index] = head + 1;
+  }
+}
+
+export function renderLiveEvents(model: TurnModel): CanonicalEvent[] {
+  const rng = new Rng(model.seed ^ 0x5bd1e995);
+  const events: CanonicalEvent[] = [{ type: "turn_start", runId: model.runId, delivery: "live" }];
+  let index = 0;
+  while (index < model.parts.length) {
+    const part = model.parts[index];
+    if (part === undefined) break;
+    const streamLike =
+      part.kind === "reasoning" ||
+      part.kind === "code" ||
+      part.kind === "output" ||
+      part.kind === "text";
+    // Adjacent stream blocks are merged 40% of the time to exercise valid
+    // interleavings across independent stream identities.
+    const next = model.parts[index + 1];
+    const nextStreamLike =
+      next &&
+      (next.kind === "reasoning" ||
+        next.kind === "code" ||
+        next.kind === "output" ||
+        next.kind === "text");
+    if (streamLike && nextStreamLike && rng.chance(0.4)) {
+      events.push(...shuffleMerge([livePartEvents(part), livePartEvents(next)], rng));
+      index += 2;
+      continue;
+    }
+    events.push(...livePartEvents(part));
+    index += 1;
+  }
+  if (model.result) {
+    events.push({
+      type: "structured_result",
+      streamId: "result",
+      schemaId: model.result.schemaId,
+      schemaVersion: model.result.schemaVersion,
+      value: model.result.value,
+    });
+  }
+  for (const textDelta of model.trailingNarrative) {
+    events.push({ type: "text", streamId: "answer", textDelta, final: true, role: "assistant" });
+  }
+  if (model.usage) {
+    events.push({
+      type: "usage",
+      streamId: "usage-1",
+      messageId: "usage-1",
+      iterations: model.usage.iterations,
+      durationMs: model.usage.durationMs,
+      usage: model.usage.usage,
+    });
+  }
+  if (model.cancelled) {
+    events.push({ type: "turn_cancelled", reason: "operator cancel" });
+  } else {
+    if (model.finishReason === "error") {
+      events.push({ type: "error", text: "stream exploded" });
+    }
+    events.push({
+      type: "turn_finish",
+      finishReason: model.finishReason,
+      durationMs: model.usage?.durationMs ?? null,
+      checkpointVersion: null,
+    });
+  }
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Durable-normalized rendering (single-shot, terminally folded)
+// ---------------------------------------------------------------------------
+
+/** The complete assistant narrative collected across text parts (fold order). */
+export function foldedNarrative(model: TurnModel): string {
+  const fragments: string[] = [];
+  for (const part of model.parts) {
+    if (part.kind === "text") fragments.push(...part.fragments);
+  }
+  fragments.push(...model.trailingNarrative);
+  return fragments.join("");
+}
+
+export function renderDurableEvents(model: TurnModel): CanonicalEvent[] {
+  const events: CanonicalEvent[] = [{ type: "turn_context", runId: model.runId }];
+  let index = 0;
+  const nextId = () => {
+    index += 1;
+    return `d-${model.runId}-${index}`;
+  };
+  for (const part of model.parts) {
+    const messageId = nextId();
+    switch (part.kind) {
+      case "reasoning":
+        events.push({
+          type: "reasoning",
+          streamId: messageId,
+          messageId,
+          step: part.step,
+          text: part.fragments.join(""),
+          final: true,
+        });
+        break;
+      case "code":
+        events.push({
+          type: "code",
+          streamId: messageId,
+          messageId,
+          step: part.step,
+          codeDelta: part.fragments.join(""),
+          isDelta: false,
+          final: true,
+        });
+        break;
+      case "output":
+        events.push({
+          type: "output",
+          streamId: messageId,
+          messageId,
+          step: part.step,
+          outputDelta: part.fragments.join(""),
+          isDelta: false,
+          final: true,
+        });
+        break;
+      case "text":
+        // With a structured result the narrative folds onto the result card;
+        // without one each text part becomes its own settled message.
+        if (!model.result) {
+          events.push({
+            type: "text",
+            streamId: messageId,
+            messageId,
+            textDelta: part.fragments.join(""),
+            final: true,
+            role: "assistant",
+          });
+        }
+        break;
+      case "tool":
+        events.push({
+          type: "tool_call",
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          input: part.input,
+          messageId,
+        });
+        events.push(
+          part.error !== undefined
+            ? { type: "tool_result", toolCallId: part.toolCallId, error: part.error, messageId }
+            : { type: "tool_result", toolCallId: part.toolCallId, output: part.output, messageId },
+        );
+        break;
+      case "skill":
+        events.push({
+          type: "skill",
+          streamId: messageId,
+          messageId,
+          skillId: part.skillId,
+          phase: "activated",
+          name: part.name,
+        });
+        break;
+      case "attachment":
+        events.push({
+          type: "attachment",
+          streamId: messageId,
+          messageId,
+          attachmentId: part.attachmentId,
+          phase: "staged",
+          filename: part.filename,
+          byteSize: part.byteSize,
+        });
+        break;
+      case "artifact":
+        events.push({
+          type: "artifact",
+          streamId: messageId,
+          messageId,
+          artifactId: part.artifactId,
+          artifactKind: part.artifactKind,
+          title: part.title,
+          byteSize: null,
+        });
+        break;
+      case "warning":
+        events.push({
+          type: "warning",
+          streamId: messageId,
+          messageId,
+          code: part.code,
+          message: part.message,
+        });
+        break;
+    }
+  }
+  if (model.result) {
+    const messageId = nextId();
+    const narrative = foldedNarrative(model);
+    events.push({
+      type: "structured_result",
+      streamId: messageId,
+      messageId,
+      schemaId: model.result.schemaId,
+      schemaVersion: model.result.schemaVersion,
+      value: model.result.value,
+      ...(narrative ? { narrativeText: narrative } : {}),
+    });
+  }
+  if (model.usage) {
+    const messageId = nextId();
+    events.push({
+      type: "usage",
+      streamId: messageId,
+      messageId,
+      iterations: model.usage.iterations,
+      durationMs: model.usage.durationMs,
+      usage: model.usage.usage,
+    });
+  }
+  return events;
+}
+
+/** Compact, replayable dump attached to every invariant failure. */
+export function dumpModel(model: TurnModel): string {
+  return JSON.stringify(model);
+}

--- a/tools/fleet-tui/src/tui/tests/turn-reducer-invariants.test.ts
+++ b/tools/fleet-tui/src/tui/tests/turn-reducer-invariants.test.ts
@@ -1,0 +1,499 @@
+/**
+ * P32/QRE-194: canonical `TurnEventReducer` invariant proofs.
+ *
+ * Deterministic generated corpus (fixed seeds) + hand-authored regressions
+ * assert replay determinism, live/durable semantic parity, accumulation and
+ * replacement rules, tool lifecycle exclusivity, and terminal closure —
+ * without changing production reducer behavior.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { CanonicalEvent } from "../canonical.js";
+import { serializeCanonicalEvent } from "../canonical.js";
+import { normalizedNarrative } from "../projection-helpers.js";
+import type { Message, StoreEvent } from "../store.js";
+import { TurnEventReducer } from "../turn-reducer.js";
+import {
+  dumpModel,
+  foldedNarrative,
+  generateTurnModel,
+  renderDurableEvents,
+  renderLiveEvents,
+  type PartPlan,
+  type TurnModel,
+} from "./reducer-sequence-gen.js";
+
+/** Fixed seed corpus: CI is deterministic and every failure reports a seed. */
+const CORPUS_SEEDS = [
+  11, 42, 77, 101, 137, 211, 307, 401, 509, 613, 727, 823, 929, 1031, 1223, 1327, 1487, 1601, 1753,
+  1871, 1999, 2113, 2221, 2371, 2503, 2671,
+] as const;
+
+const clock = () => 100;
+
+/** Non-null-assertion-free single-element access; fails loudly when absent. */
+function sole<T>(items: readonly T[], what: string): T {
+  if (items.length !== 1) throw new Error(`expected exactly one ${what}, found ${items.length}`);
+  const [value] = items;
+  if (value === undefined) throw new Error(`missing ${what}`);
+  return value;
+}
+
+function reduceAll(events: CanonicalEvent[]): { store: StoreEvent[]; messages: Message[] } {
+  const reducer = new TurnEventReducer(clock);
+  const store: StoreEvent[] = [];
+  const byId = new Map<string, Message>();
+  for (const event of events) {
+    for (const emitted of reducer.push(event)) {
+      store.push(emitted);
+      if (emitted.type === "message/upsert") byId.set(emitted.message.id, emitted.message);
+    }
+  }
+  return { store, messages: [...byId.values()] };
+}
+
+/** Semantic projection: positional ids and clocks are adapter-owned. */
+function semanticView(messages: Message[]): Record<string, unknown>[] {
+  return messages.map((message) => {
+    const { id: _id, ts: _ts, ...rest } = message as Message & { runId?: string };
+    const { runId: _runId, ...visible } = rest;
+    return visible as Record<string, unknown>;
+  });
+}
+
+function family(messages: Message[], kind: Message["kind"]): Message[] {
+  return messages.filter((message) => message.kind === kind);
+}
+
+function byKind(messages: Message[]): Map<string, Message[]> {
+  const grouped = new Map<string, Message[]>();
+  for (const message of messages) {
+    const list = grouped.get(message.kind) ?? [];
+    list.push(message);
+    grouped.set(message.kind, list);
+  }
+  return grouped;
+}
+
+function expectSemanticParity(live: Message[], durable: Message[], context: () => string): void {
+  expect(durable.map((m) => m.kind).sort(), context()).toEqual(live.map((m) => m.kind).sort());
+  const liveByKind = byKind(live);
+  const durableByKind = byKind(durable);
+  for (const [kind, liveFamily] of liveByKind) {
+    expect(semanticView(durableByKind.get(kind) ?? []), `${context()} kind=${kind}`).toEqual(
+      semanticView(liveFamily),
+    );
+  }
+}
+
+function expectAccumulation(model: TurnModel, messages: Message[]): void {
+  const reasoningByStep = new Map<number, string>();
+  for (const part of model.parts) {
+    if (part.kind === "reasoning") {
+      reasoningByStep.set(
+        part.step,
+        (reasoningByStep.get(part.step) ?? "") + part.fragments.join(""),
+      );
+    }
+  }
+  const reasoningCards = family(messages, "reasoning");
+  expect(reasoningCards.length, "one reasoning card per streamed step").toBe(reasoningByStep.size);
+  for (const card of reasoningCards) {
+    if (card.kind === "reasoning") {
+      expect(card.text, `reasoning step ${card.step} accumulates without duplication`).toBe(
+        reasoningByStep.get(card.step),
+      );
+    }
+  }
+  for (const part of model.parts) {
+    if (part.kind === "code") {
+      const card = messages.find(
+        (message) => message.kind === "code" && message.step === part.step,
+      );
+      expect(
+        card && card.kind === "code" ? card.code : undefined,
+        "code folds without duplication",
+      ).toBe(part.fragments.join(""));
+    }
+    if (part.kind === "output") {
+      const card = messages.find(
+        (message) => message.kind === "output" && message.step === part.step,
+      );
+      expect(
+        card && card.kind === "output" ? card.output : undefined,
+        "output folds without duplication",
+      ).toBe(part.fragments.join(""));
+    }
+  }
+}
+
+function expectToolPairing(model: TurnModel, messages: Message[]): void {
+  const plans = model.parts.filter(
+    (part): part is PartPlan & { kind: "tool" } => part.kind === "tool",
+  );
+  const tools = family(messages, "tool");
+  expect(tools.length, "one tool card per invocation identity").toBe(plans.length);
+  const byToolCallId = new Map<string, Message>(
+    tools.map((message) => [message.kind === "tool" ? message.toolCallId : "", message]),
+  );
+  expect(byToolCallId.size).toBe(plans.length);
+  for (const plan of plans) {
+    const card = byToolCallId.get(plan.toolCallId);
+    if (!card || card.kind !== "tool") throw new Error(`missing tool card ${plan.toolCallId}`);
+    expect(card.name).toBe(plan.toolName);
+    expect(card.input).toEqual(plan.input);
+    // Terminal states are mutually exclusive and paired to one invocation.
+    expect(card.output !== undefined).toBe(plan.output !== undefined);
+    expect(card.error !== undefined).toBe(plan.error !== undefined);
+    expect(card.status).toBe(plan.error !== undefined ? "error" : "success");
+    expect(card.endedAt).toBeDefined();
+  }
+}
+
+function expectResultSemantics(model: TurnModel, messages: Message[]): void {
+  const results = family(messages, "result");
+  const texts = family(messages, "text");
+  if (!model.result) {
+    expect(results, "no structured result, no result card").toHaveLength(0);
+    const textParts = model.parts.filter((part) => part.kind === "text");
+    expect(texts.length).toBe(textParts.length);
+    return;
+  }
+  expect(results, "structured result replaces narrative with one final card").toHaveLength(1);
+  expect(texts, "no orphan text card survives replacement").toHaveLength(0);
+  const card = sole(results, "result card");
+  if (card.kind === "result") {
+    expect(card.schemaId).toBe(model.result.schemaId);
+    expect(card.schemaVersion).toBe(model.result.schemaVersion);
+    expect(card.value).toEqual(model.result.value);
+    expect(card.narrative).toEqual(normalizedNarrative(foldedNarrative(model), model.result.value));
+  }
+}
+
+function expectTerminalClosure(messages: Message[]): void {
+  for (const message of messages) {
+    if (message.kind === "text" || message.kind === "code" || message.kind === "output") {
+      expect(message.streaming, `${message.kind} card closed at turn end`).toBe(false);
+    }
+  }
+}
+
+function expectPrimitiveIdentityOrder(model: TurnModel, a: Message[], b: Message[]): void {
+  const identity = (message: Message): string => {
+    switch (message.kind) {
+      case "artifact":
+        return `artifact:${message.artifactId}:${message.name}`;
+      case "attachment":
+        return `attachment:${message.attachmentId}:${message.filename}`;
+      case "skill":
+        return `skill:${message.skillId}:${message.name}`;
+      case "warning":
+        return `warning:${message.code}:${message.message}`;
+      default:
+        return message.kind;
+    }
+  };
+  for (const kind of ["artifact", "attachment", "skill", "warning"] as const) {
+    const one = family(a, kind).map(identity);
+    const two = family(b, kind).map(identity);
+    expect(two, `${kind} identities keep stable order under both routes`).toEqual(one);
+  }
+}
+
+/** Attach a replayable report (seed + compact model + both sequences) to any failure. */
+function prove(model: TurnModel, invariant: () => void): void {
+  const live = renderLiveEvents(model);
+  const durable = renderDurableEvents(model);
+  try {
+    invariant();
+  } catch (error) {
+    const liveDump = live.map((event) => JSON.stringify(serializeCanonicalEvent(event))).join("\n");
+    const durableDump = durable
+      .map((event) => JSON.stringify(serializeCanonicalEvent(event)))
+      .join("\n");
+    const cause = error instanceof Error ? `${error.message}\n${error.stack ?? ""}` : String(error);
+    throw new Error(
+      `P32 invariant failed (seed=${model.seed}); re-run with CORPUS_SEEDS=[${model.seed}]\n` +
+        `model=${dumpModel(model)}\nlive=\n${liveDump}\ndurable=\n${durableDump}\ncause=${cause}`,
+    );
+  }
+}
+
+describe("turn reducer generated invariants", () => {
+  for (const seed of CORPUS_SEEDS) {
+    describe(`seed ${seed}`, () => {
+      const model = generateTurnModel(seed);
+
+      it("reduces the same sequence to a deep-equal final state (replay determinism)", () => {
+        prove(model, () => {
+          const live = renderLiveEvents(model);
+          const first = reduceAll(live);
+          const second = reduceAll(live);
+          expect(second.messages).toEqual(first.messages);
+          expect(second.store).toEqual(first.store);
+          const durable = renderDurableEvents(model);
+          expect(reduceAll(durable).messages).toEqual(reduceAll(durable).messages);
+        });
+      });
+
+      it("live-normalized and durable-normalized turns converge semantically", () => {
+        prove(model, () => {
+          const live = reduceAll(renderLiveEvents(model)).messages;
+          const durable = reduceAll(renderDurableEvents(model)).messages.filter(
+            (message) => message.kind !== "error",
+          );
+          expectSemanticParity(
+            live.filter((message) => message.kind !== "error"),
+            durable,
+            () => `seed=${model.seed} kind parity`,
+          );
+          expectPrimitiveIdentityOrder(model, live, durable);
+        });
+      });
+
+      it("accumulates text/reasoning/code/output without duplication", () => {
+        prove(model, () => {
+          expectAccumulation(model, reduceAll(renderLiveEvents(model)).messages);
+        });
+      });
+
+      it("keeps tool terminal states exclusive and paired to one invocation", () => {
+        prove(model, () => {
+          expectToolPairing(model, reduceAll(renderLiveEvents(model)).messages);
+          expectToolPairing(model, reduceAll(renderDurableEvents(model)).messages);
+        });
+      });
+
+      it("yields at most one final structured-result card", () => {
+        prove(model, () => {
+          expectResultSemantics(model, reduceAll(renderLiveEvents(model)).messages);
+          expectResultSemantics(model, reduceAll(renderDurableEvents(model)).messages);
+        });
+      });
+
+      it("closes every streaming card at terminal state", () => {
+        prove(model, () => {
+          expectTerminalClosure(reduceAll(renderLiveEvents(model)).messages);
+          expectTerminalClosure(reduceAll(renderDurableEvents(model)).messages);
+        });
+      });
+
+      it("keeps usage and execution summary parity", () => {
+        if (!model.usage) return;
+        prove(model, () => {
+          for (const events of [renderLiveEvents(model), renderDurableEvents(model)]) {
+            const usageCards = family(reduceAll(events).messages, "usage");
+            expect(usageCards).toHaveLength(1);
+            const card = sole(usageCards, "usage card");
+            const usagePlan = model.usage;
+            if (usagePlan && card.kind === "usage") {
+              expect(card.iterations).toBe(usagePlan.iterations);
+              expect(card.executionSummary?.iterations).toBe(usagePlan.iterations);
+            }
+          }
+        });
+      });
+
+      it("replay in one reducer upserts stable ids without duplicating content", () => {
+        prove(model, () => {
+          const reducer = new TurnEventReducer(clock);
+          const byId = new Map<string, Message>();
+          for (let round = 0; round < 2; round += 1) {
+            for (const event of renderDurableEvents(model)) {
+              for (const emitted of reducer.push(event)) {
+                if (emitted.type === "message/upsert")
+                  byId.set(emitted.message.id, emitted.message);
+              }
+            }
+          }
+          const messages = [...byId.values()];
+          // Upsert-stable kinds must not duplicate under replay.
+          expect(family(messages, "reasoning")).toHaveLength(
+            family(reduceAll(renderDurableEvents(model)).messages, "reasoning").length,
+          );
+          expect(family(messages, "code")).toHaveLength(
+            family(reduceAll(renderDurableEvents(model)).messages, "code").length,
+          );
+          expect(family(messages, "result")).toHaveLength(
+            family(reduceAll(renderDurableEvents(model)).messages, "result").length,
+          );
+        });
+      });
+    });
+  }
+});
+
+describe("turn reducer defensive invalid-input handling", () => {
+  it("ignores a reasoning end marker with no open stream", () => {
+    const reducer = new TurnEventReducer(clock);
+    const events = reducer.push({
+      type: "reasoning",
+      streamId: "ghost-1",
+      step: 0,
+      text: "",
+      final: true,
+    });
+    expect(events).toEqual([]);
+  });
+
+  it("mints a settled tool card for a result without a known call", () => {
+    const reducer = new TurnEventReducer(clock);
+    reducer.push({ type: "turn_start", runId: "r1", delivery: "live" });
+    const out = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "tool_result", toolCallId: "orphan-1", output: { ok: true } },
+    ]);
+    const tools = family(out.messages, "tool");
+    expect(tools).toHaveLength(1);
+    const card = sole(tools, "tool card");
+    if (card.kind === "tool") {
+      expect(card.toolCallId).toBe("orphan-1");
+      expect(card.status).toBe("success");
+      expect(card.output).toEqual({ ok: true });
+    }
+    void reducer;
+  });
+
+  it("keeps duplicate provided artifact occurrences as two distinct acts", () => {
+    const byId = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      {
+        type: "artifact",
+        streamId: "artifact-1",
+        messageId: "artifact-1",
+        artifactId: "a1",
+        title: "one",
+      },
+      {
+        type: "artifact",
+        streamId: "artifact-1",
+        messageId: "artifact-1",
+        artifactId: "a1",
+        title: "one",
+      },
+    ]);
+    expect(family(byId.messages, "artifact")).toHaveLength(2);
+  });
+});
+
+describe("turn reducer regression fixtures", () => {
+  it("reopens a reasoning card when its :canonical twin arrives with corrected text", () => {
+    const { messages } = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "reasoning", streamId: "reasoning-3", step: 0, text: "", final: false },
+      { type: "reasoning", streamId: "reasoning-3", step: 0, text: "stale ", final: false },
+      { type: "reasoning", streamId: "reasoning-3", step: 0, text: "", final: true },
+      { type: "reasoning", streamId: "reasoning-3:canonical", step: 3, text: "", final: false },
+      {
+        type: "reasoning",
+        streamId: "reasoning-3:canonical",
+        step: 3,
+        text: "corrected ",
+        final: false,
+      },
+      { type: "reasoning", streamId: "reasoning-3:canonical", step: 3, text: "text", final: true },
+    ]);
+    const reasoningCards = family(messages, "reasoning");
+    expect(reasoningCards).toHaveLength(1);
+    const card = sole(reasoningCards, "reasoning card");
+    if (card.kind === "reasoning") {
+      // The twin's fresh start marker cleared the stale stream, and its final
+      // full-text fold settled the card.
+      expect(card.text).toBe("text");
+      expect(card.step).toBe(3);
+    }
+  });
+
+  it("lets a durable single-shot final fold replace accumulated reasoning text", () => {
+    const { messages } = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "reasoning", streamId: "reasoning-4", step: 0, text: "", final: false },
+      { type: "reasoning", streamId: "reasoning-4", step: 0, text: "fragment ", final: false },
+      { type: "reasoning", streamId: "reasoning-4", step: 0, text: "accumulation", final: false },
+      {
+        type: "reasoning",
+        streamId: "reasoning-4",
+        step: 4,
+        text: "settled full text",
+        final: true,
+      },
+    ]);
+    const card = sole(family(messages, "reasoning"), "reasoning card");
+    if (card.kind === "reasoning") {
+      expect(card.text).toBe("settled full text");
+      expect(card.step).toBe(4);
+    }
+  });
+
+  it("replaces the streamed text card with one structured result card", () => {
+    const { messages } = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "text", streamId: "answer", textDelta: "", final: false, role: "assistant" },
+      {
+        type: "text",
+        streamId: "answer",
+        textDelta: "The answer is 42.",
+        final: false,
+        role: "assistant",
+      },
+      { type: "text", streamId: "answer", textDelta: "", final: true, role: "assistant" },
+      {
+        type: "structured_result",
+        streamId: "result",
+        schemaId: "s",
+        schemaVersion: "1",
+        value: { answer: "42" },
+      },
+    ]);
+    expect(family(messages, "text")).toHaveLength(0);
+    const results = family(messages, "result");
+    expect(results).toHaveLength(1);
+    const card = sole(results, "result card");
+    if (card.kind === "result") {
+      expect(card.narrative).toBe("The answer is 42.");
+    }
+  });
+
+  it("appends post-result narrative deltas to the result card", () => {
+    const { messages } = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "text", streamId: "answer", textDelta: "base ", final: false, role: "assistant" },
+      {
+        type: "structured_result",
+        streamId: "result",
+        schemaId: "s",
+        schemaVersion: "1",
+        value: { answer: "x" },
+      },
+      { type: "text", streamId: "answer", textDelta: "trailing", final: true, role: "assistant" },
+    ]);
+    const results = family(messages, "result");
+    expect(results).toHaveLength(1);
+    const card = sole(results, "result card");
+    if (card.kind === "result") {
+      expect(card.narrative).toBe("base trailing");
+    }
+  });
+
+  it("carries the stream error onto an error finish without minting finish cards", () => {
+    const { store } = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "error", text: "provider exploded" },
+      { type: "turn_finish", finishReason: "error", durationMs: 12, checkpointVersion: null },
+    ]);
+    const finish = store.find((event) => event.type === "run/finish");
+    expect(finish && finish.type === "run/finish" ? finish.error : undefined).toBe(
+      "provider exploded",
+    );
+  });
+
+  it("cancels without a run/finish event", () => {
+    const { store } = reduceAll([
+      { type: "turn_start", runId: "r1", delivery: "live" },
+      { type: "turn_cancelled", reason: "operator cancel" },
+    ]);
+    expect(store.some((event) => event.type === "run/finish")).toBe(false);
+    expect(store.some((event) => event.type === "run/cancelled")).toBe(true);
+  });
+});

--- a/tools/fleet-tui/src/tui/usage-summary.ts
+++ b/tools/fleet-tui/src/tui/usage-summary.ts
@@ -1,3 +1,4 @@
+import { record } from "./coerce.js";
 import type { Message } from "./store.js";
 
 export type ObservedTokenCounts = {
@@ -65,12 +66,6 @@ function sumObservedMetric(
   }
 
   return observed ? total : null;
-}
-
-function record(value: unknown): Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
 }
 
 function nonnegativeNumber(value: unknown): number | null {


### PR DESCRIPTION
## Summary

- make the typed Settings schema authoritative for TOML policy, editor inventory, and environment references
- add sanitized, fail-soft Workspace Memory degradation diagnostics
- remove obsolete compatibility seams and consolidate Daytona/session/recursive-runtime ownership paths
- add canonical-path and TUI reducer contraction guardrails

## Validation

- `make check`
- backend unit/contract tests and coverage
- TUI tests: 478 passed
- Ruff and `ty check src`
- OpenAPI, stream fixture, docs, and harness checks

Credentialed live Daytona/provider validation was not run.