### PR TITLE
fix(release): use published DSPy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,12 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # Track DSPy's upstream main for the latest changes while uv.lock records
-    # the resolved commit for reproducible installs. The supported Fleet
-    # contract remains DSPy 3.3.x: assert_dspy_version() accepts 3.3.x patches
-    # and rejects other minors, and the runtime relies on the documented RLM
-    # interface plus the private interpreter-injection seam isolated in
-    # rlm.dspy_contract.
-    "dspy @ git+https://github.com/stanfordnlp/dspy.git@main",
+    # Use the published DSPy release so built distributions have PyPI-valid
+    # metadata. The supported Fleet contract remains DSPy 3.3.x:
+    # assert_dspy_version() accepts 3.3.x patches and rejects other minors,
+    # and the runtime relies on the documented RLM interface plus the private
+    # interpreter-injection seam isolated in rlm.dspy_contract.
+    "dspy>=3.3,<3.4",
     "packaging>=24,<27",
     # Sandboxed execution.
     "daytona==0.202.0",

--- a/uv.lock
+++ b/uv.lock
@@ -887,7 +887,7 @@ wheels = [
 [[package]]
 name = "dspy"
 version = "3.3.0"
-source = { git = "https://github.com/stanfordnlp/dspy.git?rev=main#822f393194b845d292db89b71f6b39edf4f13e80" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "cachetools" },
@@ -903,6 +903,10 @@ dependencies = [
     { name = "requests" },
     { name = "tenacity" },
     { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/24/b455b9f3ed55264c1036eecfb56dece4f3e52ae7450401a155a83433ccae/dspy-3.3.0.tar.gz", hash = "sha256:39aa9531391accda8acd7903b52f3c9d2efe462d4bab0c2256db5352e7392754", size = 354248, upload-time = "2026-08-03T19:54:46.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/28/9ae061db912d63d108cfd60593c2d715b0bb0d70191ed0882c4c8780b0a4/dspy-3.3.0-py3-none-any.whl", hash = "sha256:358cbfb15d13246dc4a289bb2350c0ee602260c8a3869f7f63a48a9d2233e48c", size = 413687, upload-time = "2026-08-03T19:54:44.661Z" },
 ]
 
 [[package]]
@@ -1213,7 +1217,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0,<1" },
     { name = "databricks-agents", marker = "extra == 'benchmark'", specifier = ">=1.5" },
     { name = "daytona", specifier = "==0.202.0" },
-    { name = "dspy", git = "https://github.com/stanfordnlp/dspy.git?rev=main" },
+    { name = "dspy", specifier = ">=3.3,<3.4" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.141.1" },
     { name = "gepa", marker = "extra == 'optimize'", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.28,<1" },


### PR DESCRIPTION
## Summary
- make the 0.7.3 distribution metadata valid for PyPI by using published DSPy 3.3.x
- regenerate uv.lock

## Validation
- uv lock
- make check-release
- make check-security
- make build-release
- focused unit tests
- git diff --check

The first CircleCI-backed 0.7.3 release reached the GitHub workflow but TestPyPI rejected the direct VCS dependency metadata; this follow-up fixes that root cause.