### PR TITLE
fix: align DSPy main and consolidate workspace tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.7.3] - 2026-08-20
+
+### Changed
+
+- **Change:** Aligned the native DSPy integration with the upstream `main`
+  revision while preserving the aggregated completion contract used by Fleet's
+  RLM runtime.
+  **Outcome:** DSPy upstream changes can be locked and consumed without
+  reintroducing raw streaming request-shape incompatibilities.
+- **Change:** Consolidated Session Workspace and Project tools behind shared
+  public factories and host-owned descriptions, preserving append capability
+  and event-view contracts.
+  **Outcome:** Both hosts share one explicit tool seam while retaining their
+  distinct filesystem scopes and operator-visible event behavior.
+- **Change:** Simplified Daytona runtime lifecycle cleanup and centralized
+  memory-record formatting.
+  **Outcome:** Runtime ownership and durable memory output remain easier to
+  reason about.
+
+### Fixed
+
+- **Change:** Broadened callback failure handling to include cancellation and
+  other `BaseException` paths, and made workspace/project tool error returns
+  explicit.
+  **Outcome:** Interruptions and filesystem failures settle through the
+  intended error contracts instead of relying on implicit nested-function
+  returns.
+
 ## [0.7.2] - 2026-08-19
 
 ### Added

--- a/docs/how-to-guides/dspy-integration.md
+++ b/docs/how-to-guides/dspy-integration.md
@@ -88,7 +88,9 @@ clients cannot provide models, Signatures, or executable capabilities.
   `rlm.acall(interpreter, ...)` delegates request and response normalization to
   stock DSPy. Application code does not call LM `forward()` methods, construct
   provider-shaped requests, or opt into DSPy's experimental typed LM API while
