### PR TITLE
ci: Optimize CircleCI caching and gating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
       - image: cimg/python:3.13.13-node
     working_directory: ~/project
     environment:
-      UV_CACHE_DIR: ~/.cache/uv
+      UV_CACHE_DIR: /home/circleci/.cache/uv
   python-compat:
     parameters:
       image:
@@ -25,7 +25,7 @@ executors:
       - image: << parameters.image >>
     working_directory: ~/project
     environment:
-      UV_CACHE_DIR: ~/.cache/uv
+      UV_CACHE_DIR: /home/circleci/.cache/uv
   node:
     docker:
       - image: cimg/node:22.23.2@sha256:7c78a95e25876729c2c9cada532b0636fd3ec7dbae922b3d90d83704f4c87639
@@ -53,8 +53,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-uv-<< parameters.python_tag >>-{{ arch }}-{{ checksum "uv.lock" }}
-            - v1-uv-<< parameters.python_tag >>-{{ arch }}-
+            - v2-uv-<< parameters.python_tag >>-{{ arch }}-{{ checksum "uv.lock" }}
+            - v2-uv-<< parameters.python_tag >>-{{ arch }}-
 
   save_uv_cache:
     parameters:
@@ -63,9 +63,9 @@ commands:
         default: "py313"
     steps:
       - save_cache:
-          key: v1-uv-<< parameters.python_tag >>-{{ arch }}-{{ checksum "uv.lock" }}
+          key: v2-uv-<< parameters.python_tag >>-{{ arch }}-{{ checksum "uv.lock" }}
           paths:
-            - ~/.cache/uv
+            - /home/circleci/.cache/uv
 
   install_python_dependencies:
     parameters:
@@ -149,7 +149,7 @@ jobs:
 
   test-unit:
     executor: python
-    resource_class: medium+
+    resource_class: medium
     parallelism: 4
     steps:
       - checkout
@@ -240,7 +240,7 @@ jobs:
           name: Trigger and wait for GitHub Actions release
           no_output_timeout: 45m
           command: |
-            uv run python scripts/circleci_trigger_release.py \
+            uv run --no-project python scripts/circleci_trigger_release.py \
               --version="<< pipeline.parameters.release_version >>" \
               --repository=Qredence/fleet-rlm \
               --ref=main
@@ -339,11 +339,14 @@ workflows:
           python_tag: "py313"
           image: cimg/python:3.13.13
       - tui
-
-  deploy-pypi:
-    when: << pipeline.parameters.deploy_pypi >>
-    jobs:
       - deploy-pypi:
-          filters:
-            branches:
-              only: main
+          requires:
+            - quality
+            - lint-typecheck
+            - test-unit
+            - coverage-gate
+            - python-compat-311
+            - python-compat-312
+            - python-compat-313
+            - tui
+          filters: pipeline.parameters.deploy_pypi and pipeline.git.branch == "main"

--- a/docs/how-to-guides/testing-strategy.md
+++ b/docs/how-to-guides/testing-strategy.md
@@ -32,18 +32,19 @@ use xdist `loadfile` scheduling to keep module-scoped fixtures together. The
 packaging/release matrix is intentionally excluded because it creates isolated
 virtual environments and artifacts; run it explicitly with `make test-packaging`.
 
-Package-wide coverage is enforced separately over the same canonical non-live
-corpus:
+Package-wide coverage remains available locally over the same canonical
+non-live corpus:
 
 ```bash
 make test-daytona-cov
 ```
 
 This target measures `src/fleet_rlm`, fails below 75%, prints missing lines,
-and writes `.scratch/coverage/daytona.xml`. CircleCI runs it as one aggregate
-job because the existing unit and E2E jobs execute independent test shards that
-cannot enforce a package-wide threshold individually. Coverage is not a
-substitute for the opt-in live Daytona durability checks below.
+and writes `.scratch/coverage/daytona.xml`. CircleCI instead measures coverage
+inside the four `test-unit` shards, persists each shard's `.coverage.*` data,
+and combines it in the downstream `coverage-gate` job, which enforces the same
+75% floor. Coverage is not a substitute for the opt-in live Daytona durability
+checks below.
 
 `make check` includes:
 
@@ -58,16 +59,19 @@ substitute for the opt-in live Daytona durability checks below.
 CircleCI enforces the same non-live surface: the `ci` workflow runs `quality`
 (on the Node-bearing `cimg/python:*-node` executor so `api-check` can run
 openapi-typescript there: release, docs, security, dependency, `api-check`,
-and `stream-check`),
-`lint-typecheck`, `test-unit`, `test-e2e`, `daytona-coverage`, lightweight
-`python-compat-311` / `python-compat-312` / `python-compat-313` jobs
-(lock/install, import check, and `tests/unit/backend` + `tests/contracts/backend`
-only, through the `pytest-compat` testsuite with the same first-flake
-`max-auto-rerun` containment as `pytest-unit`), and the `tui`
-job (pnpm format, lint, typecheck, and Vitest against the maintained client).
-Python 3.13 remains the full gate image; 3.11/3.12 certify declared support
-without duplicating Daytona coverage or E2E. Packaging/install certification
-runs in the release package gate rather than every unit shard.
+and `stream-check`), `lint-typecheck`, the four-way `test-unit` job (unit,
+contract, freeze, and E2E atoms through `pytest-unit`, with per-shard
+coverage), `coverage-gate`, lightweight `python-compat-311` /
+`python-compat-312` / `python-compat-313` jobs (lock/install, import check,
+and `tests/unit/backend` + `tests/contracts/backend` only, through the
+`pytest-compat` testsuite with the same first-flake `max-auto-rerun`
+containment as `pytest-unit`), and the `tui` job (pnpm format, lint,
+typecheck, and Vitest against the maintained client). Python 3.13 remains the
+full gate image; 3.11/3.12 certify declared support without duplicating
+Daytona coverage or the canonical E2E atoms. Packaging/install certification
+runs in the release package gate rather than every unit shard. The opt-in
+`deploy-pypi` bridge is attached to this workflow and runs only on `main`
+after every listed quality, test, compatibility, coverage, and TUI gate.
 
 `git diff --check` is required separately. The packaging lane is intentionally
 separate from the fast gate and runs serially to avoid build-metadata races:


### PR DESCRIPTION
## Summary

- Fix UV cache paths and rotate dependency cache keys so CircleCI restores the directory uv uses.
- Right-size the four-way unit-test shards while preserving coverage, compatibility, and TUI gates.
- Attach the opt-in PyPI bridge to the fully gated CI workflow and document the current coverage topology.

## Validation

- make check
- chunk validate on the Linux sidecar
- circleci config validate and process with deploy_pypi false and true
- git diff --check
- CircleCI pipeline #435 passed all eight CI jobs in 2m58s

The duplicate and accidental all-push CircleCI triggers were disabled separately in project settings; the canonical build trigger remains enabled.