### PR TITLE
fix(rlm): profile RLM output on LM trace spans

### DIFF
--- a/.github/workflows/check-dspy-pin.yml
+++ b/.github/workflows/check-dspy-pin.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   check-dspy-availability:
-    name: Verify locked dspy is installable from PyPI
+    name: Verify locked dspy Git source is installable
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -34,36 +34,49 @@ jobs:
       - name: Resolve locked dspy version
         id: locked
         run: |
-          # Runtime policy remains dspy>=3.3.0,<3.4; this workflow verifies the
-          # version recorded in uv.lock stays installable on PyPI.
+          # The project intentionally uses a direct Git DSPy requirement;
+          # uv.lock records the exact source and commit used by local and CI runs.
           LOCKED="$(uv run --no-project python - <<'PY'
-          import re
           import tomllib
           from pathlib import Path
+          from urllib.parse import parse_qs, urlsplit, urlunsplit
 
           data = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
           match = next((pkg for pkg in data["package"] if pkg["name"] == "dspy"), None)
           if match is None:
               raise SystemExit("dspy is missing from uv.lock")
           version = match["version"]
-          if not re.fullmatch(r"3\.3\.\d+", version):
+          if not (version.startswith("3.3.") and version[4:].isdigit()):
               raise SystemExit(
                   f"locked dspy=={version} is outside the declared 3.3.x patch range "
                   "(dspy>=3.3.0,<3.4)"
               )
-          print(version)
+          git_source = match.get("source", {}).get("git")
+          if not git_source:
+              raise SystemExit("uv.lock does not pin dspy to a Git source")
+          parsed = urlsplit(git_source)
+          commit = parsed.fragment
+          revision = parse_qs(parsed.query).get("rev", [None])[0]
+          if not commit or revision != commit:
+              raise SystemExit(
+                  "uv.lock dspy Git source must contain matching rev and commit hash"
+              )
+          repository = urlunsplit(
+              (parsed.scheme, parsed.netloc, parsed.path, "", "")
+          )
+          print(f"dspy @ git+{repository}@{commit}")
           PY
           )"
-          echo "version=${LOCKED}" >> "${GITHUB_OUTPUT}"
-          echo "Locked dspy==${LOCKED}"
+          echo "requirement=${LOCKED}" >> "${GITHUB_OUTPUT}"
+          echo "Locked ${LOCKED}"
 
       - name: Check locked dspy installability
         run: |
           probe_venv="$RUNNER_TEMP/dspy-pin-venv"
-          locked="${{ steps.locked.outputs.version }}"
+          locked="${{ steps.locked.outputs.requirement }}"
           uv venv --python 3.12 "$probe_venv"
-          if ! uv pip install --dry-run --python "$probe_venv/bin/python" "dspy==${locked}"; then
-            echo "::error::dspy==${locked} (from uv.lock) is no longer installable from PyPI. The release may have been yanked. Re-lock to a reissued 3.3.x release or vendor the source per the AGENTS.md contract."
+          if ! uv pip install --dry-run --no-deps --python "$probe_venv/bin/python" "$locked"; then
+            echo "::error::${locked} (from uv.lock) is no longer installable from GitHub. Re-lock after confirming the upstream commit remains available."
             exit 1
           fi
-          echo "dspy==${locked} is available from PyPI."
+          echo "${locked} is available from GitHub."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,15 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # Use the published DSPy release so built distributions have PyPI-valid
-    # metadata. The supported Fleet contract remains DSPy 3.3.x:
+    # Pin the upstream DSPy commit so the runtime receives unreleased changes
+    # with a reproducible manifest (uv.lock records the same commit). This
+    # direct Git requirement intentionally makes published distributions
+    # unsuitable for PyPI until the upstream changes are released.
+    # The supported Fleet contract remains DSPy 3.3.x:
     # assert_dspy_version() accepts 3.3.x patches and rejects other minors,
     # and the runtime relies on the documented RLM interface plus the private
     # interpreter-injection seam isolated in rlm.dspy_contract.
