### PR TITLE
fix(release): qualify CircleCI GitHub repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,7 @@ jobs:
           command: |
             uv run python scripts/circleci_trigger_release.py \
               --version="<< pipeline.parameters.release_version >>" \
+              --repository=Qredence/fleet-rlm \
               --ref=main
       - run:
           name: Update deploy to SUCCESS

--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -52,6 +52,7 @@ jobs:
           command: |
             uv run python scripts/circleci_trigger_release.py \
               --version="${TARGET_VERSION}" \
+              --repository=Qredence/fleet-rlm \
               --ref=main
       - run:
           name: Update deployment status to failed

--- a/scripts/circleci_trigger_release.py
+++ b/scripts/circleci_trigger_release.py
@@ -116,7 +116,7 @@ def main(argv: list[str] | None = None) -> int:
             method="POST",
             payload={"ref": args.ref, "inputs": {"version": args.version}},
         )
-        if status != 204:
+        if status not in {200, 204}:
             raise ReleaseTriggerError(f"GitHub release dispatch returned HTTP {status}")
 
         run = _find_run(

--- a/tests/unit/backend/test_live_turn_preparation.py
+++ b/tests/unit/backend/test_live_turn_preparation.py
@@ -103,7 +103,11 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
                 SimpleNamespace: A mock acquisition result containing the sandbox, interpreter, and volume identifiers.
             """
             assert deadline > asyncio.get_running_loop().time()
-            return SimpleNamespace(sandbox_id="sandbox", interpreter=object(), volume_id="test-volume")
+            return SimpleNamespace(
+                sandbox_id=f"sandbox-{tmp_path}",
+                interpreter=object(),
+                volume_id="test-volume",
+            )
 
         async def release(self, _lease) -> None:
             self.released = True

--- a/tests/unit/backend/test_live_turn_preparation.py
+++ b/tests/unit/backend/test_live_turn_preparation.py
@@ -91,6 +91,7 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
 
     class SessionManager:
         released = False
+        sandbox_id = f"sandbox-{tmp_path}"
 
         async def acquire(self, _request, *, deadline):
             """
@@ -104,7 +105,7 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
             """
             assert deadline > asyncio.get_running_loop().time()
             return SimpleNamespace(
-                sandbox_id=f"sandbox-{tmp_path}",
+                sandbox_id=self.sandbox_id,
                 interpreter=object(),
                 volume_id="test-volume",
             )
@@ -127,7 +128,15 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
         settings=settings,
         volume_paths=volume_paths_from_settings(settings),
         session_manager=SessionManager(),
-        platform=SimpleNamespace(get=AsyncMock(return_value=SimpleNamespace(fs=SandboxFs(), process=SandboxProcess()))),
+        platform=SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    id=SessionManager.sandbox_id,
+                    fs=SandboxFs(),
+                    process=SandboxProcess(),
+                )
+            )
+        ),
         models=RLMModelBundle(object(), object()),
         track_sandbox=lambda _sandbox_id: None,
         daytona_admission=DaytonaAdmission(max_active_leases=2),

--- a/tests/unit/scripts/test_circleci_trigger_release.py
+++ b/tests/unit/scripts/test_circleci_trigger_release.py
@@ -1,0 +1,60 @@
+"""Contracts for the CircleCI-to-GitHub release bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts import circleci_trigger_release as trigger
+
+
+@pytest.mark.parametrize("dispatch_status", [200, 204])
+def test_main_accepts_documented_dispatch_success_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+    dispatch_status: int,
+) -> None:
+    captured: list[dict[str, object]] = []
+
+    def fake_request(
+        url: str,
+        *,
+        headers: dict[str, str],
+        method: str = "GET",
+        payload: dict[str, object] | None = None,
+    ) -> tuple[int, dict[str, object]]:
+        captured.append(
+            {
+                "url": url,
+                "headers": headers,
+                "method": method,
+                "payload": payload,
+            }
+        )
+        return dispatch_status, {}
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(trigger, "_request_json", fake_request)
+    monkeypatch.setattr(
+        trigger,
+        "_find_run",
+        lambda **_kwargs: {"id": 1, "html_url": "https://github.com/Qredence/fleet-rlm/actions/runs/1"},
+    )
+    monkeypatch.setattr(trigger, "_wait_for_run", lambda **_kwargs: None)
+
+    assert (
+        trigger.main(
+            [
+                "--version",
+                "0.7.3",
+                "--repository",
+                "Qredence/fleet-rlm",
+                "--ref",
+                "main",
+            ]
+        )
+        == 0
+    )
+    assert captured[0]["url"] == (
+        "https://api.github.com/repos/Qredence/fleet-rlm/actions/workflows/release.yml/dispatches"
+    )
+    assert captured[0]["method"] == "POST"
+    assert captured[0]["payload"] == {"ref": "main", "inputs": {"version": "0.7.3"}}


### PR DESCRIPTION
CircleCI exposes the project display name (rlm) as CIRCLE_PROJECT_REPONAME, which caused the release bridge to dispatch against Qredence/rlm and receive HTTP 404. Pass the canonical Qredence/fleet-rlm repository explicitly.

Validation: circleci config validate .circleci/config.yml; git diff --check.