-  the supported DSPy 3.3.x line is selected. The current lock resolves 3.3.0.
+  the supported DSPy 3.3.x line is selected. The current lock resolves
+  the upstream `main` source at version 3.3.0; refresh the lock to capture newer
+  upstream commits.
   See DSPy's
   [normalized LM API migration](https://dspy.ai/community/normalized-lm-api-migration/).
 - Do not replace the Turn-scoped adapter with global `dspy.configure()`.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.7.2
+  version: 0.7.3
 paths:
   /api/sessions/{session_id}/turns:
     post:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,13 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # dspy 3.3.x provides the native RLM and SandboxSerializable contracts used
-    # by Fleet. Pin the 3.3 line: assert_dspy_version() accepts 3.3.x patches
+    # Track DSPy's upstream main for the latest changes while uv.lock records
+    # the resolved commit for reproducible installs. The supported Fleet
+    # contract remains DSPy 3.3.x: assert_dspy_version() accepts 3.3.x patches
     # and rejects other minors, and the runtime relies on the documented RLM
     # interface plus the private interpreter-injection seam isolated in
     # rlm.dspy_contract.
-    "dspy>=3.3.0,<3.4",
+    "dspy @ git+https://github.com/stanfordnlp/dspy.git@main",
     "packaging>=24,<27",
     # Sandboxed execution.
     "daytona==0.202.0",
@@ -141,14 +142,11 @@ override-dependencies = [
     "litellm>=1.87.0",
     # urllib3 <2.7.0 has redirect header leak and streaming decompression issues.
     "urllib3>=2.7.0",
-    # Deliberate gepa override: the current dspy 3.3.0 lock declares
-    # gepa[dspy]==0.1.1, but
-    # the optimizer lane needs the omni API (optimize_best_of / gepa.oa
-    # engines), which exists only on the gepa main branch as of 2026-08. This
-    # pinned commit is what the 2026-07-22 omni blog documents. Fleet's Turn
-    # path never invokes dspy.GEPA; coexistence of the current dspy 3.3.0 lock with this gepa
-    # commit is validated by `make check` (2026-08 omni spike). Revisit when
-    # the DSPy gepa[dspy] constraint moves or a PyPI release ships the omni API.
+    # Deliberate gepa override: the optimizer lane needs the omni API
+    # (optimize_best_of / gepa.oa engines). Keep this reviewed commit until
+    # the upstream DSPy/GEPA dependency and Fleet's optimizer checks no longer
+    # need the override. Fleet's Turn path never invokes dspy.GEPA; coexistence
+    # with this gepa commit is validated by `make check`.
     "gepa @ git+https://github.com/gepa-ai/gepa@0310bb7b4952d4695718f9f557e450fd6781301e",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-rlm"
-version = "0.7.2"
+version = "0.7.3"
 description = "RLM-native FastAPI backend with DSPy and Daytona"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/fleet_rlm/daytona/run_environment.py
+++ b/src/fleet_rlm/daytona/run_environment.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, cast
@@ -50,8 +49,6 @@ from fleet_rlm.daytona.workspace_fs import AsyncDaytonaVolumeFS, DaytonaSandboxV
 from fleet_rlm.files.memory_candidates import MemoryCandidateCollector, build_memory_promotion_intents
 from fleet_rlm.files.memory_models import WORKSPACE_MEMORY_INJECTION_TAIL_BYTES
 from fleet_rlm.files.models import (
-    AttachmentAccess,
-    AttachmentRun,
     PreparedAttachments,
 )
 from fleet_rlm.files.volume_paths import VolumePaths, volume_paths_from_settings
@@ -319,20 +316,6 @@ class _DaytonaEnvironmentProvider:
             raise
 
 
-@dataclass(slots=True)
-class _LiveAttachmentLifecycle:
-    attachment_lifecycle: Any
-
-    async def prepare_run(
-        self,
-        access: AttachmentAccess,
-        attachment_ids: Sequence[UUID],
-        run: AttachmentRun,
-        sink: Any,
-    ) -> PreparedAttachments:
-        return await self.attachment_lifecycle.prepare_run(access, attachment_ids, run, sink)
-
-
 async def _prepare_memory_digest(memory_store: Any, *, request: str) -> str:
     """Return the per-Run injection digest, degrading fail-soft with diagnostics.
 
@@ -583,7 +566,7 @@ def build_run_preparation(
         models=models,
         options=options,
         recursive_options=recursive_rlm_options(settings),
-        attachments=_LiveAttachmentLifecycle(attachment_lifecycle),
+        attachments=attachment_lifecycle,
         environments=_DaytonaEnvironmentProvider(resources, settings),
         capabilities=_LiveCapabilityPreparer(settings, skill_catalog, volume_paths=resources.volume_paths),
     )

--- a/src/fleet_rlm/daytona/sandbox_lease.py
+++ b/src/fleet_rlm/daytona/sandbox_lease.py
@@ -178,13 +178,6 @@ class SandboxLeasePolicy:
     provider_request_timeout_s: float | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class SandboxLeaseReceiptStore:
-    """Simplest owner-visible receipt carrier: last close outcome."""
-
-    receipt: SandboxLeaseReceipt | None = None
-
-
 class SandboxLease:
     """Owns one Sandbox handle and its confirmed, idempotent close.
 

--- a/src/fleet_rlm/daytona/workspace_fs.py
+++ b/src/fleet_rlm/daytona/workspace_fs.py
@@ -465,11 +465,7 @@ class DaytonaSandboxVolumeFs:
 
 
 def _is_under(path: str, root: str) -> bool:
-    try:
-        PurePosixPath(path).relative_to(PurePosixPath(root))
-    except ValueError:
-        return False
-    return True
+    return _is_relative_to(PurePosixPath(path), PurePosixPath(root))
 
 
 def _provider_not_found(exc: BaseException) -> bool:

--- a/src/fleet_rlm/files/memory_models.py
+++ b/src/fleet_rlm/files/memory_models.py
@@ -149,6 +149,24 @@ def normalize_workspace_memory_learning(key_learning: str) -> str:
     return learning
 
 
+def _v3_record_line(
+    *,
+    timestamp: str,
+    category: str,
+    learning: str,
+    memory_id: str,
+    source: str,
+    updated_at: str,
+    supersedes_id: str | None = None,
+) -> str:
+    """Emit one canonical v3 record line (single owner of the v3 on-disk shape)."""
+    supersession = f" supersedes:{supersedes_id}" if supersedes_id is not None else ""
+    return (
+        f"- [{timestamp}] **{category}** <!-- id:{memory_id} source:{source} "
+        f"updated:{updated_at}{supersession} -->: {learning}\n"
+    )
+
+
 def format_workspace_memory_record(
     key_learning: str,
     category: str,
@@ -162,9 +180,13 @@ def format_workspace_memory_record(
         raise WorkspaceMemoryRecordError
     timestamp_text = timestamp.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     memory_id = workspace_memory_record_id(timestamp_text, normalized_category, learning)
-    record = (
-        f"- [{timestamp_text}] **{normalized_category}** <!-- id:{memory_id} source:user_explicit "
-        f"updated:{timestamp_text} -->: {learning}\n"
+    record = _v3_record_line(
+        timestamp=timestamp_text,
+        category=normalized_category,
+        learning=learning,
+        memory_id=memory_id,
+        source="user_explicit",
+        updated_at=timestamp_text,
     )
     validate_workspace_memory_record(record)
     return record, normalized_category
@@ -233,10 +255,14 @@ def format_workspace_memory_v3_record(
         raise WorkspaceMemoryRecordError
     if supersedes_id is not None:
         normalize_workspace_memory_id(supersedes_id)
-    supersession = f" supersedes:{supersedes_id}" if supersedes_id is not None else ""
-    record = (
-        f"- [{created_at}] **{normalized_category}** <!-- id:{memory_id} source:{source} "
-        f"updated:{updated_at}{supersession} -->: {learning}\n"
+    record = _v3_record_line(
+        timestamp=created_at,
+        category=normalized_category,
+        learning=learning,
+        memory_id=memory_id,
+        source=source,
+        updated_at=updated_at,
+        supersedes_id=supersedes_id,
     )
     validate_workspace_memory_record(record)
     return record

--- a/src/fleet_rlm/files/project_tools.py
+++ b/src/fleet_rlm/files/project_tools.py
@@ -10,18 +10,22 @@ the Session Workspace; durable deliverables belong in a Project.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import asdict
-from types import MappingProxyType
-from typing import Any, NoReturn, cast
+from typing import NoReturn
 
 import dspy
 
 from fleet_rlm.files.volume_paths import UnsafePathError, validate_project_slug
-from fleet_rlm.files.workspace_models import SessionWorkspaceFS, WorkspaceEntry
-from fleet_rlm.files.workspace_tools import MAX_WORKSPACE_READ_CHARS, WorkspaceToolError, _translate_fs_tool_errors
-from fleet_rlm.files.workspace_validation import WorkspacePathError, normalize_workspace_path
-from fleet_rlm.rlm.events import JsonValue
-from fleet_rlm.rlm.tool_observer import ToolEventView, bound_event_text
+from fleet_rlm.files.workspace_models import SessionWorkspaceFS
+from fleet_rlm.files.workspace_tools import (
+    MAX_WORKSPACE_READ_CHARS,
+    WorkspaceToolError,
+    _translate_fs_tool_errors,
+    _workspace_like_event_views,
+    _workspace_like_tools,
+    _WorkspaceLikeConfig,
+)
+from fleet_rlm.files.workspace_validation import normalize_workspace_path
+from fleet_rlm.rlm.tool_observer import ToolEventView
 
 MAX_PROJECT_READ_CHARS = MAX_WORKSPACE_READ_CHARS
 PROJECT_WORKSPACE_NAMESPACE = "project_workspace"
@@ -33,13 +37,6 @@ class ProjectToolError(WorkspaceToolError):
     Subclasses ``WorkspaceToolError`` so the interpreter bridge keeps rendering
     structured ``{"ok": False, "error": code}`` results for project tools.
     """
-
-
-def _entry(entry: WorkspaceEntry) -> dict[str, object]:
-    result = asdict(entry)
-    if result.get("checksum_sha256") is None:
-        result.pop("checksum_sha256")
-    return result
 
 
 def _raise_tool_error(exc: BaseException) -> NoReturn:
@@ -88,345 +85,26 @@ class ProjectToolHost:
         self._max_file_bytes = max(1, int(max_file_bytes))
 
     def as_tools(self) -> tuple[dspy.Tool, ...]:
-        def list_project_files(
-            path: str = ".",
-            limit: int = 100,
-            after: str | None = None,
-        ) -> dict[str, object]:
-            """List immediate entries in one Project or the projects root."""
-            try:
-                if limit < 1 or limit > 100:
-                    raise ProjectToolError("invalid_path", "Project list bound is invalid")
-                listing = self._workspace.list_entries(
-                    _normalize_project_path(path, allow_root=True),
-                    limit=limit,
-                    after=after,
-                )
-                return {
-                    "ok": True,
-                    "namespace": PROJECT_WORKSPACE_NAMESPACE,
-                    "path": path,
-                    "count": len(listing.entries),
-                    "truncated": listing.truncated,
-                    "next_cursor": listing.next_cursor,
-                    "entries": [_entry(item) for item in listing.entries],
-                }
-            except Exception as exc:
-                _raise_tool_error(exc)
-
-        def stat_project_file(path: str) -> dict[str, object]:
-            """Return bounded metadata for one Project path."""
-            try:
-                entry = self._workspace.stat(_normalize_project_path(path, allow_root=True))
-                if entry is None:
-                    raise ProjectToolError("not_found", "Project file was not found")
-                return {"ok": True, "namespace": PROJECT_WORKSPACE_NAMESPACE, "entry": _entry(entry)}
-            except WorkspaceToolError:
-                raise
-            except Exception as exc:
-                _raise_tool_error(exc)
-
-        def read_project_text(
-            path: str,
-            cursor: str | None = None,
-            max_chars: int = MAX_PROJECT_READ_CHARS,
-        ) -> dict[str, object]:
-            """Read one UTF-8 Project file page without returning more than max_chars."""
-            if max_chars < 1 or max_chars > MAX_PROJECT_READ_CHARS:
-                raise ProjectToolError("invalid_path", "Project read bound is invalid")
-            try:
-                page = self._workspace.read_text_page(
-                    _project_file_path(path),
-                    cursor=cursor,
-                    max_chars=max_chars,
-                    max_bytes=self._max_file_bytes,
-                )
-            except Exception as exc:
-                _raise_tool_error(exc)
-            return {
-                "ok": True,
-                "namespace": PROJECT_WORKSPACE_NAMESPACE,
-                "path": path,
-                "content": page.content,
-                "next_cursor": page.next_cursor,
-                "byte_size": page.byte_size,
-                "eof": page.eof,
-            }
-
-        def write_project_text(
-            path: str,
-            content: str,
-            overwrite: bool = False,
-        ) -> dict[str, object]:
-            """Write one UTF-8 deliverable immediately under projects/<slug>/."""
-            if not isinstance(content, str):
-                raise ProjectToolError("invalid_path", "Project content must be text")
-            if len(content.encode("utf-8")) > self._max_file_bytes:
-                raise ProjectToolError("too_large", "Project file exceeds the maximum size")
-            try:
-                result = {
-                    "ok": True,
-                    "namespace": PROJECT_WORKSPACE_NAMESPACE,
-                    **_entry(self._workspace.write_text(_project_file_path(path), content, overwrite=overwrite)),
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
-
-        def delete_project_path(path: str, expected_sha256: str | None = None) -> dict[str, object]:
-            """Delete one file or empty directory immediately under projects/<slug>/."""
-            try:
-                # "." (the projects root) is refused by normalization itself.
-                normalized = _normalize_project_path(path)
-                self._workspace.delete_path(normalized, expected_sha256=expected_sha256)
-                result: dict[str, object] = {
-                    "ok": True,
-                    "namespace": PROJECT_WORKSPACE_NAMESPACE,
-                    "path": normalized,
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
-
-        def edit_project_text(
-            path: str,
-            old: str,
-            new: str,
-            expected_sha256: str | None = None,
-        ) -> dict[str, object]:
-            """Replace exactly one unique occurrence of old with new in one UTF-8 Project file."""
-            if not isinstance(old, str) or not old or not isinstance(new, str):
-                raise ProjectToolError("invalid_path", "Project edit requires non-empty old and new text")
-            if len(old.encode("utf-8")) > self._max_file_bytes or len(new.encode("utf-8")) > self._max_file_bytes:
-                raise ProjectToolError("too_large", "Project file exceeds the maximum size")
-            try:
-                normalized = _project_file_path(path)
-                entry = _entry(self._workspace.patch_text(normalized, old, new, expected_sha256=expected_sha256))
-                # The LLM-facing result keeps its established 4-key entry
-                # shape; the precondition checksum is a transport concern.
-                entry.pop("checksum_sha256", None)
-                result: dict[str, object] = {
-                    "ok": True,
-                    "namespace": PROJECT_WORKSPACE_NAMESPACE,
-                    **entry,
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
-
-        return (
-            dspy.Tool(
-                list_project_files,
-                name="list_project_files",
-                desc=(
-                    "List immediate entries under projects/<slug>/ (or the projects root) only when existing "
-                    "durable Project deliverables are relevant; do not explore them for a self-contained request."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 100},
-                    "after": {"type": ["string", "null"]},
-                },
-            ),
-            dspy.Tool(
-                stat_project_file,
-                name="stat_project_file",
-                desc="Read bounded metadata for a relevant durable Project deliverable path under projects/<slug>/.",
-                args={"path": {"type": "string"}},
-            ),
-            dspy.Tool(
-                read_project_text,
-                name="read_project_text",
-                desc=(
-                    "Read one relevant UTF-8 Project deliverable page with max_chars in 1..10000 using a "
-                    "projects/<slug>/<path> target. Continue with next_cursor until eof."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "cursor": {"type": ["string", "null"]},
-                    "max_chars": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": MAX_PROJECT_READ_CHARS,
-                    },
-                },
-            ),
-            dspy.Tool(
-                write_project_text,
-                name="write_project_text",
-                desc=(
-                    "Write UTF-8 text immediately as a durable deliverable under projects/<slug>/ when the "
-                    "result must stay browsable across Sessions; choose a short repo/task-derived slug and "
-                    "keep scratch in the Session Workspace. This durability is independent of Turn Commit."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "content": {"type": "string"},
-                    "overwrite": {"type": "boolean"},
-                },
-            ),
-            dspy.Tool(
-                delete_project_path,
-                name="delete_project_path",
-                desc=(
-                    "Delete one file or one empty directory immediately under projects/<slug>/; non-empty "
-                    "directories are refused, and a supplied expected_sha256 guards against deleting "
-                    "changed content. This durability is independent of Turn Commit."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "expected_sha256": {"type": ["string", "null"]},
-                },
-            ),
-            dspy.Tool(
-                edit_project_text,
-                name="edit_project_text",
-                desc=(
-                    "Replace exactly one unique occurrence of old with new in one UTF-8 Project file under "
-                    "projects/<slug>/; the edit fails when old is absent or occurs more than once, and a "
-                    "supplied expected_sha256 guards against editing changed content. Read the file first "
-                    "and keep old short and unique. This durability is independent of Turn Commit."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "old": {"type": "string"},
-                    "new": {"type": "string"},
-                    "expected_sha256": {"type": ["string", "null"]},
-                },
-            ),
+        config = _WorkspaceLikeConfig(
+            namespace=PROJECT_WORKSPACE_NAMESPACE,
+            domain="Project",
+            error_type=ProjectToolError,
+            read_max_chars=MAX_PROJECT_READ_CHARS,
+            normalize_list_path=lambda path: _normalize_project_path(path, allow_root=True),
+            normalize_file_path=_project_file_path,
+            # Project delete normalizes with _normalize_project_path (not _project_file_path):
+            # "." (the projects root) is refused by normalization itself.
+            normalize_mutation_path=_normalize_project_path,
+            # Project edit requires the target to name a file inside a project.
+            normalize_edit_path=_project_file_path,
+            has_append=False,
+            verb="project",
         )
+        return _workspace_like_tools(self._workspace, max_file_bytes=self._max_file_bytes, config=config)
 
     def event_views(self) -> Mapping[str, ToolEventView]:
         """Return bounded metadata-only projections for Project Tools."""
-
-        def fields(
-            arguments: Mapping[str, Any],
-            names: tuple[str, ...],
-            *,
-            allow_root: bool = False,
-        ) -> dict[str, JsonValue]:
-            projected: dict[str, JsonValue] = {}
-            for name in names:
-                if name not in arguments:
-                    continue
-                value = arguments[name]
-                if name == "path":
-                    try:
-                        value = _normalize_project_path(str(value), allow_root=allow_root)
-                    except (WorkspacePathError, WorkspaceToolError):
-                        continue
-                projected[name] = bound_event_text(value) if isinstance(value, str) else cast(JsonValue, value)
-            return projected
-
-        def output(result: object, names: tuple[str, ...]) -> JsonValue:
-            if not isinstance(result, Mapping):
-                return {}
-            values = cast(Mapping[str, JsonValue], result)
-            return {
-                name: bound_event_text(values[name]) if isinstance(values[name], str) else values[name]
-                for name in names
-                if name in values
-            }
-
-        def stat_output(result: object) -> JsonValue:
-            if not isinstance(result, Mapping):
-                return {}
-            values = cast(Mapping[str, JsonValue], result)
-            projected: dict[str, JsonValue] = {
-                name: bound_event_text(values[name]) if isinstance(values[name], str) else values[name]
-                for name in ("ok", "error")
-                if name in values
-            }
-            entry = result.get("entry")
-            if isinstance(entry, Mapping):
-                entry_values = cast(Mapping[str, JsonValue], entry)
-                projected.update(
-                    {
-                        name: bound_event_text(entry_values[name])
-                        if isinstance(entry_values[name], str)
-                        else entry_values[name]
-                        for name in ("path", "byte_size")
-                        if name in entry_values
-                    }
-                )
-            return projected
-
-        def write_input(arguments: Mapping[str, Any]) -> JsonValue:
-            content = arguments.get("content")
-            return {
-                **fields(arguments, ("path", "overwrite")),
-                "content_chars": len(str(content or "")),
-            }
-
-        def edit_input(arguments: Mapping[str, Any]) -> JsonValue:
-            # Edit fragments stay private; only their sizes are observable.
-            return {
-                **fields(arguments, ("path",)),
-                "old_chars": len(str(arguments.get("old") or "")),
-                "new_chars": len(str(arguments.get("new") or "")),
-                "checksum_precondition": bool(arguments.get("expected_sha256")),
-            }
-
-        def delete_input(arguments: Mapping[str, Any]) -> JsonValue:
-            return {
-                **fields(arguments, ("path",)),
-                "checksum_precondition": bool(arguments.get("expected_sha256")),
-            }
-
-        return MappingProxyType(
-            {
-                "list_project_files": ToolEventView(
-                    input_projection=lambda arguments: fields(
-                        arguments,
-                        ("path", "limit", "after"),
-                        allow_root=True,
-                    ),
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "error", "path", "count", "truncated", "next_cursor"),
-                    ),
-                ),
-                "stat_project_file": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path",), allow_root=True),
-                    output_projection=stat_output,
-                ),
-                "read_project_text": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path", "cursor", "max_chars")),
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "next_cursor", "byte_size", "eof"),
-                    ),
-                    allow_repeated_identical=True,
-                ),
-                "write_project_text": ToolEventView(
-                    input_projection=write_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "byte_size", "warnings"),
-                    ),
-                ),
-                "delete_project_path": ToolEventView(
-                    input_projection=delete_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "warnings"),
-                    ),
-                ),
-                "edit_project_text": ToolEventView(
-                    input_projection=edit_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "byte_size", "warnings"),
-                    ),
-                ),
-            }
+        return _workspace_like_event_views(
+            "project",
+            lambda path, allow_root: _normalize_project_path(path, allow_root=allow_root),
         )

--- a/src/fleet_rlm/files/project_tools.py
+++ b/src/fleet_rlm/files/project_tools.py
@@ -10,7 +10,6 @@ the Session Workspace; durable deliverables belong in a Project.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import NoReturn
 
 import dspy
 
@@ -18,11 +17,10 @@ from fleet_rlm.files.volume_paths import UnsafePathError, validate_project_slug
 from fleet_rlm.files.workspace_models import SessionWorkspaceFS
 from fleet_rlm.files.workspace_tools import (
     MAX_WORKSPACE_READ_CHARS,
+    WorkspaceLikeConfig,
     WorkspaceToolError,
-    _translate_fs_tool_errors,
-    _workspace_like_event_views,
-    _workspace_like_tools,
-    _WorkspaceLikeConfig,
+    workspace_like_event_views,
+    workspace_like_tools,
 )
 from fleet_rlm.files.workspace_validation import normalize_workspace_path
 from fleet_rlm.rlm.tool_observer import ToolEventView
@@ -37,10 +35,6 @@ class ProjectToolError(WorkspaceToolError):
     Subclasses ``WorkspaceToolError`` so the interpreter bridge keeps rendering
     structured ``{"ok": False, "error": code}`` results for project tools.
     """
-
-
-def _raise_tool_error(exc: BaseException) -> NoReturn:
-    _translate_fs_tool_errors(exc, ProjectToolError, domain="Project")
 
 
 def _normalize_project_path(path: str, *, allow_root: bool = False) -> str:
@@ -81,11 +75,13 @@ class ProjectToolHost:
     """Bind the browsable projects root into stable synchronous tools."""
 
     def __init__(self, workspace: SessionWorkspaceFS, *, max_file_bytes: int) -> None:
+        """Bind a project filesystem adapter and enforce the per-file byte limit."""
         self._workspace = workspace
         self._max_file_bytes = max(1, int(max_file_bytes))
 
     def as_tools(self) -> tuple[dspy.Tool, ...]:
-        config = _WorkspaceLikeConfig(
+        """Build the stable Project tool contract."""
+        config = WorkspaceLikeConfig(
             namespace=PROJECT_WORKSPACE_NAMESPACE,
             domain="Project",
             error_type=ProjectToolError,
@@ -99,12 +95,48 @@ class ProjectToolHost:
             normalize_edit_path=_project_file_path,
             has_append=False,
             verb="project",
+            tool_docs={
+                "list": "List immediate entries in one Project or the projects root.",
+                "stat": "Return bounded metadata for one Project path.",
+                "read": "Read one UTF-8 Project file page without returning more than max_chars.",
+                "write": "Write one UTF-8 deliverable immediately under projects/<slug>/.",
+                "delete": "Delete one file or empty directory immediately under projects/<slug>/.",
+                "edit": "Replace exactly one unique occurrence of old with new in one UTF-8 Project file.",
+            },
+            tool_descs={
+                "list": (
+                    "List immediate entries under projects/<slug>/ (or the projects root) only when existing "
+                    "durable Project deliverables are relevant; do not explore them for a self-contained request."
+                ),
+                "stat": "Read bounded metadata for a relevant durable Project deliverable path under projects/<slug>/.",
+                "read": (
+                    "Read one relevant UTF-8 Project deliverable page with max_chars in 1..10000 using a "
+                    "projects/<slug>/<path> target. Continue with next_cursor until eof."
+                ),
+                "write": (
+                    "Write UTF-8 text immediately as a durable deliverable under projects/<slug>/ when the "
+                    "result must stay browsable across Sessions; choose a short repo/task-derived slug and "
+                    "keep scratch in the Session Workspace. This durability is independent of Turn Commit."
+                ),
+                "delete": (
+                    "Delete one file or one empty directory immediately under projects/<slug>/; non-empty "
+                    "directories are refused, and a supplied expected_sha256 guards against deleting "
+                    "changed content. This durability is independent of Turn Commit."
+                ),
+                "edit": (
+                    "Replace exactly one unique occurrence of old with new in one UTF-8 Project file under "
+                    "projects/<slug>/; the edit fails when old is absent or occurs more than once, and a "
+                    "supplied expected_sha256 guards against editing changed content. Read the file first "
+                    "and keep old short and unique. This durability is independent of Turn Commit."
+                ),
+            },
         )
-        return _workspace_like_tools(self._workspace, max_file_bytes=self._max_file_bytes, config=config)
+        return workspace_like_tools(self._workspace, max_file_bytes=self._max_file_bytes, config=config)
 
     def event_views(self) -> Mapping[str, ToolEventView]:
         """Return bounded metadata-only projections for Project Tools."""
-        return _workspace_like_event_views(
+        return workspace_like_event_views(
             "project",
             lambda path, allow_root: _normalize_project_path(path, allow_root=allow_root),
+            has_append=False,
         )

--- a/src/fleet_rlm/files/workspace_tools.py
+++ b/src/fleet_rlm/files/workspace_tools.py
@@ -17,17 +17,29 @@ from fleet_rlm.rlm.tool_observer import ToolEventView, bound_event_text
 MAX_WORKSPACE_READ_CHARS = 10_000
 SESSION_WORKSPACE_NAMESPACE = "session_workspace"
 
+__all__ = (
+    "MAX_WORKSPACE_READ_CHARS",
+    "SESSION_WORKSPACE_NAMESPACE",
+    "WorkspaceLikeConfig",
+    "WorkspaceToolError",
+    "WorkspaceToolHost",
+    "translate_fs_tool_errors",
+    "workspace_like_event_views",
+    "workspace_like_tools",
+)
+
 
 class WorkspaceToolError(RuntimeError):
     """Safe, actionable failure returned to generated workspace-tool callers."""
 
     def __init__(self, code: str, message: str) -> None:
+        """Create a closed tool error with a stable code and public message."""
         super().__init__(message)
         self.code = code
         self.public_message = message
 
 
-def _translate_fs_tool_errors(exc: BaseException, error_type: type[WorkspaceToolError], *, domain: str) -> NoReturn:
+def translate_fs_tool_errors(exc: BaseException, error_type: type[WorkspaceToolError], *, domain: str) -> NoReturn:
     """Map one mounted-FS failure into the owning host's closed tool-error vocabulary.
 
     ``WorkspaceToolHost`` and ``ProjectToolHost`` share this translation (P33):
@@ -67,19 +79,17 @@ def _translate_fs_tool_errors(exc: BaseException, error_type: type[WorkspaceTool
     raise error_type("unavailable", f"{domain} storage is unavailable") from None
 
 
-def _raise_tool_error(exc: BaseException) -> NoReturn:
-    _translate_fs_tool_errors(exc, WorkspaceToolError, domain="Session Workspace")
-
-
 class WorkspaceToolHost:
     """Bind one authorized Session Workspace into stable synchronous tools."""
 
     def __init__(self, workspace: SessionWorkspaceFS, *, max_file_bytes: int) -> None:
+        """Bind a filesystem adapter and enforce the per-file byte limit."""
         self._workspace = workspace
         self._max_file_bytes = max(1, int(max_file_bytes))
 
     def as_tools(self) -> tuple[dspy.Tool, ...]:
-        config = _WorkspaceLikeConfig(
+        """Build the stable Session Workspace tool contract."""
+        config = WorkspaceLikeConfig(
             namespace=SESSION_WORKSPACE_NAMESPACE,
             domain="Session Workspace",
             error_type=WorkspaceToolError,
@@ -91,14 +101,54 @@ class WorkspaceToolHost:
             normalize_edit_path=normalize_workspace_path,
             has_append=True,
             verb="workspace",
+            tool_docs={
+                "list": "List immediate entries in this Session's durable workspace.",
+                "stat": "Return bounded metadata for one workspace path.",
+                "read": "Read one UTF-8 workspace page without returning more than max_chars.",
+                "write": "Write one UTF-8 file immediately into this Session's durable workspace.",
+                "append": "Append UTF-8 text immediately into this Session's durable workspace.",
+                "delete": "Delete one file or empty directory immediately from this Session's durable workspace.",
+                "edit": "Replace exactly one unique occurrence of old with new in one UTF-8 workspace file.",
+            },
+            tool_descs={
+                "list": (
+                    "List immediate entries in this Session's durable Workspace only when existing durable "
+                    "state is relevant; do not explore it for a self-contained request."
+                ),
+                "stat": "Read bounded metadata for a relevant durable Session Workspace path.",
+                "read": (
+                    "Read one relevant UTF-8 durable Workspace page with max_chars in 1..10000. Continue with "
+                    "next_cursor until eof."
+                ),
+                "write": (
+                    "Write UTF-8 text immediately into this Session's durable Workspace when the result must "
+                    "survive the Run; this durability is independent of Turn Commit."
+                ),
+                "append": (
+                    "Append UTF-8 text immediately into this Session's durable Workspace when incremental "
+                    "state must survive the Run; this durability is independent of Turn Commit."
+                ),
+                "delete": (
+                    "Delete one file or one empty directory immediately from this Session's durable "
+                    "Workspace; non-empty directories are refused, and a supplied expected_sha256 guards "
+                    "against deleting changed content. This durability is independent of Turn Commit."
+                ),
+                "edit": (
+                    "Replace exactly one unique occurrence of old with new in one UTF-8 Session Workspace "
+                    "file; the edit fails when old is absent or occurs more than once, and a supplied "
+                    "expected_sha256 guards against editing changed content. Read the file first and keep "
+                    "old short and unique. This durability is independent of Turn Commit."
+                ),
+            },
         )
-        return _workspace_like_tools(self._workspace, max_file_bytes=self._max_file_bytes, config=config)
+        return workspace_like_tools(self._workspace, max_file_bytes=self._max_file_bytes, config=config)
 
     def event_views(self) -> Mapping[str, ToolEventView]:
         """Return bounded metadata-only projections for Workspace Tools."""
-        return _workspace_like_event_views(
+        return workspace_like_event_views(
             "workspace",
             lambda path, allow_root: normalize_workspace_path(path, allow_root=allow_root),
+            has_append=True,
         )
 
 
@@ -119,7 +169,7 @@ def _warnings(workspace: SessionWorkspaceFS, result: dict[str, object]) -> dict[
     return result
 
 
-class _WorkspaceLikeConfig:
+class WorkspaceLikeConfig:
     """One axis of divergence between the Session and Project tool hosts.
 
     Path normalization is NOT uniform across ops (the P33 contract): the
@@ -151,7 +201,10 @@ class _WorkspaceLikeConfig:
         # for each op. Tool names must stay byte-identical to the existing
         # hosts, e.g. "list_workspace_files" / "list_project_files".
         verb: str,
+        tool_docs: Mapping[str, str],
+        tool_descs: Mapping[str, str],
     ) -> None:
+        """Store the host-specific behavior and public tool text."""
         self.namespace = namespace
         self.domain = domain
         self.error_type = error_type
@@ -162,11 +215,14 @@ class _WorkspaceLikeConfig:
         self.normalize_edit_path = normalize_edit_path
         self.has_append = has_append
         self.verb = verb
+        self.tool_docs = tool_docs
+        self.tool_descs = tool_descs
 
 
-def _workspace_like_tools(
-    workspace: SessionWorkspaceFS, *, max_file_bytes: int, config: _WorkspaceLikeConfig
+def workspace_like_tools(
+    workspace: SessionWorkspaceFS, *, max_file_bytes: int, config: WorkspaceLikeConfig
 ) -> tuple[dspy.Tool, ...]:
+    """Build bounded synchronous tools for a workspace-like filesystem host."""
     max_file_bytes = max(1, int(max_file_bytes))
     error_type = config.error_type
     domain = config.domain
@@ -174,7 +230,7 @@ def _workspace_like_tools(
     verb = config.verb
 
     def _raise(exc: BaseException) -> NoReturn:
-        _translate_fs_tool_errors(exc, error_type, domain=domain)
+        translate_fs_tool_errors(exc, error_type, domain=domain)
 
     def list_files(path: str = ".", limit: int = 100, after: str | None = None) -> dict[str, object]:
         """List immediate entries under one workspaces root."""
@@ -192,7 +248,7 @@ def _workspace_like_tools(
                 "entries": [_entry(item) for item in listing.entries],
             }
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
 
     def stat_file(path: str) -> dict[str, object]:
         """Return bounded metadata for one workspace path."""
@@ -204,7 +260,7 @@ def _workspace_like_tools(
         except WorkspaceToolError:
             raise
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
 
     def read_text(path: str, cursor: str | None = None, max_chars: int = config.read_max_chars) -> dict[str, object]:
         """Read one UTF-8 workspace page without returning more than max_chars."""
@@ -218,7 +274,7 @@ def _workspace_like_tools(
                 max_bytes=max_file_bytes,
             )
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
         return {
             "ok": True,
             "namespace": namespace,
@@ -243,7 +299,7 @@ def _workspace_like_tools(
             }
             return _warnings(workspace, result)
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
 
     def append_text(path: str, content: str) -> dict[str, object]:
         """Append UTF-8 text immediately under one workspace root."""
@@ -259,7 +315,7 @@ def _workspace_like_tools(
             }
             return _warnings(workspace, result)
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
 
     def delete_path_tool(path: str, expected_sha256: str | None = None) -> dict[str, object]:
         """Delete one file or empty directory immediately under one workspace root."""
@@ -269,7 +325,7 @@ def _workspace_like_tools(
             result: dict[str, object] = {"ok": True, "namespace": namespace, "path": normalized}
             return _warnings(workspace, result)
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
 
     def edit_text(path: str, old: str, new: str, expected_sha256: str | None = None) -> dict[str, object]:
         """Replace exactly one unique occurrence of old with new in one UTF-8 file."""
@@ -286,114 +342,41 @@ def _workspace_like_tools(
             result: dict[str, object] = {"ok": True, "namespace": namespace, **entry}
             return _warnings(workspace, result)
         except Exception as exc:
-            _raise(exc)
+            return _raise(exc)
 
-    # Per-tool function docstrings feed each dspy.Tool desc below; keep them
-    # distinct per jurisdiction so the generated tool descriptions match the
-    # existing public surface. (dspy.Tool receives the SAME desc strings the
-    # old inline bodies used.)
-    list_files.__doc__ = (
-        "List immediate entries in one Project or the projects root."
-        if verb == "project"
-        else "List immediate entries in this Session's durable workspace."
-    )
-    stat_file.__doc__ = (
-        "Return bounded metadata for one Project path."
-        if verb == "project"
-        else "Return bounded metadata for one workspace path."
-    )
-    read_text.__doc__ = (
-        "Read one UTF-8 Project file page without returning more than max_chars."
-        if verb == "project"
-        else "Read one UTF-8 workspace page without returning more than max_chars."
-    )
-    write_text.__doc__ = (
-        "Write one UTF-8 deliverable immediately under projects/<slug>/."
-        if verb == "project"
-        else "Write one UTF-8 file immediately into this Session's durable workspace."
-    )
-    append_text.__doc__ = "Append UTF-8 text immediately into this Session's durable workspace."
-    delete_path_tool.__doc__ = (
-        "Delete one file or empty directory immediately under projects/<slug>/."
-        if verb == "project"
-        else "Delete one file or empty directory immediately from this Session's durable workspace."
-    )
-    edit_text.__doc__ = (
-        "Replace exactly one unique occurrence of old with new in one UTF-8 Project file."
-        if verb == "project"
-        else "Replace exactly one unique occurrence of old with new in one UTF-8 workspace file."
-    )
-
-    # Tool descs (the LLM-facing sentences) — byte-identical to the previous
-    # inline dspy.Tool(...) desc= values in workspace_tools.py/project_tools.py.
-    desc_list = (
-        "List immediate entries under projects/<slug>/ (or the projects root) only when existing "
-        "durable Project deliverables are relevant; do not explore them for a self-contained request."
-        if verb == "project"
-        else "List immediate entries in this Session's durable Workspace only when existing durable "
-        "state is relevant; do not explore it for a self-contained request."
-    )
-    desc_stat = (
-        "Read bounded metadata for a relevant durable Project deliverable path under projects/<slug>/."
-        if verb == "project"
-        else "Read bounded metadata for a relevant durable Session Workspace path."
-    )
-    desc_read = (
-        "Read one relevant UTF-8 Project deliverable page with max_chars in 1..10000 using a "
-        "projects/<slug>/<path> target. Continue with next_cursor until eof."
-        if verb == "project"
-        else "Read one relevant UTF-8 durable Workspace page with max_chars in 1..10000. Continue with "
-        "next_cursor until eof."
-    )
-    desc_write = (
-        "Write UTF-8 text immediately as a durable deliverable under projects/<slug>/ when the "
-        "result must stay browsable across Sessions; choose a short repo/task-derived slug and "
-        "keep scratch in the Session Workspace. This durability is independent of Turn Commit."
-        if verb == "project"
-        else "Write UTF-8 text immediately into this Session's durable Workspace when the result must "
-        "survive the Run; this durability is independent of Turn Commit."
-    )
-    desc_append = (
-        "Append UTF-8 text immediately into this Session's durable Workspace when incremental "
-        "state must survive the Run; this durability is independent of Turn Commit."
-    )
-    desc_delete = (
-        "Delete one file or one empty directory immediately under projects/<slug>/; non-empty "
-        "directories are refused, and a supplied expected_sha256 guards against deleting "
-        "changed content. This durability is independent of Turn Commit."
-        if verb == "project"
-        else "Delete one file or one empty directory immediately from this Session's durable "
-        "Workspace; non-empty directories are refused, and a supplied expected_sha256 guards "
-        "against deleting changed content. This durability is independent of Turn Commit."
-    )
-    desc_edit = (
-        "Replace exactly one unique occurrence of old with new in one UTF-8 Project file under "
-        "projects/<slug>/; the edit fails when old is absent or occurs more than once, and a "
-        "supplied expected_sha256 guards against editing changed content. Read the file first "
-        "and keep old short and unique. This durability is independent of Turn Commit."
-        if verb == "project"
-        else "Replace exactly one unique occurrence of old with new in one UTF-8 Session Workspace "
-        "file; the edit fails when old is absent or occurs more than once, and a supplied "
-        "expected_sha256 guards against editing changed content. Read the file first and keep "
-        "old short and unique. This durability is independent of Turn Commit."
-    )
+    for function, key in (
+        (list_files, "list"),
+        (stat_file, "stat"),
+        (read_text, "read"),
+        (write_text, "write"),
+        (delete_path_tool, "delete"),
+        (edit_text, "edit"),
+    ):
+        function.__doc__ = config.tool_docs[key]
+    if config.has_append:
+        append_text.__doc__ = config.tool_docs["append"]
 
     tools: list[dspy.Tool] = [
         dspy.Tool(
             list_files,
             name=f"list_{verb}_files",
-            desc=desc_list,
+            desc=config.tool_descs["list"],
             args={
                 "path": {"type": "string"},
                 "limit": {"type": "integer", "minimum": 1, "maximum": 100},
                 "after": {"type": ["string", "null"]},
             },
         ),
-        dspy.Tool(stat_file, name=f"stat_{verb}_file", desc=desc_stat, args={"path": {"type": "string"}}),
+        dspy.Tool(
+            stat_file,
+            name=f"stat_{verb}_file",
+            desc=config.tool_descs["stat"],
+            args={"path": {"type": "string"}},
+        ),
         dspy.Tool(
             read_text,
             name=f"read_{verb}_text",
-            desc=desc_read,
+            desc=config.tool_descs["read"],
             args={
                 "path": {"type": "string"},
                 "cursor": {"type": ["string", "null"]},
@@ -403,7 +386,7 @@ def _workspace_like_tools(
         dspy.Tool(
             write_text,
             name=f"write_{verb}_text",
-            desc=desc_write,
+            desc=config.tool_descs["write"],
             args={
                 "path": {"type": "string"},
                 "content": {"type": "string"},
@@ -416,7 +399,7 @@ def _workspace_like_tools(
             dspy.Tool(
                 append_text,
                 name=f"append_{verb}_text",
-                desc=desc_append,
+                desc=config.tool_descs["append"],
                 args={"path": {"type": "string"}, "content": {"type": "string"}},
             )
         )
@@ -425,13 +408,13 @@ def _workspace_like_tools(
             dspy.Tool(
                 delete_path_tool,
                 name=f"delete_{verb}_path",
-                desc=desc_delete,
+                desc=config.tool_descs["delete"],
                 args={"path": {"type": "string"}, "expected_sha256": {"type": ["string", "null"]}},
             ),
             dspy.Tool(
                 edit_text,
                 name=f"edit_{verb}_text",
-                desc=desc_edit,
+                desc=config.tool_descs["edit"],
                 args={
                     "path": {"type": "string"},
                     "old": {"type": "string"},
@@ -444,7 +427,12 @@ def _workspace_like_tools(
     return tuple(tools)
 
 
-def _workspace_like_event_views(verb: str, normalize_path: Callable[[str, bool], str]) -> Mapping[str, ToolEventView]:
+def workspace_like_event_views(
+    verb: str,
+    normalize_path: Callable[[str, bool], str],
+    *,
+    has_append: bool,
+) -> Mapping[str, ToolEventView]:
     """Return bounded metadata-only projections shared by Session/Project hosts.
 
     ``normalize_path`` is the host's path normalizer taking ``(path, allow_root)``
@@ -560,8 +548,7 @@ def _workspace_like_event_views(verb: str, normalize_path: Callable[[str, bool],
             output_projection=lambda result: output(result, ("ok", "namespace", "path", "byte_size", "warnings")),
         ),
     }
-    # Only the Session host has an append tool/view.
-    if verb == "workspace":
+    if has_append:
         views[f"append_{verb}_text"] = ToolEventView(
             input_projection=append_input,
             output_projection=lambda result: output(result, ("ok", "namespace", "path", "byte_size", "warnings")),

--- a/src/fleet_rlm/files/workspace_tools.py
+++ b/src/fleet_rlm/files/workspace_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import asdict
 from types import MappingProxyType
 from typing import Any, NoReturn, cast
@@ -25,16 +25,6 @@ class WorkspaceToolError(RuntimeError):
         super().__init__(message)
         self.code = code
         self.public_message = message
-
-
-def _entry(entry: WorkspaceEntry) -> dict[str, object]:
-    result = asdict(entry)
-    # The LLM-facing tool result keeps its established 4-key entry shape; the
-    # checksum is an opt-in workspace-fs capability that REPL stat/list never
-    # requests, so an absent checksum adds no key.
-    if result.get("checksum_sha256") is None:
-        result.pop("checksum_sha256")
-    return result
 
 
 def _translate_fs_tool_errors(exc: BaseException, error_type: type[WorkspaceToolError], *, domain: str) -> NoReturn:
@@ -89,239 +79,359 @@ class WorkspaceToolHost:
         self._max_file_bytes = max(1, int(max_file_bytes))
 
     def as_tools(self) -> tuple[dspy.Tool, ...]:
-        def list_workspace_files(
-            path: str = ".",
-            limit: int = 100,
-            after: str | None = None,
-        ) -> dict[str, object]:
-            """List immediate entries in this Session's durable workspace."""
-            try:
-                if limit < 1 or limit > 100:
-                    raise WorkspaceToolError("invalid_path", "Session Workspace list bound is invalid")
-                listing = self._workspace.list_entries(path, limit=limit, after=after)
-                return {
-                    "ok": True,
-                    "namespace": SESSION_WORKSPACE_NAMESPACE,
-                    "path": path,
-                    "count": len(listing.entries),
-                    "truncated": listing.truncated,
-                    "next_cursor": listing.next_cursor,
-                    "entries": [_entry(item) for item in listing.entries],
-                }
-            except Exception as exc:
-                _raise_tool_error(exc)
+        config = _WorkspaceLikeConfig(
+            namespace=SESSION_WORKSPACE_NAMESPACE,
+            domain="Session Workspace",
+            error_type=WorkspaceToolError,
+            read_max_chars=MAX_WORKSPACE_READ_CHARS,
+            normalize_list_path=lambda path: path,
+            normalize_file_path=lambda path: path,
+            # The Session host normalizes only delete/edit; read-only ops pass the raw path.
+            normalize_mutation_path=normalize_workspace_path,
+            normalize_edit_path=normalize_workspace_path,
+            has_append=True,
+            verb="workspace",
+        )
+        return _workspace_like_tools(self._workspace, max_file_bytes=self._max_file_bytes, config=config)
 
-        def stat_workspace_file(path: str) -> dict[str, object]:
-            """Return bounded metadata for one workspace path."""
-            try:
-                entry = self._workspace.stat(path)
-                if entry is None:
-                    raise WorkspaceToolError("not_found", "Session Workspace file was not found")
-                return {"ok": True, "namespace": SESSION_WORKSPACE_NAMESPACE, "entry": _entry(entry)}
-            except WorkspaceToolError:
-                raise
-            except Exception as exc:
-                _raise_tool_error(exc)
+    def event_views(self) -> Mapping[str, ToolEventView]:
+        """Return bounded metadata-only projections for Workspace Tools."""
+        return _workspace_like_event_views(
+            "workspace",
+            lambda path, allow_root: normalize_workspace_path(path, allow_root=allow_root),
+        )
 
-        def read_workspace_text(
-            path: str,
-            cursor: str | None = None,
-            max_chars: int = MAX_WORKSPACE_READ_CHARS,
-        ) -> dict[str, object]:
-            """Read one UTF-8 workspace page without returning more than max_chars."""
-            if max_chars < 1 or max_chars > MAX_WORKSPACE_READ_CHARS:
-                raise WorkspaceToolError("invalid_path", "Session Workspace read bound is invalid")
-            try:
-                page = self._workspace.read_text_page(
-                    path,
-                    cursor=cursor,
-                    max_chars=max_chars,
-                    max_bytes=self._max_file_bytes,
-                )
-            except Exception as exc:
-                _raise_tool_error(exc)
+
+def _entry(entry: WorkspaceEntry) -> dict[str, object]:
+    result = asdict(entry)
+    # The LLM-facing tool result keeps its established 4-key entry shape; the
+    # checksum is an opt-in workspace-fs capability that REPL stat/list never
+    # requests, so an absent checksum adds no key.
+    if result.get("checksum_sha256") is None:
+        result.pop("checksum_sha256")
+    return result
+
+
+def _warnings(workspace: SessionWorkspaceFS, result: dict[str, object]) -> dict[str, object]:
+    warnings = getattr(workspace, "last_warnings", None)
+    if isinstance(warnings, tuple) and warnings:
+        result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
+    return result
+
+
+class _WorkspaceLikeConfig:
+    """One axis of divergence between the Session and Project tool hosts.
+
+    Path normalization is NOT uniform across ops (the P33 contract): the
+    Session host passes raw paths to read-only ops and normalizes only
+    delete/edit, while the Project host normalizes everything but splits
+    "file inside a project" (read/write/edit: ``_project_file_path``) from
+    "browsable root ok" (list/stat: ``_normalize_project_path(allow_root=True)``).
+    The three mappers below carry that per-op distinction exactly.
+    """
+
+    def __init__(
+        self,
+        *,
+        namespace: str,
+        domain: str,
+        error_type: type[WorkspaceToolError],
+        read_max_chars: int,
+        # Read-only traversal paths (list, stat).
+        normalize_list_path: Callable[[str], str],
+        # File-body paths (read, write, append).
+        normalize_file_path: Callable[[str], str],
+        # Mutation paths: delete and edit differ per host (Project delete uses
+        # _normalize_project_path so "." is refused; Project edit uses
+        # _project_file_path so the target must name a file inside a project).
+        normalize_mutation_path: Callable[[str], str],
+        normalize_edit_path: Callable[[str], str],
+        has_append: bool,
+        # Tool-name components: verb prefix ("workspace"/"project") + noun suffix
+        # for each op. Tool names must stay byte-identical to the existing
+        # hosts, e.g. "list_workspace_files" / "list_project_files".
+        verb: str,
+    ) -> None:
+        self.namespace = namespace
+        self.domain = domain
+        self.error_type = error_type
+        self.read_max_chars = read_max_chars
+        self.normalize_list_path = normalize_list_path
+        self.normalize_file_path = normalize_file_path
+        self.normalize_mutation_path = normalize_mutation_path
+        self.normalize_edit_path = normalize_edit_path
+        self.has_append = has_append
+        self.verb = verb
+
+
+def _workspace_like_tools(
+    workspace: SessionWorkspaceFS, *, max_file_bytes: int, config: _WorkspaceLikeConfig
+) -> tuple[dspy.Tool, ...]:
+    max_file_bytes = max(1, int(max_file_bytes))
+    error_type = config.error_type
+    domain = config.domain
+    namespace = config.namespace
+    verb = config.verb
+
+    def _raise(exc: BaseException) -> NoReturn:
+        _translate_fs_tool_errors(exc, error_type, domain=domain)
+
+    def list_files(path: str = ".", limit: int = 100, after: str | None = None) -> dict[str, object]:
+        """List immediate entries under one workspaces root."""
+        try:
+            if limit < 1 or limit > 100:
+                raise error_type("invalid_path", f"{domain} list bound is invalid")
+            listing = workspace.list_entries(config.normalize_list_path(path), limit=limit, after=after)
             return {
                 "ok": True,
-                "namespace": SESSION_WORKSPACE_NAMESPACE,
+                "namespace": namespace,
                 "path": path,
-                "content": page.content,
-                "next_cursor": page.next_cursor,
-                "byte_size": page.byte_size,
-                "eof": page.eof,
+                "count": len(listing.entries),
+                "truncated": listing.truncated,
+                "next_cursor": listing.next_cursor,
+                "entries": [_entry(item) for item in listing.entries],
             }
+        except Exception as exc:
+            _raise(exc)
 
-        def write_workspace_text(
-            path: str,
-            content: str,
-            overwrite: bool = False,
-        ) -> dict[str, object]:
-            """Write one UTF-8 file immediately into this Session's durable workspace."""
-            if not isinstance(content, str):
-                raise WorkspaceToolError("invalid_path", "Session Workspace content must be text")
-            if len(content.encode("utf-8")) > self._max_file_bytes:
-                raise WorkspaceToolError("too_large", "Session Workspace file exceeds the maximum size")
-            try:
-                result = {
-                    "ok": True,
-                    "namespace": SESSION_WORKSPACE_NAMESPACE,
-                    **_entry(self._workspace.write_text(path, content, overwrite=overwrite)),
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
+    def stat_file(path: str) -> dict[str, object]:
+        """Return bounded metadata for one workspace path."""
+        try:
+            entry = workspace.stat(config.normalize_list_path(path))
+            if entry is None:
+                raise error_type("not_found", f"{domain} file was not found")
+            return {"ok": True, "namespace": namespace, "entry": _entry(entry)}
+        except WorkspaceToolError:
+            raise
+        except Exception as exc:
+            _raise(exc)
 
-        def append_workspace_text(path: str, content: str) -> dict[str, object]:
-            """Append UTF-8 text immediately into this Session's durable workspace."""
-            if not isinstance(content, str):
-                raise WorkspaceToolError("invalid_path", "Session Workspace content must be text")
-            if len(content.encode("utf-8")) > self._max_file_bytes:
-                raise WorkspaceToolError("too_large", "Session Workspace file exceeds the maximum size")
-            try:
-                result = {
-                    "ok": True,
-                    "namespace": SESSION_WORKSPACE_NAMESPACE,
-                    **_entry(self._workspace.append_text(path, content)),
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
+    def read_text(path: str, cursor: str | None = None, max_chars: int = config.read_max_chars) -> dict[str, object]:
+        """Read one UTF-8 workspace page without returning more than max_chars."""
+        if max_chars < 1 or max_chars > config.read_max_chars:
+            raise error_type("invalid_path", f"{domain} read bound is invalid")
+        try:
+            page = workspace.read_text_page(
+                config.normalize_file_path(path),
+                cursor=cursor,
+                max_chars=max_chars,
+                max_bytes=max_file_bytes,
+            )
+        except Exception as exc:
+            _raise(exc)
+        return {
+            "ok": True,
+            "namespace": namespace,
+            "path": path,
+            "content": page.content,
+            "next_cursor": page.next_cursor,
+            "byte_size": page.byte_size,
+            "eof": page.eof,
+        }
 
-        def delete_workspace_path(path: str, expected_sha256: str | None = None) -> dict[str, object]:
-            """Delete one file or empty directory immediately from this Session's durable workspace."""
-            try:
-                normalized = normalize_workspace_path(path)
-                self._workspace.delete_path(normalized, expected_sha256=expected_sha256)
-                result: dict[str, object] = {
-                    "ok": True,
-                    "namespace": SESSION_WORKSPACE_NAMESPACE,
-                    "path": normalized,
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
+    def write_text(path: str, content: str, overwrite: bool = False) -> dict[str, object]:
+        """Write one UTF-8 file immediately under one workspace root."""
+        if not isinstance(content, str):
+            raise error_type("invalid_path", f"{domain} content must be text")
+        if len(content.encode("utf-8")) > max_file_bytes:
+            raise error_type("too_large", f"{domain} file exceeds the maximum size")
+        try:
+            result = {
+                "ok": True,
+                "namespace": namespace,
+                **_entry(workspace.write_text(config.normalize_file_path(path), content, overwrite=overwrite)),
+            }
+            return _warnings(workspace, result)
+        except Exception as exc:
+            _raise(exc)
 
-        def edit_workspace_text(
-            path: str,
-            old: str,
-            new: str,
-            expected_sha256: str | None = None,
-        ) -> dict[str, object]:
-            """Replace exactly one unique occurrence of old with new in one UTF-8 workspace file."""
-            if not isinstance(old, str) or not old or not isinstance(new, str):
-                raise WorkspaceToolError("invalid_path", "Session Workspace edit requires non-empty old and new text")
-            if len(old.encode("utf-8")) > self._max_file_bytes or len(new.encode("utf-8")) > self._max_file_bytes:
-                raise WorkspaceToolError("too_large", "Session Workspace file exceeds the maximum size")
-            try:
-                normalized = normalize_workspace_path(path)
-                entry = _entry(self._workspace.patch_text(normalized, old, new, expected_sha256=expected_sha256))
-                # The LLM-facing result keeps its established 4-key entry
-                # shape; the precondition checksum is a transport concern.
-                entry.pop("checksum_sha256", None)
-                result: dict[str, object] = {
-                    "ok": True,
-                    "namespace": SESSION_WORKSPACE_NAMESPACE,
-                    **entry,
-                }
-                warnings = getattr(self._workspace, "last_warnings", None)
-                if isinstance(warnings, tuple) and warnings:
-                    result["warnings"] = [dict(item) for item in warnings if isinstance(item, Mapping)]
-                return result
-            except Exception as exc:
-                _raise_tool_error(exc)
+    def append_text(path: str, content: str) -> dict[str, object]:
+        """Append UTF-8 text immediately under one workspace root."""
+        if not isinstance(content, str):
+            raise error_type("invalid_path", f"{domain} content must be text")
+        if len(content.encode("utf-8")) > max_file_bytes:
+            raise error_type("too_large", f"{domain} file exceeds the maximum size")
+        try:
+            result = {
+                "ok": True,
+                "namespace": namespace,
+                **_entry(workspace.append_text(config.normalize_file_path(path), content)),
+            }
+            return _warnings(workspace, result)
+        except Exception as exc:
+            _raise(exc)
 
-        return (
+    def delete_path_tool(path: str, expected_sha256: str | None = None) -> dict[str, object]:
+        """Delete one file or empty directory immediately under one workspace root."""
+        try:
+            normalized = config.normalize_mutation_path(path)
+            workspace.delete_path(normalized, expected_sha256=expected_sha256)
+            result: dict[str, object] = {"ok": True, "namespace": namespace, "path": normalized}
+            return _warnings(workspace, result)
+        except Exception as exc:
+            _raise(exc)
+
+    def edit_text(path: str, old: str, new: str, expected_sha256: str | None = None) -> dict[str, object]:
+        """Replace exactly one unique occurrence of old with new in one UTF-8 file."""
+        if not isinstance(old, str) or not old or not isinstance(new, str):
+            raise error_type("invalid_path", f"{domain} edit requires non-empty old and new text")
+        if len(old.encode("utf-8")) > max_file_bytes or len(new.encode("utf-8")) > max_file_bytes:
+            raise error_type("too_large", f"{domain} file exceeds the maximum size")
+        try:
+            normalized = config.normalize_edit_path(path)
+            entry = _entry(workspace.patch_text(normalized, old, new, expected_sha256=expected_sha256))
+            # The LLM-facing result keeps its established 4-key entry shape;
+            # the precondition checksum is a transport concern.
+            entry.pop("checksum_sha256", None)
+            result: dict[str, object] = {"ok": True, "namespace": namespace, **entry}
+            return _warnings(workspace, result)
+        except Exception as exc:
+            _raise(exc)
+
+    # Per-tool function docstrings feed each dspy.Tool desc below; keep them
+    # distinct per jurisdiction so the generated tool descriptions match the
+    # existing public surface. (dspy.Tool receives the SAME desc strings the
+    # old inline bodies used.)
+    list_files.__doc__ = (
+        "List immediate entries in one Project or the projects root."
+        if verb == "project"
+        else "List immediate entries in this Session's durable workspace."
+    )
+    stat_file.__doc__ = (
+        "Return bounded metadata for one Project path."
+        if verb == "project"
+        else "Return bounded metadata for one workspace path."
+    )
+    read_text.__doc__ = (
+        "Read one UTF-8 Project file page without returning more than max_chars."
+        if verb == "project"
+        else "Read one UTF-8 workspace page without returning more than max_chars."
+    )
+    write_text.__doc__ = (
+        "Write one UTF-8 deliverable immediately under projects/<slug>/."
+        if verb == "project"
+        else "Write one UTF-8 file immediately into this Session's durable workspace."
+    )
+    append_text.__doc__ = "Append UTF-8 text immediately into this Session's durable workspace."
+    delete_path_tool.__doc__ = (
+        "Delete one file or empty directory immediately under projects/<slug>/."
+        if verb == "project"
+        else "Delete one file or empty directory immediately from this Session's durable workspace."
+    )
+    edit_text.__doc__ = (
+        "Replace exactly one unique occurrence of old with new in one UTF-8 Project file."
+        if verb == "project"
+        else "Replace exactly one unique occurrence of old with new in one UTF-8 workspace file."
+    )
+
+    # Tool descs (the LLM-facing sentences) — byte-identical to the previous
+    # inline dspy.Tool(...) desc= values in workspace_tools.py/project_tools.py.
+    desc_list = (
+        "List immediate entries under projects/<slug>/ (or the projects root) only when existing "
+        "durable Project deliverables are relevant; do not explore them for a self-contained request."
+        if verb == "project"
+        else "List immediate entries in this Session's durable Workspace only when existing durable "
+        "state is relevant; do not explore it for a self-contained request."
+    )
+    desc_stat = (
+        "Read bounded metadata for a relevant durable Project deliverable path under projects/<slug>/."
+        if verb == "project"
+        else "Read bounded metadata for a relevant durable Session Workspace path."
+    )
+    desc_read = (
+        "Read one relevant UTF-8 Project deliverable page with max_chars in 1..10000 using a "
+        "projects/<slug>/<path> target. Continue with next_cursor until eof."
+        if verb == "project"
+        else "Read one relevant UTF-8 durable Workspace page with max_chars in 1..10000. Continue with "
+        "next_cursor until eof."
+    )
+    desc_write = (
+        "Write UTF-8 text immediately as a durable deliverable under projects/<slug>/ when the "
+        "result must stay browsable across Sessions; choose a short repo/task-derived slug and "
+        "keep scratch in the Session Workspace. This durability is independent of Turn Commit."
+        if verb == "project"
+        else "Write UTF-8 text immediately into this Session's durable Workspace when the result must "
+        "survive the Run; this durability is independent of Turn Commit."
+    )
+    desc_append = (
+        "Append UTF-8 text immediately into this Session's durable Workspace when incremental "
+        "state must survive the Run; this durability is independent of Turn Commit."
+    )
+    desc_delete = (
+        "Delete one file or one empty directory immediately under projects/<slug>/; non-empty "
+        "directories are refused, and a supplied expected_sha256 guards against deleting "
+        "changed content. This durability is independent of Turn Commit."
+        if verb == "project"
+        else "Delete one file or one empty directory immediately from this Session's durable "
+        "Workspace; non-empty directories are refused, and a supplied expected_sha256 guards "
+        "against deleting changed content. This durability is independent of Turn Commit."
+    )
+    desc_edit = (
+        "Replace exactly one unique occurrence of old with new in one UTF-8 Project file under "
+        "projects/<slug>/; the edit fails when old is absent or occurs more than once, and a "
+        "supplied expected_sha256 guards against editing changed content. Read the file first "
+        "and keep old short and unique. This durability is independent of Turn Commit."
+        if verb == "project"
+        else "Replace exactly one unique occurrence of old with new in one UTF-8 Session Workspace "
+        "file; the edit fails when old is absent or occurs more than once, and a supplied "
+        "expected_sha256 guards against editing changed content. Read the file first and keep "
+        "old short and unique. This durability is independent of Turn Commit."
+    )
+
+    tools: list[dspy.Tool] = [
+        dspy.Tool(
+            list_files,
+            name=f"list_{verb}_files",
+            desc=desc_list,
+            args={
+                "path": {"type": "string"},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100},
+                "after": {"type": ["string", "null"]},
+            },
+        ),
+        dspy.Tool(stat_file, name=f"stat_{verb}_file", desc=desc_stat, args={"path": {"type": "string"}}),
+        dspy.Tool(
+            read_text,
+            name=f"read_{verb}_text",
+            desc=desc_read,
+            args={
+                "path": {"type": "string"},
+                "cursor": {"type": ["string", "null"]},
+                "max_chars": {"type": "integer", "minimum": 1, "maximum": config.read_max_chars},
+            },
+        ),
+        dspy.Tool(
+            write_text,
+            name=f"write_{verb}_text",
+            desc=desc_write,
+            args={
+                "path": {"type": "string"},
+                "content": {"type": "string"},
+                "overwrite": {"type": "boolean"},
+            },
+        ),
+    ]
+    if config.has_append:
+        tools.append(
             dspy.Tool(
-                list_workspace_files,
-                name="list_workspace_files",
-                desc=(
-                    "List immediate entries in this Session's durable Workspace only when existing durable "
-                    "state is relevant; do not explore it for a self-contained request."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 100},
-                    "after": {"type": ["string", "null"]},
-                },
+                append_text,
+                name=f"append_{verb}_text",
+                desc=desc_append,
+                args={"path": {"type": "string"}, "content": {"type": "string"}},
+            )
+        )
+    tools.extend(
+        [
+            dspy.Tool(
+                delete_path_tool,
+                name=f"delete_{verb}_path",
+                desc=desc_delete,
+                args={"path": {"type": "string"}, "expected_sha256": {"type": ["string", "null"]}},
             ),
             dspy.Tool(
-                stat_workspace_file,
-                name="stat_workspace_file",
-                desc="Read bounded metadata for a relevant durable Session Workspace path.",
-                args={"path": {"type": "string"}},
-            ),
-            dspy.Tool(
-                read_workspace_text,
-                name="read_workspace_text",
-                desc=(
-                    "Read one relevant UTF-8 durable Workspace page with max_chars in 1..10000. Continue with "
-                    "next_cursor until eof."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "cursor": {"type": ["string", "null"]},
-                    "max_chars": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": MAX_WORKSPACE_READ_CHARS,
-                    },
-                },
-            ),
-            dspy.Tool(
-                write_workspace_text,
-                name="write_workspace_text",
-                desc=(
-                    "Write UTF-8 text immediately into this Session's durable Workspace when the result must "
-                    "survive the Run; this durability is independent of Turn Commit."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "content": {"type": "string"},
-                    "overwrite": {"type": "boolean"},
-                },
-            ),
-            dspy.Tool(
-                append_workspace_text,
-                name="append_workspace_text",
-                desc=(
-                    "Append UTF-8 text immediately into this Session's durable Workspace when incremental "
-                    "state must survive the Run; this durability is independent of Turn Commit."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "content": {"type": "string"},
-                },
-            ),
-            dspy.Tool(
-                delete_workspace_path,
-                name="delete_workspace_path",
-                desc=(
-                    "Delete one file or one empty directory immediately from this Session's durable "
-                    "Workspace; non-empty directories are refused, and a supplied expected_sha256 guards "
-                    "against deleting changed content. This durability is independent of Turn Commit."
-                ),
-                args={
-                    "path": {"type": "string"},
-                    "expected_sha256": {"type": ["string", "null"]},
-                },
-            ),
-            dspy.Tool(
-                edit_workspace_text,
-                name="edit_workspace_text",
-                desc=(
-                    "Replace exactly one unique occurrence of old with new in one UTF-8 Session Workspace "
-                    "file; the edit fails when old is absent or occurs more than once, and a supplied "
-                    "expected_sha256 guards against editing changed content. Read the file first and keep "
-                    "old short and unique. This durability is independent of Turn Commit."
-                ),
+                edit_text,
+                name=f"edit_{verb}_text",
+                desc=desc_edit,
                 args={
                     "path": {"type": "string"},
                     "old": {"type": "string"},
@@ -329,144 +439,131 @@ class WorkspaceToolHost:
                     "expected_sha256": {"type": ["string", "null"]},
                 },
             ),
-        )
+        ]
+    )
+    return tuple(tools)
 
-    def event_views(self) -> Mapping[str, ToolEventView]:
-        """Return bounded metadata-only projections for Workspace Tools."""
 
-        def fields(
-            arguments: Mapping[str, Any],
-            names: tuple[str, ...],
-            *,
-            allow_root: bool = False,
-        ) -> dict[str, JsonValue]:
-            projected: dict[str, JsonValue] = {}
-            for name in names:
-                if name not in arguments:
+def _workspace_like_event_views(verb: str, normalize_path: Callable[[str, bool], str]) -> Mapping[str, ToolEventView]:
+    """Return bounded metadata-only projections shared by Session/Project hosts.
+
+    ``normalize_path`` is the host's path normalizer taking ``(path, allow_root)``
+    and raising on invalid input; keys are the exact tool names for this host.
+    """
+
+    def fields(
+        arguments: Mapping[str, Any], names: tuple[str, ...], *, allow_root: bool = False
+    ) -> dict[str, JsonValue]:
+        projected: dict[str, JsonValue] = {}
+        for name in names:
+            if name not in arguments:
+                continue
+            value = arguments[name]
+            if name == "path":
+                try:
+                    value = normalize_path(str(value), allow_root)
+                except (WorkspacePathError, WorkspaceToolError):
                     continue
-                value = arguments[name]
-                if name == "path":
-                    try:
-                        value = normalize_workspace_path(str(value), allow_root=allow_root)
-                    except WorkspacePathError:
-                        continue
-                projected[name] = bound_event_text(value) if isinstance(value, str) else cast(JsonValue, value)
-            return projected
+            projected[name] = bound_event_text(value) if isinstance(value, str) else cast(JsonValue, value)
+        return projected
 
-        def output(result: object, names: tuple[str, ...]) -> JsonValue:
-            if not isinstance(result, Mapping):
-                return {}
-            values = cast(Mapping[str, JsonValue], result)
-            return {
-                name: bound_event_text(values[name]) if isinstance(values[name], str) else values[name]
-                for name in names
-                if name in values
-            }
+    def output(result: object, names: tuple[str, ...]) -> JsonValue:
+        if not isinstance(result, Mapping):
+            return {}
+        values = cast(Mapping[str, JsonValue], result)
+        return {
+            name: bound_event_text(values[name]) if isinstance(values[name], str) else values[name]
+            for name in names
+            if name in values
+        }
 
-        def stat_output(result: object) -> JsonValue:
-            if not isinstance(result, Mapping):
-                return {}
-            values = cast(Mapping[str, JsonValue], result)
-            projected: dict[str, JsonValue] = {
-                name: bound_event_text(values[name]) if isinstance(values[name], str) else values[name]
-                for name in ("ok", "error")
-                if name in values
-            }
-            entry = result.get("entry")
-            if isinstance(entry, Mapping):
-                entry_values = cast(Mapping[str, JsonValue], entry)
-                projected.update(
-                    {
-                        name: bound_event_text(entry_values[name])
-                        if isinstance(entry_values[name], str)
-                        else entry_values[name]
-                        for name in ("path", "byte_size")
-                        if name in entry_values
-                    }
-                )
-            return projected
+    def stat_output(result: object) -> JsonValue:
+        if not isinstance(result, Mapping):
+            return {}
+        values = cast(Mapping[str, JsonValue], result)
+        projected: dict[str, JsonValue] = {
+            name: bound_event_text(values[name]) if isinstance(values[name], str) else values[name]
+            for name in ("ok", "error")
+            if name in values
+        }
+        entry = result.get("entry")
+        if isinstance(entry, Mapping):
+            entry_values = cast(Mapping[str, JsonValue], entry)
+            projected.update(
+                {
+                    name: bound_event_text(entry_values[name])
+                    if isinstance(entry_values[name], str)
+                    else entry_values[name]
+                    for name in ("path", "byte_size")
+                    if name in entry_values
+                }
+            )
+        return projected
 
-        def write_input(arguments: Mapping[str, Any]) -> JsonValue:
-            content = arguments.get("content")
-            return {
-                **fields(arguments, ("path", "overwrite")),
-                "content_chars": len(str(content or "")),
-            }
+    def write_input(arguments: Mapping[str, Any]) -> JsonValue:
+        content = arguments.get("content")
+        return {
+            **fields(arguments, ("path", "overwrite")),
+            "content_chars": len(str(content or "")),
+        }
 
-        def append_input(arguments: Mapping[str, Any]) -> JsonValue:
-            content = arguments.get("content")
-            return {
-                **fields(arguments, ("path",)),
-                "content_chars": len(str(content or "")),
-            }
+    def append_input(arguments: Mapping[str, Any]) -> JsonValue:
+        content = arguments.get("content")
+        return {
+            **fields(arguments, ("path",)),
+            "content_chars": len(str(content or "")),
+        }
 
-        def edit_input(arguments: Mapping[str, Any]) -> JsonValue:
-            # Edit fragments stay private; only their sizes are observable.
-            return {
-                **fields(arguments, ("path",)),
-                "old_chars": len(str(arguments.get("old") or "")),
-                "new_chars": len(str(arguments.get("new") or "")),
-                "checksum_precondition": bool(arguments.get("expected_sha256")),
-            }
+    def edit_input(arguments: Mapping[str, Any]) -> JsonValue:
+        # Edit fragments stay private; only their sizes are observable.
+        return {
+            **fields(arguments, ("path",)),
+            "old_chars": len(str(arguments.get("old") or "")),
+            "new_chars": len(str(arguments.get("new") or "")),
+            "checksum_precondition": bool(arguments.get("expected_sha256")),
+        }
 
-        def delete_input(arguments: Mapping[str, Any]) -> JsonValue:
-            return {
-                **fields(arguments, ("path",)),
-                "checksum_precondition": bool(arguments.get("expected_sha256")),
-            }
+    def delete_input(arguments: Mapping[str, Any]) -> JsonValue:
+        return {
+            **fields(arguments, ("path",)),
+            "checksum_precondition": bool(arguments.get("expected_sha256")),
+        }
 
-        return MappingProxyType(
-            {
-                "list_workspace_files": ToolEventView(
-                    input_projection=lambda arguments: fields(
-                        arguments,
-                        ("path", "limit", "after"),
-                        allow_root=True,
-                    ),
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "error", "path", "count", "truncated", "next_cursor"),
-                    ),
-                ),
-                "stat_workspace_file": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path",)),
-                    output_projection=stat_output,
-                ),
-                "read_workspace_text": ToolEventView(
-                    input_projection=lambda arguments: fields(arguments, ("path", "cursor", "max_chars")),
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "next_cursor", "byte_size", "eof"),
-                    ),
-                    allow_repeated_identical=True,
-                ),
-                "write_workspace_text": ToolEventView(
-                    input_projection=write_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "byte_size", "warnings"),
-                    ),
-                ),
-                "append_workspace_text": ToolEventView(
-                    input_projection=append_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "byte_size", "warnings"),
-                    ),
-                ),
-                "delete_workspace_path": ToolEventView(
-                    input_projection=delete_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "warnings"),
-                    ),
-                ),
-                "edit_workspace_text": ToolEventView(
-                    input_projection=edit_input,
-                    output_projection=lambda result: output(
-                        result,
-                        ("ok", "namespace", "path", "byte_size", "warnings"),
-                    ),
-                ),
-            }
+    views = {
+        f"list_{verb}_files": ToolEventView(
+            input_projection=lambda arguments: fields(arguments, ("path", "limit", "after"), allow_root=True),
+            output_projection=lambda result: output(
+                result, ("ok", "error", "path", "count", "truncated", "next_cursor")
+            ),
+        ),
+        f"stat_{verb}_file": ToolEventView(
+            input_projection=lambda arguments: fields(arguments, ("path",)),
+            output_projection=stat_output,
+        ),
+        f"read_{verb}_text": ToolEventView(
+            input_projection=lambda arguments: fields(arguments, ("path", "cursor", "max_chars")),
+            output_projection=lambda result: output(
+                result, ("ok", "namespace", "path", "next_cursor", "byte_size", "eof")
+            ),
+            allow_repeated_identical=True,
+        ),
+        f"write_{verb}_text": ToolEventView(
+            input_projection=write_input,
+            output_projection=lambda result: output(result, ("ok", "namespace", "path", "byte_size", "warnings")),
+        ),
+        f"delete_{verb}_path": ToolEventView(
+            input_projection=delete_input,
+            output_projection=lambda result: output(result, ("ok", "namespace", "path", "warnings")),
+        ),
+        f"edit_{verb}_text": ToolEventView(
+            input_projection=edit_input,
+            output_projection=lambda result: output(result, ("ok", "namespace", "path", "byte_size", "warnings")),
+        ),
+    }
+    # Only the Session host has an append tool/view.
+    if verb == "workspace":
+        views[f"append_{verb}_text"] = ToolEventView(
+            input_projection=append_input,
+            output_projection=lambda result: output(result, ("ok", "namespace", "path", "byte_size", "warnings")),
         )
+    return MappingProxyType(views)

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -377,7 +377,7 @@ class _RLMReasoningCallback(BaseCallback):
         self,
         call_id: str,
         outputs: Any | None,
-        exception: Exception | None = None,
+        exception: BaseException | None = None,
     ) -> None:
         action_span = self._action_spans.pop(call_id, None)
         try:
@@ -502,7 +502,7 @@ class _RLMTraceCallback(BaseCallback):
         self,
         call_id: str,
         outputs: dict[str, Any] | None,
-        exception: Exception | None = None,
+        exception: BaseException | None = None,
     ) -> None:
         """
         Finalize tracing and telemetry for an LM call.
@@ -510,7 +510,7 @@ class _RLMTraceCallback(BaseCallback):
         Parameters:
             call_id (str): Identifier of the LM call.
             outputs (dict[str, Any] | None): Response data from the call.
-            exception (Exception | None): Exception raised by the call, if applicable.
+            exception (BaseException | None): Exception raised by the call, if applicable.
         """
         state = self._spans.pop(call_id, None)
         if state is None:

--- a/src/fleet_rlm/rlm/lm_factory.py
+++ b/src/fleet_rlm/rlm/lm_factory.py
@@ -113,21 +113,15 @@ def build_lm(
         dspy.LM: Configured DSPy language model.
     """
     model_id = normalize_model_id(model)
-    allowed_openai_params: list[str] = ["stream_options"]
+    allowed_openai_params: list[str] = []
     kwargs: dict[str, Any] = {
         "model_type": "chat",
         "cache": cache,
         "num_retries": num_retries,
-        # Stream and ask for a usage block on the final chunk. Gateways such as
-        # the Databricks AI Gateway ignore ``stream_options.include_usage`` on a
-        # non-streamed request, so streaming is required to observe token usage.
-        # DSPy/litellm aggregate the streamed deltas internally and ``lm()``
-        # still returns the same final outputs, leaving ChatAdapter parsing
-        # untouched. ``stream`` is a litellm transport toggle (a first-class
-        # completion() param), while ``stream_options`` is an OpenAI body param
-        # LiteLLM filters unless allowlisted.
-        "stream": True,
-        "stream_options": {"include_usage": True},
+        # Keep DSPy 3.3.x on its aggregated completion path. Its legacy LM
+        # parser consumes ``response.choices``; raw provider stream wrappers
+        # are supported through DSPy's streamify/callback APIs, not by passing
+        # ``stream=True`` to the LM itself.
     }
     if api_key:
         kwargs["api_key"] = api_key

--- a/tests/unit/backend/files/test_project_tools.py
+++ b/tests/unit/backend/files/test_project_tools.py
@@ -306,6 +306,7 @@ def test_project_event_views_expose_metadata_without_file_bodies_or_entries() ->
     host = ProjectToolHost(fs, max_file_bytes=64)
     tools = {str(tool.name): tool for tool in host.as_tools()}
     views = host.event_views()
+    assert "append_project_text" not in views
     observed: list[object] = []
 
     observe_tool(tools["write_project_text"], observed.append, views["write_project_text"])(

--- a/tests/unit/backend/files/test_workspace_tools.py
+++ b/tests/unit/backend/files/test_workspace_tools.py
@@ -203,6 +203,7 @@ def test_workspace_event_views_expose_metadata_without_file_bodies_or_entries() 
     host = WorkspaceToolHost(workspace, max_file_bytes=64)
     tools = {str(tool.name): tool for tool in host.as_tools()}
     views = host.event_views()
+    assert "append_workspace_text" in views
     observed: list[object] = []
 
     observe_tool(tools["write_workspace_text"], observed.append, views["write_workspace_text"])(

--- a/tests/unit/backend/test_lm_factory.py
+++ b/tests/unit/backend/test_lm_factory.py
@@ -53,30 +53,25 @@ def test_build_lm_allows_reasoning_effort_only_when_configured(monkeypatch: pyte
 
     assert default == "default-lm"
     assert bounded == "bounded-lm"
-    # stream_options (usage) is always allowlisted; reasoning_effort only appends
-    # its param when explicitly configured.
+    # reasoning_effort is allowlisted only when explicitly configured.
     assert "reasoning_effort" not in lm.call_args_list[0].kwargs
-    assert lm.call_args_list[0].kwargs["allowed_openai_params"] == ["stream_options"]
+    assert lm.call_args_list[0].kwargs["allowed_openai_params"] == []
     assert lm.call_args_list[1].kwargs["reasoning_effort"] == "none"
-    assert lm.call_args_list[1].kwargs["allowed_openai_params"] == ["stream_options", "reasoning_effort"]
+    assert lm.call_args_list[1].kwargs["allowed_openai_params"] == ["reasoning_effort"]
 
 
-def test_build_lm_requests_usage_via_stream_options(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_lm_uses_dspy_aggregated_completion_path(monkeypatch: pytest.MonkeyPatch) -> None:
     lm = MagicMock(return_value="lm")
     monkeypatch.setattr(factory.dspy, "LM", lm)
 
     factory.build_lm("openai/model", api_key=None)
 
     kwargs = lm.call_args.kwargs
-    # Stream so the provider emits a usage block on the final chunk: gateways
-    # (Databricks AI Gateway included) ignore stream_options.include_usage on a
-    # non-streamed request. `stream` is a litellm transport toggle passed
-    # directly; `stream_options` is an OpenAI body param that must be allowlisted.
-    # DSPy/litellm aggregate the deltas internally, so lm() still returns the
-    # same final outputs and ChatAdapter parsing is untouched.
-    assert kwargs["stream"] is True
-    assert kwargs["stream_options"] == {"include_usage": True}
-    assert kwargs["allowed_openai_params"] == ["stream_options"]
+    # DSPy 3.3.x's legacy LM parser expects the provider's aggregated
+    # completion object, not a raw streaming wrapper.
+    assert "stream" not in kwargs
+    assert "stream_options" not in kwargs
+    assert kwargs["allowed_openai_params"] == []
 
 
 def test_build_lm_requests_usage_and_reasoning_effort_together(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -86,10 +81,55 @@ def test_build_lm_requests_usage_and_reasoning_effort_together(monkeypatch: pyte
     factory.build_lm("openai/model", api_key=None, reasoning_effort="none")
 
     kwargs = lm.call_args.kwargs
-    assert kwargs["stream"] is True
-    assert kwargs["stream_options"] == {"include_usage": True}
     assert kwargs["reasoning_effort"] == "none"
-    assert kwargs["allowed_openai_params"] == ["stream_options", "reasoning_effort"]
+    assert "stream" not in kwargs
+    assert "stream_options" not in kwargs
+    assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
+
+
+@pytest.mark.asyncio
+async def test_build_lm_legacy_async_call_processes_an_aggregated_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The DSPy 3.3.x legacy LM path must receive an aggregated completion."""
+
+    import dspy.clients.lm as dspy_lm
+
+    class FakeStreamingResponse:
+        pass
+
+    class FakeCompletionResponse(dict):
+        def __init__(self) -> None:
+            choice = SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="OK"),
+            )
+            super().__init__(choices=[choice])
+            self.choices = [choice]
+            self.model = "openai/test"
+            self.usage = {}
+            self._hidden_params = {}
+
+    def completion(**kwargs):
+        if kwargs.get("stream", False):
+            return FakeStreamingResponse()
+        return FakeCompletionResponse()
+
+    async def acompletion(**kwargs):
+        return completion(**kwargs)
+
+    monkeypatch.setattr(
+        dspy_lm,
+        "_get_litellm",
+        lambda: SimpleNamespace(completion=completion, acompletion=acompletion),
+    )
+    monkeypatch.setattr(dspy_lm.dspy.settings, "send_stream", None)
+
+    lm = factory.build_lm("openai/model", api_key=None, cache=False)
+
+    result = await lm.acall(prompt="Reply with exactly OK.")
+
+    assert result == ["OK"]
 
 
 def test_build_lm_uses_chat_completion_transport(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/backend/test_session_manager.py
+++ b/tests/unit/backend/test_session_manager.py
@@ -753,6 +753,7 @@ async def test_cancellation_during_provider_create_transfers_owned_cleanup() -> 
 
     platform.release_creates.set()
     replacement_lease = await asyncio.wait_for(replacement, timeout=2)
+    await mgr._cleanup.shutdown(drain_seconds=2)
 
     from fleet_rlm.daytona.session_manager import get_active_lease_registry
 

--- a/uv.lock
+++ b/uv.lock
@@ -1147,7 +1147,7 @@ wheels = [
 
 [[package]]
 name = "fleet-rlm"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -887,7 +887,7 @@ wheels = [
 [[package]]
 name = "dspy"
 version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/stanfordnlp/dspy.git?rev=main#822f393194b845d292db89b71f6b39edf4f13e80" }
 dependencies = [
     { name = "anyio" },
     { name = "cachetools" },
@@ -903,10 +903,6 @@ dependencies = [
     { name = "requests" },
     { name = "tenacity" },
     { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/24/b455b9f3ed55264c1036eecfb56dece4f3e52ae7450401a155a83433ccae/dspy-3.3.0.tar.gz", hash = "sha256:39aa9531391accda8acd7903b52f3c9d2efe462d4bab0c2256db5352e7392754", size = 354248, upload-time = "2026-08-03T19:54:46.112Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/28/9ae061db912d63d108cfd60593c2d715b0bb0d70191ed0882c4c8780b0a4/dspy-3.3.0-py3-none-any.whl", hash = "sha256:358cbfb15d13246dc4a289bb2350c0ee602260c8a3869f7f63a48a9d2233e48c", size = 413687, upload-time = "2026-08-03T19:54:44.661Z" },
 ]
 
 [[package]]
@@ -1217,7 +1213,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0,<1" },
     { name = "databricks-agents", marker = "extra == 'benchmark'", specifier = ">=1.5" },
     { name = "daytona", specifier = "==0.202.0" },
-    { name = "dspy", specifier = ">=3.3.0,<3.4" },
+    { name = "dspy", git = "https://github.com/stanfordnlp/dspy.git?rev=main" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.141.1" },
     { name = "gepa", marker = "extra == 'optimize'", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.28,<1" },


### PR DESCRIPTION
## Summary

- track DSPy upstream main at the locked commit and keep legacy LM calls on DSPy’s aggregated completion path
- consolidate shared Session Workspace and Project tool construction and event projections
- simplify Daytona lifecycle wiring and centralize workspace-memory record formatting
- update the integration guide and LM regression coverage

## Validation

- focused backend tests: 83 passed
- related Workspace/Project/Memory/Daytona contract tests: passed
- make check-security: passed
- make build-release: passed
- make check-release: passed
- make check: stopped at the existing ignored local docs/plans quality violation; all earlier backend, type, API, stream, TUI, and code-tree checks passed

## Notes

The PR is intentionally draft pending review of the upstream DSPy-main dependency change.