-    "dspy>=3.3,<3.4",
+    "dspy @ git+https://github.com/stanfordnlp/dspy.git@e0400fd32feac35cf8e19f18640d6a36f71724b7",
     "packaging>=24,<27",
     # Sandboxed execution.
     "daytona==0.202.0",

--- a/src/fleet_rlm/daytona/errors.py
+++ b/src/fleet_rlm/daytona/errors.py
@@ -30,6 +30,22 @@ _SECRET_PATTERNS = (
     re.compile(r"sk-[A-Za-z0-9_-]+"),
 )
 
+# Bounded HTTP status classes that may appear in already-sanitized provider
+# text when the exception carries no structured ``status_code`` metadata (for
+# example a gateway error wrapped by litellm/dspy). These ground classification
+# for statuses such as 404 that would otherwise fall through to ``unknown``.
+_BARE_STATUS_TEXT = re.compile(r"\b(4\d{2}|5\d{2})\b")
+
+
+def _sanitized_status(exc: object) -> int | None:
+    """Extract a provider HTTP status even when it is only present in the text."""
+    status = provider_status_code(exc)
+    if isinstance(status, int):
+        return status
+    message = sanitize_provider_message(str(getattr(exc, "message", str(exc)) or ""))
+    match = _BARE_STATUS_TEXT.search(message)
+    return int(match.group(1)) if match is not None else None
+
 
 def sanitize_provider_message(raw: str) -> str:
     """Strip credentials and private paths from provider error text."""
@@ -91,7 +107,7 @@ def classify_provider_error(exc: object) -> ProviderFailureKind:
     cause_type = getattr(exc, "cause_type", None)
     type_name = cause_type if isinstance(cause_type, str) and cause_type else type(exc).__name__
     normalized = type_name.replace("-", "_").lower()
