### PR TITLE
fix(ci): first-flake auto-rerun for python-compat jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,12 +292,13 @@ jobs:
           name: Unit and contract tests
           no_output_timeout: 15m
           command: |
-            env FLEET_DAYTONA_API_KEY= FLEET_OPENAI_API_KEY= FLEET_LLM_BASE_URL= FLEET_DATABASE_URL= \
-              uv run --python "<< parameters.python_version >>" pytest \
-              tests/unit/backend tests/contracts/backend -q \
-              -n 2 \
-              --dist=loadfile \
-              -m "not live_llm and not live_daytona and not benchmark and not db and not packaging"
+            mkdir -p test-results
+            circleci run testsuite "pytest-compat"
+      - store_test_results:
+          path: test-results
+      - store_artifacts:
+          path: test-results
+          destination: test-results/compat
 
   tui:
     executor: node

--- a/.circleci/test-suites.yml
+++ b/.circleci/test-suites.yml
@@ -11,3 +11,15 @@ options:
   # fail whole workflows on their first flake. A test failing every
   # attempt still fails the job.
   max-auto-rerun: 2
+---
+name: pytest-compat
+discover: bash -c 'find tests/unit/backend tests/contracts/backend -type f -name "*.py" ! -path "tests/unit/backend/packaging/*" ! -name "__init__.py" ! -name "fakes.py" ! -name "_*.py" -print | sort'
+run: bash -c 'set -f; mkdir -p test-results; FLEET_DAYTONA_API_KEY= FLEET_OPENAI_API_KEY= FLEET_LLM_BASE_URL= FLEET_DATABASE_URL= .venv/bin/pytest -q -n 2 --dist=loadfile -p no:warnings -m "not live_llm and not live_daytona and not benchmark and not db and not packaging" --junit-xml=<< outputs.junit >> << test.atoms >>'
+outputs:
+  junit: test-results/pytest-compat.xml
+options:
+  # Same first-flake containment as pytest-unit for the python-compat
+  # matrix: each compat job runs on one node without dynamic splitting,
+  # so a timing flake reruns in place instead of failing the matrix
+  # entry — and with it every main push — on its first occurrence.
+  max-auto-rerun: 2

--- a/docs/how-to-guides/testing-strategy.md
+++ b/docs/how-to-guides/testing-strategy.md
@@ -60,8 +60,10 @@ CircleCI enforces the same non-live surface: the `ci` workflow runs `quality`
 openapi-typescript there: release, docs, security, dependency, `api-check`,
 and `stream-check`),
 `lint-typecheck`, `test-unit`, `test-e2e`, `daytona-coverage`, lightweight
-`python-compat-311` / `python-compat-312` jobs (lock/install, import check, and
-`tests/unit/backend` + `tests/contracts/backend` only), and the `tui`
+`python-compat-311` / `python-compat-312` / `python-compat-313` jobs
+(lock/install, import check, and `tests/unit/backend` + `tests/contracts/backend`
+only, through the `pytest-compat` testsuite with the same first-flake
+`max-auto-rerun` containment as `pytest-unit`), and the `tui`
 job (pnpm format, lint, typecheck, and Vitest against the maintained client).
 Python 3.13 remains the full gate image; 3.11/3.12 certify declared support
 without duplicating Daytona coverage or E2E. Packaging/install certification


### PR DESCRIPTION
# Description

Gives the `python-compat-311/312/313` CircleCI jobs the same first-flake auto-rerun containment that `pytest-unit` already has.

Motivation: main went red at `79761ac81` because `python-compat-313` failed in one of three duplicate `ci` pipelines while the identical job passed in its two sibling pipelines (same commit, same code). The compat jobs ran `pytest` directly with `-n 2` and no rerun safety net, so one CI-timing-sensitive test (the repo already documents "recursion-flow deadline races" as its known flake class in `.circleci/test-suites.yml`) failed the whole matrix entry. Because `store_test_results` never ran, the failure left no JUnit records to identify the flaky test.

Changes:

- `.circleci/test-suites.yml`: adds a `pytest-compat` suite (documented multi-document format) with `max-auto-rerun: 2`, running `tests/unit/backend` + `tests/contracts/backend` with the same marker exclusions, env masking, and `-n 2 --dist=loadfile` parallelism as before; the existing `pytest-unit` suite is unchanged.
- `.circleci/config.yml`: the python-compat jobs now run `circleci run testsuite "pytest-compat"` and upload per-run JUnit test results and artifacts, so any future failure is attributable to specific tests instead of silent.
- `docs/how-to-guides/testing-strategy.md`: the CI lane description now includes `python-compat-313` (previously omitted) and the shared auto-rerun containment.

Validation:

- `circleci config validate` passes.
- Both suites parse and discover via the local testsuite CLI: `pytest-compat` lists 223 atoms, `pytest-unit` lists 262.
- Full `pytest-compat` suite run locally end-to-end: 223 atoms, all passing, JUnit written.
- `make check-docs` and `git diff --check` pass.
- This PR's own `python-compat-*` CI runs exercise the new suite config end-to-end before merge.

Related: main's separate red `deploy - 3078fcb4` check is a CircleCI deployment-trigger misconfiguration (it fires on main pushes with `deploy_pypi=true` but no `release_version`), which needs a dashboard-side fix and is out of scope here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Relevant local validation passed (config validated, both suites parsed and discovered, full pytest-compat suite green locally, check-docs)
- [ ] Pre-commit and pre-push hooks installed locally (not installed in this environment; equivalent gates run directly)
- [x] Documentation updated (docs/how-to-guides/testing-strategy.md)
- [x] Commit messages follow conventions
- [x] PR description clearly explains the change
- [ ] Link related issues in the PR description (none exist)
