### PR TITLE
feat(api): add public /health and /health/ready probes

### DIFF
--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -25,6 +25,8 @@ The generated source of truth is [`openapi.yaml`](../../openapi.yaml).
 | `GET` | `/api/skills/{skill_id}` | Read one bounded system Skill Card |
 | `PUT` | `/api/runs/{run_id}/cancellation` | Request cancellation of an owned Run |
 | `GET/PATCH` | `/api/settings` | Read or revision-update non-secret `config/fleet.toml` policy from a loopback client |
+| `GET` | `/health` | Liveness probe: process identity, no dependency checks |
+| `GET` | `/health/ready` | Readiness probe: composition installed and the configured database answers |
 
 The API uses one deterministic local User and Workspace scope. It accepts no
 Authorization or caller-supplied identity headers. The settings endpoint is a
@@ -97,3 +99,15 @@ content checksum for precondition chaining.
 
 `POST /api/artifacts` does not exist. Artifacts become public only through Turn
 Commit after host-mediated `create_artifact` produces a private candidate.
+
+## Health probes
+
+`GET /health` answers liveness for any caller while the process serves HTTP,
+even before lifespan composition completes: it returns the application name and
+version and performs no dependency checks. `GET /health/ready` answers
+readiness: before composition installs it returns the closed `service_not_ready`
+JSON 503 used by serving routes; once composed it probes the configured database
+with one `SELECT 1` round-trip and reports `database: "ok"`, or
+`database: "not_configured"` when no database URL is set. An unreachable
+configured database degrades readiness to the same closed 503. Neither probe
+requires an identity header, a loopback client, or an existing Session.

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -106,8 +106,9 @@ Commit after host-mediated `create_artifact` produces a private candidate.
 even before lifespan composition completes: it returns the application name and
 version and performs no dependency checks. `GET /health/ready` answers
 readiness: before composition installs it returns the closed `service_not_ready`
-JSON 503 used by serving routes; once composed it probes the configured database
-with one `SELECT 1` round-trip and reports `database: "ok"`, or
-`database: "not_configured"` when no database URL is set. An unreachable
-configured database degrades readiness to the same closed 503. Neither probe
+JSON 503 on the shared error envelope (serving routes use `turn_unavailable`
+there); once composed it probes the configured database with one bounded
+`SELECT 1` round-trip and reports `database: "ok"`, or
+`database: "not_configured"` when no database URL is set. An unreachable or
+hung database degrades readiness to the same closed 503. Neither probe
 requires an identity header, a loopback client, or an existing Session.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -807,6 +807,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /health:
+    get:
+      tags:
+      - health
+      summary: Get Health
+      description: 'Liveness: the process is serving HTTP regardless of composition
+        state.'
+      operationId: get_health
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthLivenessResponse'
+  /health/ready:
+    get:
+      tags:
+      - health
+      summary: Get Readiness
+      description: 'Readiness: composition installed and the configured database answers.'
+      operationId: get_readiness
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthReadinessResponse'
+        '503':
+          description: Service is not ready
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
     ArtifactResponse:
@@ -1129,6 +1164,43 @@ components:
       - state
       - input
       title: DynamicToolUIMessagePart
+    HealthLivenessResponse:
+      properties:
+        status:
+          type: string
+          const: ok
+          title: Status
+        app:
+          type: string
+          title: App
+        version:
+          type: string
+          title: Version
+      type: object
+      required:
+      - status
+      - app
+      - version
+      title: HealthLivenessResponse
+      description: Liveness payload — the process is serving HTTP; no dependency checks.
+    HealthReadinessResponse:
+      properties:
+        status:
+          type: string
+          const: ready
+          title: Status
+        database:
+          type: string
+          enum:
+          - ok
+          - not_configured
+          title: Database
+      type: object
+      required:
+      - status
+      - database
+      title: HealthReadinessResponse
+      description: Readiness payload — composition installed and the database answers.
     JsonValue: {}
     ReasoningUIMessagePart:
       properties:

--- a/src/fleet_rlm/api/dependencies.py
+++ b/src/fleet_rlm/api/dependencies.py
@@ -63,6 +63,18 @@ def get_ready_runtime_inventory(request: Request) -> RuntimeInventory:
     return inventory
 
 
+def get_runtime_inventory_if_ready(request: Request) -> RuntimeInventory | None:
+    """Return the composed inventory without failing pre-composition requests.
+
+    Health probes must distinguish "process alive but not composed" from
+    "composition complete", so they read composition readiness directly
+    instead of sharing the closed 503 dependency used by serving routes.
+    """
+    if not getattr(request.app.state, "composition_ready", False):
+        return None
+    return get_runtime_inventory(request.app)
+
+
 def get_turn_runtime(request: Request) -> TurnRuntime:
     runtime = get_ready_runtime_inventory(request).turn_runtime
     if runtime is None:
@@ -174,6 +186,7 @@ SessionCatalogDep = Annotated[SessionCatalog, Depends(get_session_catalog)]
 SessionRuntimeRegistryDep = Annotated[SessionRLMRegistry | None, Depends(get_session_runtime_registry)]
 SessionPrewarmDep = Annotated[Callable[[UUID, UUID, UUID], asyncio.Task[None]] | None, Depends(get_session_prewarm)]
 RunLifecycleDep = Annotated[RunLifecycle, Depends(get_run_lifecycle)]
+RuntimeInventoryIfReadyDep = Annotated[RuntimeInventory | None, Depends(get_runtime_inventory_if_ready)]
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 SkillCatalogDep = Annotated[SkillCatalog, Depends(get_skill_catalog)]
 ConfigPolicyDep = Annotated[ConfigPolicyService, Depends(get_config_policy)]