-    status = provider_status_code(exc)
+    status = _sanitized_status(exc)
     message_value = getattr(exc, "message", "")
     safe_message = sanitize_provider_message(str(message_value or "")).lower()
 

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -656,30 +656,69 @@ def _lm_input_profile(
     return profile
 
 
+def _to_output_mapping(outputs: Any) -> Mapping[str, Any] | None:
+    """Normalize LM callback outputs into a Mapping for profiling.
+
+    DSPy's ``on_lm_end`` may deliver the post-processed outputs (a Mapping), the
+    raw LiteLLM ``ModelResponse`` (a pydantic object, NOT a ``collections.abc``
+    ``Mapping`` — whose parsed text lives at ``choices[i].message.content``), or a
+    bare completion string. Key the profile off the meaningful payload for each
+    shape rather than throwing the object away.
+    """
+    if isinstance(outputs, Mapping):
+        return outputs
+    if isinstance(outputs, str):
+        return {"content": outputs}
+
+    choices = getattr(outputs, "choices", None)
+    if isinstance(choices, Sequence) and not isinstance(choices, (str, bytes, bytearray)):
+        first = choices[0] if choices else None
+        message = getattr(first, "message", None)
+        if message is None and isinstance(first, Mapping):
+            message = first.get("message")
+        content = getattr(message, "content", None)
+        if content is None and isinstance(message, Mapping):
+            content = message.get("content")
+        if isinstance(content, str):
+            finish = getattr(first, "finish_reason", None)
+            if finish is None and isinstance(first, Mapping):
+                finish = first.get("finish_reason")
+            result: dict[str, Any] = {"content": content}
+            if isinstance(finish, str):
+                result["finish_reason"] = finish
+            return result
+
+    model_dump = getattr(outputs, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump()
+        except Exception:  # pragma: no cover - provider objects vary
+            dumped = None
+        if isinstance(dumped, Mapping):
+            return dumped
+    return None
+
+
 def _lm_output_profile(
-    outputs: Mapping[str, Any] | None,
+    outputs: Any,
     *,
     include_previews: bool = True,
 ) -> dict[str, JsonValue]:
-    """
-    Describe an LM response for tracing.
+    """Describe an LM response for tracing.
 
-    Parameters:
-        outputs (Mapping[str, Any] | None): The LM response values to profile.
-        include_previews (bool): Whether to include a bounded response preview.
+    Accepts the post-processed outputs, the LiteLLM ``ModelResponse`` object, or a
+    bare string; all three are normalized via ``_to_output_mapping`` so the profile
+    reflects the real payload instead of collapsing to empty keys."""
 
-    Returns:
-        dict[str, JsonValue]: Structural response metadata, character count, and optionally a response preview.
-    """
-
-    if not isinstance(outputs, Mapping):
+    mapping = _to_output_mapping(outputs)
+    if mapping is None:
         return {"response_keys": ()}
-    profile: dict[str, JsonValue] = {"response_keys": tuple(sorted(str(key) for key in outputs)[:32])}
-    response_chars = sum(len(str(value)) for value in outputs.values() if isinstance(value, str))
+    profile: dict[str, JsonValue] = {"response_keys": tuple(sorted(str(key) for key in mapping)[:32])}
+    response_chars = sum(len(str(value)) for value in mapping.values() if isinstance(value, str))
     if response_chars:
         profile["response_chars"] = response_chars
-    if outputs and include_previews:
-        profile["response_preview"] = _trace_preview(_trace_payload_text(outputs))
+    if mapping and include_previews:
+        profile["response_preview"] = _trace_preview(_trace_payload_text(mapping))
     return profile
 
 

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -571,8 +571,11 @@ class _RLMTraceCallback(BaseCallback):
             value = response_details.get(key)
             if value is not None:
                 last_call[key] = value
+        failure_outputs: dict[str, JsonValue] = {}
+        failure_attributes: dict[str, JsonValue] = {}
         if exception is not None:
-            last_call["failure_category"] = _trace_failure_category(exception)
+            failure_outputs, failure_attributes = _lm_failure_details(exception)
+            last_call.update(failure_outputs)
         self._last_call = last_call
         if self._metrics is not None:
             self._metrics.record_lm_call(
@@ -598,11 +601,11 @@ class _RLMTraceCallback(BaseCallback):
                 phase_status="failed",
                 outputs={
                     "request_status": "failed",
-                    "failure_category": _trace_failure_category(exception),
+                    **failure_outputs,
                     **response_details,
                     **({"token_usage": usage} if usage else {}),
                 },
-                attributes=attributes,
+                attributes={**(attributes or {}), **failure_attributes},
             )
 
     def last_call_summary(self) -> dict[str, JsonValue]:
@@ -857,6 +860,50 @@ def _trace_failure_category(exc: BaseException) -> str:
     from fleet_rlm.observability.failure_diagnostics import trace_failure_category
 
     return trace_failure_category(exc)
+
+
+_TRACE_FAILURE_DETAIL_MAX_CHARS = 300
+
+
+def _lm_failure_details(exception: BaseException) -> tuple[dict[str, JsonValue], dict[str, JsonValue]]:
+    """Build bounded, sanitized error detail for a failed LM span and summary.
+
+    Traces such as tr-db96 surfaced a failed Root LM call with an empty status
+    message and ``failure_category: unknown``: the span recorded that *a* call
+    failed but never *why*. This supplies a bounded, credential-free breakdown
+    (exception type, provider status class, and a short sanitized message) so a
+    dead model is debuggable from the trace alone.
+
+    Returns a ``(span_failure_outputs, span_failure_attributes)`` pair: the
+    classified kinds ride on span attributes (immune to output re-sanitization
+    rewriting), while a bounded ``detail`` preview stays in outputs for the UI.
+    Everything is derived from ``sanitize_provider_message``-cleaned text —
+    raw provider exception text never reaches the trace.
+    """
+    from fleet_rlm.daytona.errors import (
+        classify_provider_error,
+        provider_status_code,
+        sanitize_provider_message,
+    )
+
+    cleaned = sanitize_provider_message(str(exception))
+    detail = cleaned[:_TRACE_FAILURE_DETAIL_MAX_CHARS]
+    status = provider_status_code(exception)
+    status_category = f"{status // 100}xx" if isinstance(status, int) and 100 <= status <= 599 else "none"
+    failure_outputs: dict[str, JsonValue] = {
+        "failure_category": classify_provider_error(exception),
+        "error_kind": type(exception).__name__,
+        "provider_status_category": status_category,
+    }
+    span_failure_attributes: dict[str, JsonValue] = {
+        "fleet.error.kind": type(exception).__name__,
+        "fleet.error.category": classify_provider_error(exception),
+        "fleet.error.status": status_category,
+    }
+    if detail:
+        failure_outputs["detail"] = detail
+        span_failure_attributes["fleet.error.detail"] = detail
+    return failure_outputs, span_failure_attributes
 
 
 def bind_native_rlm_observer(

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -50,9 +50,22 @@ class PredictionOutputError(ValueError):
 
 
 class PredictionOutputTooLargeError(PredictionOutputError):
-    """Declared Prediction JSON exceeds the Turn commit character budget."""
+    """Declared Prediction JSON exceeds the Turn commit character budget.
+
+    Diagnostics are carried as typed, sanitized attributes (never in the public
+    message, which is a closed Literal surfaced to operators)."""
 
     public_message = "Turn output is too large"
+
+    def __init__(
+        self,
+        *,
+        output_chars: int | None = None,
+        output_preview: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.output_chars = output_chars
+        self.output_preview = output_preview
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,7 +170,13 @@ def prediction_result(
     plain_outputs = _plain_json(result.outputs)
     encoded = json.dumps(plain_outputs, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
     if len(encoded) > max_output_chars:
-        raise PredictionOutputTooLargeError
+        from fleet_rlm.rlm.sanitize import sanitize_public_text
+
+        preview = sanitize_public_text(_trace_preview(result.display_text, max_chars=400))
+        raise PredictionOutputTooLargeError(
+            output_chars=len(encoded),
+            output_preview=preview,
+        )
     try:
         validate_declared_public_value(result.outputs)
     except ValueError:

--- a/src/fleet_rlm/rlm/dspy_contract.py
+++ b/src/fleet_rlm/rlm/dspy_contract.py
@@ -172,7 +172,7 @@ def prediction_result(
     if len(encoded) > max_output_chars:
         from fleet_rlm.rlm.sanitize import sanitize_public_text
 
-        preview = sanitize_public_text(_trace_preview(result.display_text, max_chars=400))
+        preview = sanitize_public_text(result.display_text, max_len=400)
         raise PredictionOutputTooLargeError(
             output_chars=len(encoded),
             output_preview=preview,

--- a/src/fleet_rlm/rlm/execution_trace.py
+++ b/src/fleet_rlm/rlm/execution_trace.py
@@ -69,6 +69,12 @@ def record_phase_failure(
     }
     if last_lm_call:
         outputs["last_lm_call"] = dict(last_lm_call)
+    output_diag = getattr(exc, "output_chars", None)
+    if isinstance(output_diag, int):
+        outputs["output_diagnostic"] = {
+            "output_chars": output_diag,
+            "output_preview": getattr(exc, "output_preview", None),
+        }
     phase.set_outputs(outputs)
 
 

--- a/src/fleet_rlm/rlm/lm_factory.py
+++ b/src/fleet_rlm/rlm/lm_factory.py
@@ -118,10 +118,9 @@ def build_lm(
         "model_type": "chat",
         "cache": cache,
         "num_retries": num_retries,
-        # Keep DSPy 3.3.x on its aggregated completion path. Its legacy LM
-        # parser consumes ``response.choices``; raw provider stream wrappers
-        # are supported through DSPy's streamify/callback APIs, not by passing
-        # ``stream=True`` to the LM itself.
+        # Native RLM calls consume completed DSPy LM responses. Provider token
+        # streaming is owned by DSPy's streamify/callback APIs and is not
+        # enabled on this model-construction seam.
     }
     if api_key:
         kwargs["api_key"] = api_key

--- a/tests/unit/backend/rlm/test_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_contract.py
@@ -711,3 +711,53 @@ def test_malformed_provider_usage_degrades_without_losing_measured_fields(provid
         "observed_lm_usage": {},
         "duration_ms": 17,
     }
+
+
+def test_lm_output_profile_reads_mapping_of_parsed_fields() -> None:
+    from fleet_rlm.rlm.dspy_contract import _lm_output_profile
+
+    # Success path: adapter-parsed outputs arrive as a Mapping of signature fields.
+    outputs = {"reasoning": "step", "code": "print(1)"}
+    profile = _lm_output_profile(outputs)
+    assert profile["response_keys"] == ("code", "reasoning")
+    assert profile["response_chars"] == len("step") + len("print(1)")
+    assert "response_preview" in profile
+
+
+def test_lm_output_profile_reads_model_response_choices_content() -> None:
+    from litellm import ModelResponse
+
+    from fleet_rlm.rlm.dspy_contract import _lm_output_profile
+
+    # Build a ModelResponse whose choices carry the JSON completion in message.content.
+    outputs = ModelResponse(
+        choices=[
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": '{"reasoning": "r", "code": "c"}',
+                },
+            }
+        ]
+    )
+    profile = _lm_output_profile(outputs)
+    assert profile["response_keys"] == ("content", "finish_reason")
+    # response_chars sums every string value in the emitted mapping:
+    # content (31) + finish_reason "stop" (4) = 35.
+    assert profile["response_chars"] == len('{"reasoning": "r", "code": "c"}') + len("stop")
+    assert "response_preview" in profile
+
+
+def test_lm_output_profile_reads_string_and_unknown_shapes() -> None:
+    from fleet_rlm.rlm.dspy_contract import _lm_output_profile
+
+    # A bare string completion is keyed as ("content",).
+    profile = _lm_output_profile('{"reasoning": "x"}')
+    assert profile["response_keys"] == ("content",)
+    assert profile["response_chars"] == len('{"reasoning": "x"}')
+
+    # Genuinely unusable shapes still degrade to the historical empty-keys shape.
+    assert _lm_output_profile(None) == {"response_keys": ()}
+    assert _lm_output_profile(object()) == {"response_keys": ()}

--- a/tests/unit/backend/rlm/test_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_contract.py
@@ -96,7 +96,7 @@ def test_prediction_result_oversized_carries_sanitized_metrics_attrs() -> None:
     assert isinstance(exc.output_chars, int) and exc.output_chars > 64
     assert isinstance(exc.output_preview, str)
     assert secret not in exc.output_preview  # secrets redacted
-    assert len(exc.output_preview) <= 900  # bounded (_trace_preview default cap)
+    assert len(exc.output_preview) <= 400  # bounded (sanitize_public_text max_len)
 
 
 def test_prediction_result_preserves_benign_security_text_and_documented_mount_verbatim() -> None:

--- a/tests/unit/backend/rlm/test_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_contract.py
@@ -445,6 +445,9 @@ def test_lm_trace_callback_records_role_and_failure_category(monkeypatch: pytest
         def set_outputs(self, payload):
             calls.outputs.append(payload)
 
+        def set_attributes(self, payload):
+            calls.attributes = payload
+
         def set_status(self, status):
             calls.status = status
 
@@ -467,10 +470,16 @@ def test_lm_trace_callback_records_role_and_failure_category(monkeypatch: pytest
     monkeypatch.setattr("fleet_rlm.rlm.dspy_contract.time.perf_counter", lambda: next(ticks))
     callback = _RLMTraceCallback(root_lm=root, sub_lm=SimpleNamespace(model="sub-model"))
 
+    class SecretError(Exception):
+        def __str__(self) -> str:
+            return "payment failed api_key=topsecret"
+
+    boom = SecretError()
+
     token = turn_tracing._fleet_trace_active.set(True)
     try:
         callback.on_lm_start("call-1", root, {"prompt": "readable prompt"})
-        callback.on_lm_end("call-1", [], ValueError("provider response failed"))
+        callback.on_lm_end("call-1", [], boom)
     finally:
         turn_tracing._fleet_trace_active.reset(token)
 
@@ -493,8 +502,96 @@ def test_lm_trace_callback_records_role_and_failure_category(monkeypatch: pytest
         "call_index": 1,
         "wall_time_ms": 125.0,
         "phase_status": "failed",
+        "error_kind": "SecretError",
+        "provider_status_category": "none",
+        "detail": "payment failed [redacted]",
     }
     assert calls.status == "ERROR"
+
+
+def test_lm_trace_callback_records_classified_failure_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed LM call must carry the *classified* provider failure on its span.
+
+    Regression coverage for traces such as tr-db96 where the root LM span was
+    ERROR with an empty message and ``failure_category: unknown``: the span
+    must record a bounded, sanitized error kind and status class so the model
+    that failed is debuggable without a live gateway.
+    """
+    from types import SimpleNamespace
+
+    from fleet_rlm.daytona.errors import ProviderRequestError
+    from fleet_rlm.observability import turn_tracing
+    from fleet_rlm.rlm.dspy_contract import _RLMTraceCallback
+
+    captured = SimpleNamespace(outputs=[])
+
+    class Span:
+        def set_inputs(self, payload):
+            captured.inputs = payload
+
+        def set_outputs(self, payload):
+            captured.outputs.append(payload)
+
+        def set_attributes(self, payload):
+            captured.attributes = payload
+
+        def set_status(self, status):
+            captured.status = status
+
+    # The span the callback actually finishes is the one opened by start_span;
+    # get_current_active_span (a separate handle) must not mask its attributes.
+    span = Span()
+
+    class SpanContext:
+        def __enter__(self):
+            return span
+
+        def __exit__(self, *_args):
+            return None
+
+    fake_mlflow = SimpleNamespace(
+        get_current_active_span=lambda: span,
+        start_span=lambda **_kwargs: SpanContext(),
+    )
+    fake_entities = SimpleNamespace(SpanType=SimpleNamespace(CHAIN="CHAIN", LLM="LLM"))
+    monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
+    monkeypatch.setitem(sys.modules, "mlflow.entities", fake_entities)
+
+    root = SimpleNamespace(model="root-model")
+    callback = _RLMTraceCallback(root_lm=root, sub_lm=SimpleNamespace(model="sub-model"))
+    boom = ProviderRequestError(
+        "404 Not Found: model api_key=topsecret is unavailable",
+        cause_type="NotFoundError",
+        status_code=404,
+    )
+
+    token = turn_tracing._fleet_trace_active.set(True)
+    try:
+        callback.on_lm_start("call-404", root, {"prompt": "p"})
+        callback.on_lm_end("call-404", [], boom)
+    finally:
+        turn_tracing._fleet_trace_active.reset(token)
+
+    span_outputs = captured.outputs[-1]
+    assert span_outputs["request_status"] == "failed"
+    assert span_outputs["phase_status"] == "failed"
+    assert span_outputs["failure_category"] == "request_validation"
+    assert span_outputs["error_kind"] == "ProviderRequestError"
+    assert span_outputs["provider_status_category"] == "4xx"
+    # The classified kinds also ride on span attributes for the UI.
+    attrs = captured.attributes
+    assert attrs["fleet.error.kind"] == "ProviderRequestError"
+    assert attrs["fleet.error.category"] == "request_validation"
+    assert attrs["fleet.error.status"] == "4xx"
+    # The sanitized details must be present but free of the embedded secret.
+    assert "detail" in span_outputs
+    assert "topsecret" not in str(span_outputs)
+    assert "topsecret" not in str(attrs)
+    # last_call_summary must mirror the classified failure.
+    summary = callback.last_call_summary()
+    assert summary["failure_category"] == "request_validation"
+    assert summary["error_kind"] == "ProviderRequestError"
+    assert "topsecret" not in str(summary)
 
 
 def test_lm_trace_callback_keeps_structural_last_call_summary() -> None:

--- a/tests/unit/backend/rlm/test_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_contract.py
@@ -73,6 +73,32 @@ def test_prediction_result_rejects_oversized_or_publicly_unsafe_outputs_without_
         )
 
 
+def test_prediction_result_oversized_carries_sanitized_metrics_attrs() -> None:
+    from fleet_rlm.rlm.dspy_contract import PredictionOutputTooLargeError, prediction_result
+
+    class Report(dspy.Signature):
+        answer: str = dspy.OutputField()
+        metadata: dict[str, str] = dspy.OutputField()
+
+    secret = "sk-live-abcdef123456"
+    with pytest.raises(PredictionOutputTooLargeError) as excinfo:
+        prediction_result(
+            dspy.Prediction(answer=f"token={secret} " + "A" * 200, metadata={}),
+            Report,
+            max_output_chars=64,
+        )
+    exc = excinfo.value
+
+    # Public message text stays exactly the closed-Literal string.
+    assert str(exc) == "Turn output is too large"
+    assert exc.public_message == "Turn output is too large"
+    # Diagnostics ride typed attrs, not the message.
+    assert isinstance(exc.output_chars, int) and exc.output_chars > 64
+    assert isinstance(exc.output_preview, str)
+    assert secret not in exc.output_preview  # secrets redacted
+    assert len(exc.output_preview) <= 900  # bounded (_trace_preview default cap)
+
+
 def test_prediction_result_preserves_benign_security_text_and_documented_mount_verbatim() -> None:
     from fleet_rlm.rlm.dspy_contract import prediction_result
 

--- a/tests/unit/backend/test_lm_factory.py
+++ b/tests/unit/backend/test_lm_factory.py
@@ -67,8 +67,8 @@ def test_build_lm_uses_dspy_aggregated_completion_path(monkeypatch: pytest.Monke
     factory.build_lm("openai/model", api_key=None)
 
     kwargs = lm.call_args.kwargs
-    # DSPy 3.3.x's legacy LM parser expects the provider's aggregated
-    # completion object, not a raw streaming wrapper.
+    # DSPy's native RLM path consumes the provider's completed response rather
+    # than a raw streaming wrapper.
     assert "stream" not in kwargs
     assert "stream_options" not in kwargs
     assert kwargs["allowed_openai_params"] == []
@@ -88,10 +88,10 @@ def test_build_lm_requests_usage_and_reasoning_effort_together(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
-async def test_build_lm_legacy_async_call_processes_an_aggregated_completion(
+async def test_build_lm_async_call_processes_an_aggregated_completion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The DSPy 3.3.x legacy LM path must receive an aggregated completion."""
+    """The native async RLM path receives an aggregated completion response."""
 
     import dspy.clients.lm as dspy_lm
 
@@ -111,7 +111,8 @@ async def test_build_lm_legacy_async_call_processes_an_aggregated_completion(
             self._hidden_params = {}
 
     def completion(**kwargs):
-        if kwargs.get("stream", False):
+        # A raw stream wrapper is intentionally incompatible with this path.
+        if kwargs.get("stream") or "stream_options" in kwargs:
             return FakeStreamingResponse()
         return FakeCompletionResponse()
 

--- a/tests/unit/backend/test_sandbox_lifecycle.py
+++ b/tests/unit/backend/test_sandbox_lifecycle.py
@@ -88,6 +88,29 @@ def test_provider_error_classification(exc: object, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        # Gateway errors frequently hide status under a nested httpx/requests
+        # response object rather than a top-level ``status_code`` attribute.
+        (RuntimeError("model not found"), "unknown"),
+        (SimpleNamespace(response=SimpleNamespace(status_code=404)), "request_validation"),
+        (SimpleNamespace(response=SimpleNamespace(status_code=401)), "auth"),
+        (SimpleNamespace(response=SimpleNamespace(status_code=503)), "provider_5xx"),
+        # Bare HTTP status text (no structured metadata at all) is how many
+        # gateway 404/5xx failures actually surface after wrapping.
+        (RuntimeError("404 Not Found: model databricks-deepseek-v4-flash-0731"), "request_validation"),
+        (RuntimeError("Error 503: upstream unavailable"), "provider_5xx"),
+        (RuntimeError("400 Bad Request: invalid model"), "request_validation"),
+        (RuntimeError("401 Unauthorized"), "auth"),
+        (RuntimeError("429 Too Many Requests"), "quota"),
+    ],
+)
+def test_provider_error_classification_reads_nested_status_and_text(exc: object, expected: str) -> None:
+    """404/5xx must classify even without a top-level ``status_code`` attribute."""
+    assert classify_provider_error(exc) == expected
+
+
+@pytest.mark.parametrize(
     ("status", "expected"),
     [(None, "none"), (401, "4xx"), (429, "4xx"), (503, "5xx")],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -887,7 +887,7 @@ wheels = [
 [[package]]
 name = "dspy"
 version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/stanfordnlp/dspy.git?rev=e0400fd32feac35cf8e19f18640d6a36f71724b7#e0400fd32feac35cf8e19f18640d6a36f71724b7" }
 dependencies = [
     { name = "anyio" },
     { name = "cachetools" },
@@ -903,10 +903,6 @@ dependencies = [
     { name = "requests" },
     { name = "tenacity" },
     { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/24/b455b9f3ed55264c1036eecfb56dece4f3e52ae7450401a155a83433ccae/dspy-3.3.0.tar.gz", hash = "sha256:39aa9531391accda8acd7903b52f3c9d2efe462d4bab0c2256db5352e7392754", size = 354248, upload-time = "2026-08-03T19:54:46.112Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/28/9ae061db912d63d108cfd60593c2d715b0bb0d70191ed0882c4c8780b0a4/dspy-3.3.0-py3-none-any.whl", hash = "sha256:358cbfb15d13246dc4a289bb2350c0ee602260c8a3869f7f63a48a9d2233e48c", size = 413687, upload-time = "2026-08-03T19:54:44.661Z" },
 ]
 
 [[package]]
@@ -1217,7 +1213,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0,<1" },
     { name = "databricks-agents", marker = "extra == 'benchmark'", specifier = ">=1.5" },
     { name = "daytona", specifier = "==0.202.0" },
-    { name = "dspy", specifier = ">=3.3,<3.4" },
+    { name = "dspy", git = "https://github.com/stanfordnlp/dspy.git?rev=e0400fd32feac35cf8e19f18640d6a36f71724b7" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.141.1" },
     { name = "gepa", marker = "extra == 'optimize'", specifier = ">=0.1.1" },
     { name = "httpx", specifier = ">=0.28,<1" },


### PR DESCRIPTION
## Summary

Profiles and hardens RLM output surfaced on LM trace spans. Five commits on `main`:

- **bebef800a** — profile `ModelResponse` `choices` in LM trace output
- **d7ebcaee7** — sanitized oversized-output diagnostic on RLM span
- **b33180456** — cap oversized-output preview at 400 via `sanitize max_len`
- **efd8f9900** — surface classified provider failure on failed LM spans
- **1801a5167** — pin DSPy to Git commit for native RLM compatibility

## Changes

- Trace spans now carry profiled `choices` and a sanitized oversized-output diagnostic capped at 400 chars.
- Provider failures are classified and surfaced on failed LM spans instead of hiding behind the dropped/generic error path.
- Dependencies pinned to the DSPy Git commit that provides native RLM compatibility.

## Testing

RLM tests + typing are green locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)