@@ -187,6 +200,7 @@ __all__ = [
     "ConfigPolicyDep",
     "LocalScopeDep",
     "RunLifecycleDep",
+    "RuntimeInventoryIfReadyDep",
     "SessionCatalogDep",
     "SessionPrewarmDep",
     "SessionRuntimeRegistryDep",

--- a/src/fleet_rlm/api/routes/health.py
+++ b/src/fleet_rlm/api/routes/health.py
@@ -1,0 +1,40 @@
+"""Liveness and readiness probes for the Fleet RLM backend."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from fleet_rlm import __version__
+from fleet_rlm.api.dependencies import RuntimeInventoryIfReadyDep, SettingsDep
+from fleet_rlm.api.errors import http_error
+from fleet_rlm.api.schemas import HealthLivenessResponse, HealthReadinessResponse
+
+router = APIRouter(prefix="/health", tags=["health"])
+
+
+@router.get(
+    "",
+    response_model=HealthLivenessResponse,
+    operation_id="get_health",
+)
+def get_health(settings: SettingsDep) -> HealthLivenessResponse:
+    """Liveness: the process is serving HTTP regardless of composition state."""
+    return HealthLivenessResponse(status="ok", app=settings.app_name, version=__version__)
+
+
+@router.get(
+    "/ready",
+    response_model=HealthReadinessResponse,
+    operation_id="get_readiness",
+    responses={503: {"description": "Service is not ready"}},
+)
+async def get_readiness(inventory: RuntimeInventoryIfReadyDep) -> HealthReadinessResponse:
+    """Readiness: composition installed and the configured database answers."""
+    if inventory is None:
+        raise http_error(503, "service_not_ready", "Service is not ready")
+    database = await inventory.database.readiness()
+    if database == "unreachable":
+        raise http_error(503, "service_not_ready", "Service is not ready")
+    if database == "ok":
+        return HealthReadinessResponse(status="ready", database="ok")
+    return HealthReadinessResponse(status="ready", database="not_configured")

--- a/src/fleet_rlm/api/schemas.py
+++ b/src/fleet_rlm/api/schemas.py
@@ -383,3 +383,23 @@ class SettingsPolicyPatchRequest(BaseModel):
     path: str | None = Field(default=None, min_length=1, max_length=128, pattern=r"^[a-z][a-z0-9_.]*$")
     value: JsonValue = None
     profile: str | None = Field(default=None, min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+# ---------------------------------------------------------------------------
+# Health probes (liveness / readiness)
+# ---------------------------------------------------------------------------
+
+
+class HealthLivenessResponse(BaseModel):
+    """Liveness payload — the process is serving HTTP; no dependency checks."""
+
+    status: Literal["ok"]
+    app: str
+    version: str
+
+
+class HealthReadinessResponse(BaseModel):
+    """Readiness payload — composition installed and the database answers."""
+
+    status: Literal["ready"]
+    database: Literal["ok", "not_configured"]

--- a/src/fleet_rlm/app.py
+++ b/src/fleet_rlm/app.py
@@ -246,6 +246,7 @@ def create_app(
 
     from fleet_rlm.api.routes.artifacts import router as artifacts_router
     from fleet_rlm.api.routes.attachments import router as attachments_router
+    from fleet_rlm.api.routes.health import router as health_router
     from fleet_rlm.api.routes.runs import router as runs_router
     from fleet_rlm.api.routes.sessions import router as sessions_router
     from fleet_rlm.api.routes.settings import router as settings_router
@@ -263,6 +264,7 @@ def create_app(
     app.include_router(settings_router)
     app.include_router(workspace_files_router)
     app.include_router(volume_router)
+    app.include_router(health_router)
 
     from fleet_rlm.skills.catalog import build_bundled_skill_catalog
 

--- a/src/fleet_rlm/composition/inventory.py
+++ b/src/fleet_rlm/composition/inventory.py
@@ -90,6 +90,9 @@ class RuntimeDatabaseLifecycle:
     engine: AsyncEngine | None = None
     session_factory: async_sessionmaker[AsyncSession] | None = None
     dispose_engine: bool = True
+    # Bounded probe window for readiness(); a hung connection or statement
+    # must degrade readiness, never wedge the probe open.
+    _PROBE_TIMEOUT_SECONDS: ClassVar[float] = 5.0
 
     async def aclose(self) -> None:
         if self.dispose_engine and self.engine is not None:
@@ -99,15 +102,18 @@ class RuntimeDatabaseLifecycle:
         """Probe the configured engine for health checks without raising.
 
         A probe failure degrades the verdict to "unreachable" instead of
-        surfacing an error: any transport, driver, or server refusal is one
-        closed verdict, and the caller translates it into its own public
-        contract. Cancellation is BaseException and is never swallowed here.
+        surfacing an error: any transport, driver, or server refusal, or a
+        probe that exceeds its bounded window, is one closed verdict, and
+        the caller translates it into its own public contract. The bound is
+        cancellation-safe: CancelledError is BaseException and is never
+        swallowed here.
         """
         if self.engine is None:
             return "not_configured"
         try:
-            async with self.engine.connect() as connection:
-                await connection.execute(text("SELECT 1"))
+            async with asyncio.timeout(self._PROBE_TIMEOUT_SECONDS):
+                async with self.engine.connect() as connection:
+                    await connection.execute(text("SELECT 1"))
         except Exception:
             return "unreachable"
         return "ok"

--- a/src/fleet_rlm/composition/inventory.py
+++ b/src/fleet_rlm/composition/inventory.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, ClassVar, Protocol
+from typing import TYPE_CHECKING, ClassVar, Literal, Protocol
 from uuid import UUID
 
 from fastapi import FastAPI
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 if TYPE_CHECKING:
@@ -93,6 +94,23 @@ class RuntimeDatabaseLifecycle:
     async def aclose(self) -> None:
         if self.dispose_engine and self.engine is not None:
             await self.engine.dispose()
+
+    async def readiness(self) -> Literal["ok", "not_configured", "unreachable"]:
+        """Probe the configured engine for health checks without raising.
+
+        A probe failure degrades the verdict to "unreachable" instead of
+        surfacing an error: any transport, driver, or server refusal is one
+        closed verdict, and the caller translates it into its own public
+        contract. Cancellation is BaseException and is never swallowed here.
+        """
+        if self.engine is None:
+            return "not_configured"
+        try:
+            async with self.engine.connect() as connection:
+                await connection.execute(text("SELECT 1"))
+        except Exception:
+            return "unreachable"
+        return "ok"
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/contracts/backend/test_health_api.py
+++ b/tests/contracts/backend/test_health_api.py
@@ -1,0 +1,90 @@
+"""HTTP contract for Fleet liveness and readiness probes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import fleet_rlm
+from fleet_rlm.composition.inventory import RuntimeDatabaseLifecycle
+from fleet_rlm.composition.testing import create_testing_app
+from fleet_rlm.config.settings import Settings
+from fleet_rlm.persistence.database import create_async_engine_from_url
+
+
+def _settings(tmp_path: Path, database_url: str | None) -> Settings:
+    return Settings(
+        run_environment="daytona",
+        data_root=str(tmp_path / "data"),
+        database_url=database_url,
+    )
+
+
+def test_liveness_answers_before_composition_and_reports_identity(tmp_path: Path) -> None:
+    app = create_testing_app(settings=_settings(tmp_path, None))
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "app": "fleet-rlm",
+        "version": fleet_rlm.__version__,
+    }
+
+
+def test_readiness_is_closed_503_before_composition(tmp_path: Path) -> None:
+    app = create_testing_app(settings=_settings(tmp_path, None))
+    client = TestClient(app)
+
+    response = client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert response.json() == {"code": "service_not_ready", "message": "Service is not ready"}
+
+
+def test_readiness_reports_database_ok_when_composed(tmp_path: Path) -> None:
+    database_url = f"sqlite+aiosqlite:///{(tmp_path / 'readiness.db').resolve()}"
+    app = create_testing_app(settings=_settings(tmp_path, database_url))
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready", "database": "ok"}
+
+
+def test_readiness_reports_not_configured_without_a_database(tmp_path: Path) -> None:
+    app = create_testing_app(settings=_settings(tmp_path, None))
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready", "database": "not_configured"}
+
+
+def test_readiness_is_closed_503_when_the_configured_database_is_unreachable(tmp_path: Path) -> None:
+    database_url = f"sqlite+aiosqlite:///{(tmp_path / 'readiness.db').resolve()}"
+    app = create_testing_app(settings=_settings(tmp_path, database_url))
+    broken_engine = create_async_engine_from_url(
+        f"sqlite+aiosqlite:///{(tmp_path / 'missing' / 'broken.db').resolve()}"
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/health/ready").status_code == 200
+
+        inventory = app.state.runtime_inventory
+        assert inventory is not None
+        app.state.runtime_inventory = replace(
+            inventory,
+            database=RuntimeDatabaseLifecycle(engine=broken_engine),
+        )
+
+        degraded = client.get("/health/ready")
+
+    assert degraded.status_code == 503
+    assert degraded.json() == {"code": "service_not_ready", "message": "Service is not ready"}

--- a/tests/contracts/backend/test_health_api.py
+++ b/tests/contracts/backend/test_health_api.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from dataclasses import replace
 from pathlib import Path
+from typing import Any, cast
 
+import pytest
 from fastapi.testclient import TestClient
 
 import fleet_rlm
@@ -88,3 +92,31 @@ def test_readiness_is_closed_503_when_the_configured_database_is_unreachable(tmp
 
     assert degraded.status_code == 503
     assert degraded.json() == {"code": "service_not_ready", "message": "Service is not ready"}
+
+
+@pytest.mark.asyncio
+async def test_readiness_probe_is_bounded_against_a_hung_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(RuntimeDatabaseLifecycle, "_PROBE_TIMEOUT_SECONDS", 0.05)
+
+    class HungConnection:
+        async def __aenter__(self) -> HungConnection:
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            del exc_info
+
+        async def execute(self, statement: object) -> None:
+            del statement
+            await asyncio.sleep(30)
+
+    class HungEngine:
+        def connect(self) -> HungConnection:
+            return HungConnection()
+
+    lifecycle = RuntimeDatabaseLifecycle(engine=cast(Any, HungEngine()))
+    started = time.monotonic()
+
+    verdict = await lifecycle.readiness()
+
+    assert verdict == "unreachable"
+    assert time.monotonic() - started < 5

--- a/tools/fleet-tui/src/generated/openapi.ts
+++ b/tools/fleet-tui/src/generated/openapi.ts
@@ -355,6 +355,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Health
+         * @description Liveness: the process is serving HTTP regardless of composition state.
+         */
+        get: operations["get_health"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/health/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Readiness
+         * @description Readiness: composition installed and the configured database answers.
+         */
+        get: operations["get_readiness"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -557,6 +597,37 @@ export interface components {
             errorText?: string | null;
             /** Providerexecuted */
             providerExecuted?: boolean | null;
+        };
+        /**
+         * HealthLivenessResponse
+         * @description Liveness payload — the process is serving HTTP; no dependency checks.
+         */
+        HealthLivenessResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "ok";
+            /** App */
+            app: string;
+            /** Version */
+            version: string;
+        };
+        /**
+         * HealthReadinessResponse
+         * @description Readiness payload — composition installed and the database answers.
+         */
+        HealthReadinessResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "ready";
+            /**
+             * Database
+             * @enum {string}
+             */
+            database: "ok" | "not_configured";
         };
         JsonValue: unknown;
         /** ReasoningUIMessagePart */
@@ -2047,6 +2118,55 @@ export interface operations {
             };
             /** @description Validation Error */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    get_health: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthLivenessResponse"];
+                };
+            };
+        };
+    };
+    get_readiness: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthReadinessResponse"];
+                };
+            };
+            /** @description Service is not ready */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
# Description

Adds two public health probes to the FastAPI backend:

- `GET /health` (liveness): answers `{"status": "ok", "app", "version"}` for any caller while the process serves HTTP, even before lifespan composition completes. No dependency checks.
- `GET /health/ready` (readiness): returns the closed `service_not_ready` JSON 503 before composition installs; once composed, it probes the configured database with one `SELECT 1` round-trip and reports `database: "ok"`, or `database: "not_configured"` when no database URL is set. An unreachable configured database degrades readiness to the same closed 503.

Motivation: the backend previously exposed no health surface, so orchestrators (and the agent-readiness audit `health_checks` criterion) could not distinguish a dead process from a live-but-degrading one, nor detect an unreachable configured database before user-visible Turn traffic. Neither probe requires an identity header, a loopback client, or an existing Session.

No new dependencies. Implementation follows existing seams:

- The router retrieves the composed inventory through a new non-raising `RuntimeInventoryIfReadyDep` (probes must distinguish "not composed" from "composed", unlike the closed 503 dependency used by serving routes).
- `RuntimeDatabaseLifecycle.readiness()` owns the fail-soft `SELECT 1` verdict (`ok` / `not_configured` / `unreachable`) and never raises.
- Response models live in `api/schemas.py`; the OpenAPI hook maps the 503 to the closed `ErrorResponse` contract.
- Generated contracts regenerated via `make api-sync` (`openapi.yaml` + `tools/fleet-tui/src/generated/openapi.ts`; 16 to 18 paths).
- `docs/reference/http-api.md` documents both probes.

Five contract tests in `tests/contracts/backend/test_health_api.py` cover: liveness before composition, closed 503 before composition, database ok with a real SQLite engine, not_configured without a database, and closed 503 with a broken engine swapped in mid-lifespan.

No linked issue: this closes the `health_checks` gap from the repository agent-readiness audit.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Relevant local validation passed (all `make quality-gate` components run and green: lint, format-check, typecheck, test-daytona-cov at 78.30% coverage / 75% gate, api-check, tui-check, check-codebase-tree, check-dependency-boundaries, check-docs, check-security, build-release, check-release)
- [ ] Pre-commit and pre-push hooks installed locally (not installed in this environment; equivalent gates were run directly via `make`)
- [x] Documentation updated (`docs/reference/http-api.md`, route docstrings)
- [x] Commit messages follow conventions
- [x] PR description clearly explains the change
- [ ] Link related issues in the PR description (none exist)
