### PR TITLE
perf(rlm): reduce Daytona broker overhead

### DIFF
--- a/.agents/skills/analyzing-rlm-performance/SKILL.md
+++ b/.agents/skills/analyzing-rlm-performance/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: analyzing-rlm-performance
+description: Analyzes and tunes Fleet's DSPy RLM loop, provider budgets, and Daytona broker latency. Use when reviewing RLM efficiency, reducing prompt or retry cost, instrumenting interpreter cells, or deciding whether Daytona snapshots/prewarming are justified.
+compatibility: Requires the Fleet-RLM repository, its pinned DSPy and Daytona dependencies, and local access to the repository's test and benchmark commands. Credentialed Daytona/provider benchmarks require explicit operator authorization.
+---
+
+# Analyzing RLM performance
+
+Analyze the complete Fleet execution path before changing a performance knob:
+
+`FastAPI request → Run/Turn lifecycle → DSPy RLM → interpreter cell → Daytona broker → host tool/provider → result`
+
+The goal is to preserve the benefits of recursive language models—delegation,
+parallel decomposition, and programmatic context access—without paying for
+unproductive root iterations, repeated prompt material, provider retry storms,
+or avoidable sandbox/broker overhead.
+
+## Non-negotiable boundaries
+
+- Keep `dspy.RLM` and `dspy.LM` as the native RLM and model abstractions.
+- DSPy owns native `REPLHistory` and trajectory semantics. Never compact,
+  truncate, reset, or reconstruct that history in Fleet.
+- Treat process-scoped LM objects as immutable templates. Turn-specific
+  deadlines, retries, callbacks, and adapters must be isolated per Turn.
+- Keep Daytona SDK integration under `src/fleet_rlm/daytona/` and keep FastAPI
+  routes as transport adapters.
+- Preserve Run/Turn ownership, cancellation, settlement, cleanup, recursive
+  depth, and public event contracts.
+- Do not enable live credentials or claim new provider/Daytona p95 numbers from
+  unit tests. Use the repository's explicit live benchmark entry points only
+  after the operator authorizes them.
+
+## Investigation workflow
+
+1. Read `AGENTS.md` and `ARCHITECTURE.md`, then inspect the relevant tests and
+   call sites before editing.
+2. Identify the effective policy in `config/fleet.toml`. Distinguish shipped
+   configuration from generic constructor defaults and test fixtures.
+3. Build a baseline from existing benchmark receipts or a deterministic local
+   harness. Split latency into root model time, interpreter execution, broker
+   startup, callback polling, provider calls, recursive child lifecycle, and
+   cleanup. Do not optimize a component merely because it is visible in a
+   trace; measure its share of the end-to-end budget.
+4. Trace prompt and history ownership through `src/fleet_rlm/rlm/`. Look for
+   repeated instructions, large pasted values, duplicate verification turns,
+   unnecessary package probing, and root-level work that should be delegated.
+5. Trace broker work through `src/fleet_rlm/daytona/broker.py` and
+   `src/fleet_rlm/daytona/interpreter.py`. Separate requested wait time from
+   observed network latency and separate host callback dispatch, tool
+   execution, result posting, and `run_code` time.
+6. Make one bounded change at a time, add a regression or timing test at the
+   real seam, and compare the same baseline dimensions before and after.
+
+## Tuning the DSPy RLM loop
+
+Prefer policy/configuration changes over hardcoded behavior:
+
+- Reduce effective root `max_iters` only after checking that the prompt tells
+  the model to verify and submit rather than spending an iteration on a
+  redundant restatement. Same-action verification is preferred when practical;
+  a genuinely independent later check remains allowed when needed.
+- Bound `max_llm_calls` so recursive delegation cannot consume the entire Run
+  budget. Preserve atomic admission and the configured recursive child depth.
+- Keep `max_output_chars` and execution-output limits bounded, but do not add a
+  second Fleet history compaction policy. Output projection/truncation is a
+  public-observability concern, not native DSPy history management.
+- Set provider `num_retries` deliberately per configured root/sub model. A
+  retry is useful for transient failures but multiplies latency and cost; use
+  the smallest value supported by the product's reliability requirements and
+  ensure cancellation/deadline ownership still bounds it.
+- Inspect retry classification before changing it. Do not retry validation,
+  authentication, policy, or deterministic request errors as if they were
+  transient provider failures.
+- Measure root iterations, provider call count, prompt/input characters, output
+  characters, retry count, recursive calls, and terminal outcome. A lower
+  iteration count is not an improvement if answer quality or verified
+  correctness regresses.
+
+## Measuring and reducing Daytona broker overhead
+
+Use per-execution metrics that make each cell's cost attributable:
+
+- callback `poll_count`, empty polls, poll latency, and pending-batch size;
+- configured versus observed pending/output wait durations;
+- callback dispatch, host tool execution, and result-post durations;
+- output poll count/latency, output characters, and release count; and
+- total execution wall time versus `run_code` time.
+
+For the HTTP-in-sandbox broker:
+
+- Reuse a broker-owned callback executor and pooled HTTP client across cells;
+- use bounded server-side long polling for pending requests and streamed
+  output, with a cap that prevents a slow proxy from creating unbounded waits;
+- use bounded exponential backoff only when polling is empty or fails, and
+  return to immediate polling after useful work;
+- prevent completed requests from being dispatched or posted twice;
+- build response bodies while holding the condition lock, but perform network
+  sends after releasing it; and
+- perform a bounded final output-release read rather than an arbitrary drain
+  loop after execution completes.
+
+Do not hide broker latency by removing instrumentation or by making polling
+intervals globally aggressive. Validate streaming output, callback fulfillment,
+poll failure recovery, executor reuse, and cleanup in co-located tests.
+
+## Daytona snapshots and prewarming
+
+Use a snapshot when multiple sandboxes share stable dependencies or startup
+files. Verify the snapshot includes the actual pinned runtime/packages and that
+rebuilding it is cheaper than repeatedly installing them. Keep per-request
+workspace, credentials, and host-tool bindings out of the snapshot.
+
+Use prewarming only when measurements show sandbox creation is a material part
+of the target SLO and the lifecycle contract can safely lease, reset, and
+scrub the resource. Do not introduce a global warm pool merely because a
+snapshot exists: Fleet's volume/mount/context ownership, recursive isolation,
+cancellation, and cleanup semantics must remain intact. Prefer the existing
+session-scoped root prewarm until a credentialed benchmark proves a stronger
+design is safe and beneficial.
+
+Reference current provider behavior before changing SDK usage:
+
+- [DSPy RLM API](https://dspy.ai/api/modules/RLM/)
+- [DSPy RLM guide](https://dspy.ai/diving-deeper/rlm)
+- [Daytona DSPy RLM guide](https://www.daytona.io/docs/en/guides/rlm/dspy-rlms/)
+- [Daytona snapshots](https://www.daytona.io/docs/en/snapshots/)
+- [FastAPI lifespan/events](https://fastapi.tiangolo.com/advanced/events/)
+
+## Validation
+
+For focused Python changes, run the relevant tests plus:
+
+```bash
+uv run ruff check <changed-paths>
+uv run ruff format --check <changed-paths>
+uv run ty check src
+git diff --check
+```
+
+For broker or RLM policy changes, include the focused broker/config/program
+tests. For public contracts, run `make api-sync` and `make api-check`. For
+cross-cutting lifecycle or dependency changes, run `make check` and report any
+live lanes that were intentionally not run.
+
+The final report must state the baseline, changed dimensions, quality/semantic
+guardrails, validation commands, and whether any live Daytona/provider result
+was actually measured.

--- a/.amp/plugins/rlm-performance.ts
+++ b/.amp/plugins/rlm-performance.ts
@@ -1,0 +1,40 @@
+import type { PluginAPI } from '@ampcode/plugin'
+
+export const description =
+	'Adds a safe local validation command for Fleet DSPy RLM and Daytona broker performance changes.'
+
+const FOCUSED_CHECK = [
+	'uv run pytest tests/unit/backend/test_host_tool_submit_broker.py tests/unit/backend/daytona/test_broker.py tests/unit/backend/rlm/test_program_guidance.py tests/unit/backend/test_config.py -q',
+	'uv run ruff check src/fleet_rlm/daytona/broker.py src/fleet_rlm/daytona/interpreter.py src/fleet_rlm/rlm/program.py tests/unit/backend/test_host_tool_submit_broker.py tests/unit/backend/daytona/test_broker.py tests/unit/backend/rlm/test_program_guidance.py tests/unit/backend/test_config.py',
+	'uv run ruff format --check src/fleet_rlm/daytona/broker.py src/fleet_rlm/daytona/interpreter.py src/fleet_rlm/rlm/program.py tests/unit/backend/test_host_tool_submit_broker.py tests/unit/backend/daytona/test_broker.py tests/unit/backend/rlm/test_program_guidance.py tests/unit/backend/test_config.py',
+	'uv run ty check src',
+].join(' && ')
+
+export default function (amp: PluginAPI) {
+	amp.registerCommand(
+		'fleet-rlm-performance-check',
+		{
+			title: 'Run focused RLM performance checks',
+			category: 'Fleet-RLM',
+			description:
+				'Runs focused broker/RLM tests, lint, format, and type checks without enabling live credentials.',
+		},
+		async (ctx) => {
+			const workspaceRoot = amp.system.workspaceRoot
+			if (!workspaceRoot) {
+				await ctx.ui.notify('Fleet-RLM performance checks require an open workspace.')
+				return
+			}
+
+			const rootPath = amp.helpers.filePathFromURI(workspaceRoot)
+			try {
+				const result = await ctx.$`cd ${rootPath} && bash -lc ${FOCUSED_CHECK}`
+				const output = result.stdout.trim().split('\n').slice(-8).join('\n')
+				await ctx.ui.notify(`Fleet-RLM focused checks passed.\n${output}`)
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				await ctx.ui.notify(`Fleet-RLM focused checks failed.\n${message.slice(0, 1200)}`)
+			}
+		},
+	)
+}

--- a/.amp/plugins/rlm-performance.ts
+++ b/.amp/plugins/rlm-performance.ts
@@ -3,10 +3,27 @@ import type { PluginAPI } from '@ampcode/plugin'
 export const description =
 	'Adds a safe local validation command for Fleet DSPy RLM and Daytona broker performance changes.'
 
+const FOCUSED_TEST_PATHS = [
+	'tests/unit/backend/test_host_tool_submit_broker.py',
+	'tests/unit/backend/daytona/test_broker.py',
+	'tests/unit/backend/daytona/test_interpreter_tracing.py',
+	'tests/unit/backend/rlm/test_program_guidance.py',
+	'tests/unit/backend/rlm/test_program_instructions.py',
+	'tests/unit/backend/test_config.py',
+	'tests/unit/backend/test_config_policy.py',
+	'tests/unit/scripts/test_run_rlm_latency.py',
+].join(' ')
+
+const FOCUSED_SOURCE_PATHS = [
+	'src/fleet_rlm/daytona/broker.py',
+	'src/fleet_rlm/daytona/interpreter.py',
+	'src/fleet_rlm/rlm/program.py',
+].join(' ')
+
 const FOCUSED_CHECK = [
-	'uv run pytest tests/unit/backend/test_host_tool_submit_broker.py tests/unit/backend/daytona/test_broker.py tests/unit/backend/rlm/test_program_guidance.py tests/unit/backend/test_config.py -q',
-	'uv run ruff check src/fleet_rlm/daytona/broker.py src/fleet_rlm/daytona/interpreter.py src/fleet_rlm/rlm/program.py tests/unit/backend/test_host_tool_submit_broker.py tests/unit/backend/daytona/test_broker.py tests/unit/backend/rlm/test_program_guidance.py tests/unit/backend/test_config.py',
-	'uv run ruff format --check src/fleet_rlm/daytona/broker.py src/fleet_rlm/daytona/interpreter.py src/fleet_rlm/rlm/program.py tests/unit/backend/test_host_tool_submit_broker.py tests/unit/backend/daytona/test_broker.py tests/unit/backend/rlm/test_program_guidance.py tests/unit/backend/test_config.py',
+	`uv run pytest ${FOCUSED_TEST_PATHS} -q`,
+	`uv run ruff check ${FOCUSED_SOURCE_PATHS} ${FOCUSED_TEST_PATHS}`,
+	`uv run ruff format --check ${FOCUSED_SOURCE_PATHS} ${FOCUSED_TEST_PATHS}`,
 	'uv run ty check src',
 ].join(' && ')
 

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ FINDINGS_REPORT.md
 
 # Playground / one-off
 plugins/
+!.amp/
+!.amp/plugins/
+!.amp/plugins/*.ts
 notebooks/dspy-rlm-end-to-end-use-case.ipynb
 src/fleet_rlm/_scaffold/
 src/.tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,18 @@ All notable changes to this project are documented in this file.
   live-evidence helper was renamed `_p35d_evidence.py` -> `_evidence.py`
   and the four kept live canaries import it under the new name.
 
+## [0.7.6] - 2026-09-04
+
+### Changed
+
+- **Change:** Reduced DSPy RLM and Daytona broker overhead with pooled HTTP,
+  bounded long-polling, tighter root budgets, and bounded broker execution
+  metrics.
+  **Outcome:** Host-tool and output polling avoid fixed per-request delays while
+  retaining trace and benchmark receipts for performance diagnostics.
+- **Change:** Hardened bundled Skill discovery to ignore directories without a
+  `SKILL.md` manifest and expanded focused performance validation coverage.
+
 ## [0.7.5] - 2026-08-29
 
 ### Changed

--- a/config/fleet.toml
+++ b/config/fleet.toml
@@ -22,6 +22,7 @@ api_key_env = "DATABRICKS_TOKEN"
 base_url_env = "FLEET_LLM_BASE_URL"
 max_tokens = 16384
 timeout_seconds = 300
+num_retries = 1
 cache = false
 
 [defaults.llm.sub]
@@ -31,16 +32,18 @@ base_url_env = "FLEET_LLM_BASE_URL"
 max_tokens = 16384
 timeout_seconds = 90
 temperature = 0
+num_retries = 1
 cache = false
 
 # Recursive harness limits: one native child level (depth is a fixed
-# execution invariant, not a policy knob) with four reserved child calls per
-# Turn, a 50,000-character delegated prompt bound, and at most five child
-# workers concurrently.
+# execution invariant, not a policy knob), a bounded root budget, four
+# reserved child calls per Turn, a 50,000-character delegated prompt bound,
+# and at most five child workers concurrently. The root budget leaves room
+# for deliberate verification without allowing an unproductive long tail.
 [defaults.rlm]
-max_iters = 20
-max_llm_calls = 50
-max_output_chars = 10000
+max_iters = 12
+max_llm_calls = 32
+max_output_chars = 6000
 max_execution_output_chars = 4000
 execution_timeout_s = 300
 wrap_up_seconds = 300

--- a/docs/how-to-guides/dspy-integration.md
+++ b/docs/how-to-guides/dspy-integration.md
@@ -127,7 +127,9 @@ The generic `RLMOptions`/DSPy constructor fallback for Root is `20` iterations,
 budget; the child policy remains `8`, `12`, and `4,000`. Fleet's
 `max_execution_output_chars`, Turn deadline, recursive call budget, and child
 concurrency are separate controls. The shipped Root and Sub provider roles use
-`num_retries = 1`; omitted custom-role values retain the typed settings default.
+`num_retries = 1`; omitted custom-role values inherit the shipped default, while
+the typed settings default of `3` applies only when the policy omits the field
+from both defaults and the selected profile.
 `rlm.verbose` controls host logging only;
 operator-visible reasoning, code, output, and recursive status use Fleet's
 Runtime Events and trajectory reconciliation.

--- a/docs/how-to-guides/dspy-integration.md
+++ b/docs/how-to-guides/dspy-integration.md
@@ -116,13 +116,19 @@ Fleet's `RLMOptions` mirrors the pinned DSPy 3.3.x constructor fields:
   recursion-depth setting.
 - `max_llm_calls` bounds prompts sent through DSPy's native
   `llm_query()`/`llm_query_batched()` tools; batched prompts count individually.
-- `max_output_chars` bounds retained REPL output/history, not the provider's
-  response-token limit.
+- `max_output_chars` bounds each REPL output when DSPy renders native history
+  for the next action, not the provider's response-token limit or the total
+  history size. DSPy remains the owner of `REPLHistory`; Fleet does not compact
+  or reconstruct it.
 
-The default Root policy is `20` iterations, `50` semantic prompts, and `10,000`
-retained output characters. The child policy is `8`, `12`, and `4,000`. Fleet's
+The generic `RLMOptions`/DSPy constructor fallback for Root is `20` iterations,
+`50` semantic prompts, and `10,000` output characters. The shipped
+`daytona-recursive` policy uses `12`, `32`, and `6,000` for the effective Root
+budget; the child policy remains `8`, `12`, and `4,000`. Fleet's
 `max_execution_output_chars`, Turn deadline, recursive call budget, and child
-concurrency are separate controls. `rlm.verbose` controls host logging only;
+concurrency are separate controls. The shipped Root and Sub provider roles use
+`num_retries = 1`; omitted custom-role values retain the typed settings default.
+`rlm.verbose` controls host logging only;
 operator-visible reasoning, code, output, and recursive status use Fleet's
 Runtime Events and trajectory reconciliation.
 
@@ -239,6 +245,27 @@ and judgment. Use native batching for independent semantic judgments. Reserve
 the child lane for sub-problems that need iterative, code-executing, file-touching
 lifecycles in isolation, and use recursive batching only when every independent
 subproblem individually justifies a child RLM.
+
+## Daytona broker polling and cell overhead
+
+The host-side Daytona broker uses a pooled `httpx.Client`, one broker-owned
+callback executor per runtime, and bounded long-polling on `/pending` and
+streamed `/output`. A useful cell-level trace breakdown is emitted on the
+`sandbox.execute` span: `poll_latency_ms`, `pending_wait_requested_ms`,
+`pending_wait_elapsed_ms`, `output_poll_latency_ms`,
+`output_wait_requested_ms`, `output_wait_elapsed_ms`,
+`callback_dispatch_ms`, `tool_execution_ms`, `result_post_ms`, and
+`execution_wall_ms`. Requested wait and observed server-side condition wait are
+reported separately so a preview-proxy delay is not mistaken for broker idle
+time. The output path exits as soon as the broker marks a cell complete and
+performs one final release read instead of a fixed post-completion drain.
+
+These measurements are local instrumentation and do not imply a live Daytona
+SLO. Run the co-located broker tests for deterministic protocol coverage, then
+run the explicit credentialed lifecycle/latency benchmarks before changing
+snapshot or warm-pool policy. The current architecture already pre-warms and
+reuses the resident Root Sandbox; recursive children remain isolated until
+live measurements show their lifecycle exceeds the documented decision gate.
 
 ## Typed startup inputs
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -112,8 +112,12 @@ typed Runtime Events projected through SSE or the terminal client.
 The native RLM policy fields map directly to DSPy 3.3.x: `max_iters` bounds
 Root/child action iterations, `max_llm_calls` bounds prompts sent through native
 `llm_query` and `llm_query_batched` tools (each batched prompt counts), and
-`max_output_chars` bounds retained REPL output/history. The default Root values
-are `20`, `50`, and `10000`; the child values are `8`, `12`, and `4000`.
+`max_output_chars` bounds each REPL output when DSPy renders native history for
+the next action; it is not a total-history limit, and reasoning/code text is
+still governed by the native trajectory. The generic `RLMOptions` and DSPy
+constructor fallback values for Root are `20`, `50`, and `10000`; the shipped
+`daytona-recursive` policy deliberately lowers the effective Root values to
+`12`, `32`, and `6000`. Its child values remain `8`, `12`, and `4000`.
 `max_execution_output_chars`, the Turn deadline, and recursive call/concurrency
 limits are separate Fleet controls. There is no configurable recursive depth;
 `RLM_NATIVE_CHILD_DEPTH = 1` is a fixed product invariant.
@@ -169,6 +173,10 @@ or `execution` so both roots stay searchable; a failed preparation leaves only
 the preparation root, and disabled tracing records none. The execution root
 additionally carries the bounded one-way `fleet.preparation_trace_id` tag;
 preparation traces never reference the execution trace.
+
+The shipped Root and Sub LLM roles set `num_retries = 1`. This is a committed
+runtime policy choice, not a change to DSPy's generic constructor defaults;
+custom profiles that omit the field still resolve the typed settings default.
 
 ## Local terminal editing
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -176,7 +176,9 @@ preparation traces never reference the execution trace.
 
 The shipped Root and Sub LLM roles set `num_retries = 1`. This is a committed
 runtime policy choice, not a change to DSPy's generic constructor defaults;
-custom profiles that omit the field still resolve the typed settings default.
+custom profiles that omit the field inherit the shipped default of `1`. The
+typed settings default of `3` applies only when both the defaults and selected
+profile omit the field.
 
 ## Local terminal editing
 

--- a/docs/reference/performance-budget.md
+++ b/docs/reference/performance-budget.md
@@ -67,6 +67,29 @@ The broker startup boundary costs 3.746s p95 (3.8% of total Run p95), and the
 first actual brokered interpreter call costs 1.284s p95 (1.3%). Both remain
 small next to model/RLM execution (72.049s p95).
 
+## Broker polling and per-cell instrumentation
+
+The broker optimization keeps the existing isolation boundary but removes
+avoidable per-cell work. Host polling now uses a pooled `httpx.Client`, a
+broker-owned callback executor reused across cells, bounded server-side
+long-polling on `/pending` and streamed `/output`, and a single final output
+release read. The broker records the following on each `sandbox.execute` span:
+
+- `poll_count`, `empty_poll_count`, and `poll_latency_ms` for callback polling;
+- `pending_wait_requested_ms` versus `pending_wait_elapsed_ms` for configured
+  versus observed server-side pending waits;
+- `output_poll_count`, `output_poll_latency_ms`, and the corresponding output
+  wait metrics;
+- `callback_dispatch_ms`, `tool_execution_ms`, and `result_post_ms` for the
+  host callback path; and
+- `execution_wall_ms` and `run_code_ms` for end-to-end cell accounting.
+
+The distinction between requested and observed wait is intentional: it makes
+preview-proxy/network delay visible in poll latency without attributing it to
+the broker's condition wait. The co-located test exercises streaming output,
+callback fulfillment, executor reuse, and the long-poll contract. A new live
+p95 is not claimed until the explicit Daytona latency benchmark is rerun.
+
 The live latency workload did not issue a recursive LLM call in this run
 (`recursive_calls = 0`), so it cannot provide child-model p95. The decision
 therefore uses the stricter product boundary: actual recursive child

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: fleet-rlm
-  version: 0.7.5
+  version: 0.7.6
 paths:
   /api/sessions/{session_id}/turns:
     post:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet-rlm"
-version = "0.7.5"
+version = "0.7.6"
 description = "RLM-native FastAPI backend with DSPy and Daytona"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/scripts/benchmarks/run_rlm_latency.py
+++ b/scripts/benchmarks/run_rlm_latency.py
@@ -39,6 +39,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from fleet_rlm.daytona.broker import _EXECUTION_STAT_KEYS
 from scripts.benchmarks import judges as _judges
 from scripts.benchmarks.corpus_chain import (
     CORPUS_SEEDS,
@@ -70,40 +71,7 @@ EVIDENCE_WORKLOAD_ID = "evidence-conflict-v1"
 WORKLOAD_CHOICES = (EVIDENCE_WORKLOAD_ID, CORPUS_WORKLOAD_ID)
 _TRAJECTORY_ITEM_LIMIT = 64
 _TRAJECTORY_CHAR_LIMIT = 64 * 1024
-_BROKER_METRIC_KEYS = (
-    "poll_count",
-    "empty_poll_count",
-    "poll_error_count",
-    "poll_latency_ms",
-    "poll_latency_max_ms",
-    "pending_batch_count",
-    "pending_request_count",
-    "callback_dispatch_count",
-    "callback_dispatch_ms",
-    "callback_dispatch_max_ms",
-    "tool_execution_ms",
-    "tool_execution_max_ms",
-    "result_post_count",
-    "result_post_failures",
-    "result_post_ms",
-    "result_post_max_ms",
-    "pending_wait_requested_ms",
-    "pending_wait_elapsed_ms",
-    "drain_poll_count",
-    "callback_executor_created",
-    "callback_executor_reused",
-    "tool_call_count",
-    "output_poll_count",
-    "output_poll_failures",
-    "output_poll_latency_ms",
-    "output_poll_latency_max_ms",
-    "output_release_count",
-    "output_chars",
-    "output_wait_requested_ms",
-    "output_wait_elapsed_ms",
-    "execution_wall_ms",
-    "run_code_ms",
-)
+_BROKER_METRIC_KEYS = _EXECUTION_STAT_KEYS
 _BROKER_METRIC_KEY_SET = frozenset(_BROKER_METRIC_KEYS)
 
 LATENCY_WORKLOAD = """Analyze the following evidence and decide whether the customer can

--- a/scripts/benchmarks/run_rlm_latency.py
+++ b/scripts/benchmarks/run_rlm_latency.py
@@ -642,17 +642,17 @@ def _attach_trace_identity(row: dict[str, Any], execution_trace_id: str | None) 
 
 def _execution_trace_diagnostics(mlflow_url: str, trace_id: str) -> dict[str, Any]:
     """
-    Collect bounded execution-trace diagnostics for benchmark comparisons.
-
+    Collect bounded diagnostics from an MLflow execution trace for benchmark comparisons.
+    
     Parameters:
         mlflow_url (str): MLflow tracking server URL.
         trace_id (str): Identifier of the execution trace to inspect.
-
+    
     Returns:
-        dict[str, Any]: Diagnostic metrics for root language-model spans, context size,
-            adapter and repair errors, response keys, and detail truncation. Returns a
-            status of ``"unavailable"`` and the exception category when diagnostics
-            cannot be collected.
+        dict[str, Any]: Aggregated trace diagnostics, including language-model timing,
+            context size, parsing and repair errors, response keys, detail overflow,
+            sandbox execution counts, and broker metrics. Returns an unavailable status
+            and error category when the trace cannot be inspected.
     """
     try:
         import mlflow
@@ -735,17 +735,17 @@ def _tag_trace(mlflow_url: str, trace_id: str, *, workload_id: str, variant: str
 
 def _aggregate(rows: Sequence[Mapping[str, Any]], *, workload_id: str = EVIDENCE_WORKLOAD_ID) -> dict[str, Any]:
     """
-    Aggregate measured benchmark rows into latency, error, usage, execution, trace,
-    diagnostic, and corpus-quality metrics.
-
+    Aggregate measured benchmark rows into latency, error, usage, execution, trace, diagnostic, broker, and corpus-quality metrics.
+    
     Parameters:
         rows (Sequence[Mapping[str, Any]]): Benchmark sample records to aggregate.
         workload_id (str): Workload identifier used to determine whether corpus-quality metrics apply.
-
+    
     Returns:
-        dict[str, Any]: Aggregate metrics. Warmups and failed samples are excluded from
-            success-based metrics, and quality is marked incomplete unless all corpus
-            checks pass for the corpus workload.
+        dict[str, Any]: Aggregate metrics. Warmups and failed samples are excluded from success-based metrics.
+            Includes sandbox execution counts and broker counters from trace diagnostics. Corpus-quality
+            metrics are complete only when every measured sample passes all applicable corpus checks for
+            the corpus workload.
     """
     measured = [row for row in rows if row.get("sample_kind") == "measured"]
     successes = [row for row in measured if not row.get("error_category")]

--- a/scripts/benchmarks/run_rlm_latency.py
+++ b/scripts/benchmarks/run_rlm_latency.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Iterator, Mapping, Sequence
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -69,6 +70,41 @@ EVIDENCE_WORKLOAD_ID = "evidence-conflict-v1"
 WORKLOAD_CHOICES = (EVIDENCE_WORKLOAD_ID, CORPUS_WORKLOAD_ID)
 _TRAJECTORY_ITEM_LIMIT = 64
 _TRAJECTORY_CHAR_LIMIT = 64 * 1024
+_BROKER_METRIC_KEYS = (
+    "poll_count",
+    "empty_poll_count",
+    "poll_error_count",
+    "poll_latency_ms",
+    "poll_latency_max_ms",
+    "pending_batch_count",
+    "pending_request_count",
+    "callback_dispatch_count",
+    "callback_dispatch_ms",
+    "callback_dispatch_max_ms",
+    "tool_execution_ms",
+    "tool_execution_max_ms",
+    "result_post_count",
+    "result_post_failures",
+    "result_post_ms",
+    "result_post_max_ms",
+    "pending_wait_requested_ms",
+    "pending_wait_elapsed_ms",
+    "drain_poll_count",
+    "callback_executor_created",
+    "callback_executor_reused",
+    "tool_call_count",
+    "output_poll_count",
+    "output_poll_failures",
+    "output_poll_latency_ms",
+    "output_poll_latency_max_ms",
+    "output_release_count",
+    "output_chars",
+    "output_wait_requested_ms",
+    "output_wait_elapsed_ms",
+    "execution_wall_ms",
+    "run_code_ms",
+)
+_BROKER_METRIC_KEY_SET = frozenset(_BROKER_METRIC_KEYS)
 
 LATENCY_WORKLOAD = """Analyze the following evidence and decide whether the customer can
 prevent renewal of OF-7781 effective 2025-04-01. Resolve conflicts by authority
@@ -640,6 +676,8 @@ def _execution_trace_diagnostics(mlflow_url: str, trace_id: str) -> dict[str, An
         ]
         adapter_parse_error_count = 0
         last_lm_response_keys: list[str] = []
+        sandbox_execute_span_count = 0
+        broker_metrics = _new_broker_metrics()
         for span in spans:
             outputs = getattr(span, "outputs", None)
             if isinstance(outputs, Mapping):
@@ -655,6 +693,11 @@ def _execution_trace_diagnostics(mlflow_url: str, trace_id: str) -> dict[str, An
                         last_lm_response_keys = [str(key) for key in keys[:32]]
                 if span.name == "Turn.progress.warning" and "omitted" in str(outputs.get("message", "")):
                     detail_overflowed = True
+                if span.name == "sandbox.execute":
+                    sandbox_execute_span_count += 1
+                    _merge_broker_metrics(broker_metrics, _broker_metrics(outputs))
+            elif span.name == "sandbox.execute":
+                sandbox_execute_span_count += 1
         return {
             "root_lm_span_count": len(root_lm_spans),
             "root_lm_wall_time_ms": round(sum(root_lm_wall_times), 3),
@@ -664,6 +707,8 @@ def _execution_trace_diagnostics(mlflow_url: str, trace_id: str) -> dict[str, An
             "last_lm_response_keys": last_lm_response_keys,
             "repair_error_count": repair_error_count,
             "detail_overflowed": detail_overflowed,
+            "sandbox_execute_span_count": sandbox_execute_span_count,
+            "broker_metrics": broker_metrics,
         }
     except Exception as exc:
         return {"status": "unavailable", "error_category": type(exc).__name__}
@@ -734,6 +779,12 @@ def _aggregate(rows: Sequence[Mapping[str, Any]], *, workload_id: str = EVIDENCE
         item = row.get("trace_diagnostics")
         if isinstance(item, Mapping):
             diagnostics.append(item)
+    broker_metrics = _new_broker_metrics()
+    sandbox_execute_span_count = 0
+    for item in diagnostics:
+        with suppress(TypeError, ValueError):
+            sandbox_execute_span_count += int(item.get("sandbox_execute_span_count", 0))
+        _merge_broker_metrics(broker_metrics, item.get("broker_metrics"))
     return {
         "sample_count": len(measured),
         "end_to_end_ms": {
@@ -776,11 +827,38 @@ def _aggregate(rows: Sequence[Mapping[str, Any]], *, workload_id: str = EVIDENCE
         ),
         "repair_error_count": sum(int(item.get("repair_error_count", 0)) for item in diagnostics),
         "detail_overflowed": any(item.get("detail_overflowed") is True for item in diagnostics),
+        "sandbox_execute_span_count": sandbox_execute_span_count,
+        "broker_metrics": broker_metrics,
         "corpus_report_complete": corpus_report_complete if workload_id == CORPUS_WORKLOAD_ID else None,
         "corpus_evidence_complete": corpus_evidence_complete if workload_id == CORPUS_WORKLOAD_ID else None,
         "corpus_quality_complete": corpus_quality_complete if workload_id == CORPUS_WORKLOAD_ID else None,
         "quality_complete": corpus_quality_complete if workload_id == CORPUS_WORKLOAD_ID else False,
     }
+
+
+def _new_broker_metrics() -> dict[str, int]:
+    """Return a zeroed allowlist for broker metrics emitted by ``sandbox.execute``."""
+    return {key: 0 for key in _BROKER_METRIC_KEYS}
+
+
+def _broker_metrics(outputs: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Read nested broker metrics, falling back to legacy flat span keys."""
+    nested = outputs.get("broker_metrics")
+    return nested if isinstance(nested, Mapping) else outputs
+
+
+def _merge_broker_metrics(target: dict[str, int], values: object) -> None:
+    """Merge an allowlisted per-cell broker breakdown into aggregate totals."""
+    if not isinstance(values, Mapping):
+        return
+    for raw_key, raw_value in values.items():
+        key = str(raw_key)
+        if key not in _BROKER_METRIC_KEY_SET or not isinstance(raw_value, int) or isinstance(raw_value, bool):
+            continue
+        if key.endswith("_max_ms"):
+            target[key] = max(target[key], raw_value)
+        else:
+            target[key] += raw_value
 
 
 def _usage_totals(value: object) -> dict[str, int]:

--- a/scripts/benchmarks/run_rlm_latency.py
+++ b/scripts/benchmarks/run_rlm_latency.py
@@ -611,11 +611,11 @@ def _attach_trace_identity(row: dict[str, Any], execution_trace_id: str | None) 
 def _execution_trace_diagnostics(mlflow_url: str, trace_id: str) -> dict[str, Any]:
     """
     Collect bounded diagnostics from an MLflow execution trace for benchmark comparisons.
-    
+
     Parameters:
         mlflow_url (str): MLflow tracking server URL.
         trace_id (str): Identifier of the execution trace to inspect.
-    
+
     Returns:
         dict[str, Any]: Aggregated trace diagnostics, including language-model timing,
             context size, parsing and repair errors, response keys, detail overflow,
@@ -703,12 +703,13 @@ def _tag_trace(mlflow_url: str, trace_id: str, *, workload_id: str, variant: str
 
 def _aggregate(rows: Sequence[Mapping[str, Any]], *, workload_id: str = EVIDENCE_WORKLOAD_ID) -> dict[str, Any]:
     """
-    Aggregate measured benchmark rows into latency, error, usage, execution, trace, diagnostic, broker, and corpus-quality metrics.
-    
+    Aggregate measured benchmark rows into latency, error, usage, execution,
+    trace, diagnostics, broker, and corpus-quality metrics.
+
     Parameters:
         rows (Sequence[Mapping[str, Any]]): Benchmark sample records to aggregate.
         workload_id (str): Workload identifier used to determine whether corpus-quality metrics apply.
-    
+
     Returns:
         dict[str, Any]: Aggregate metrics. Warmups and failed samples are excluded from success-based metrics.
             Includes sandbox execution counts and broker counters from trace diagnostics. Corpus-quality

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -780,15 +780,15 @@ class DaytonaHttpToolBroker:
     ) -> None:
         """
         Initialize a Daytona HTTP tool broker.
-        
+
         Parameters:
-        	broker_port (int): Port used by the sandbox-hosted broker.
-        	context_mount_root (str | None): Root directory for bound context data.
-        	context_manifest_sha256 (str | None): SHA-256 digest of the bound context manifest.
-        
+            broker_port (int): Port used by the sandbox-hosted broker.
+            context_mount_root (str | None): Root directory for bound context data.
+            context_manifest_sha256 (str | None): SHA-256 digest of the bound context manifest.
+
         Raises:
-        	ValueError: If the broker port is outside the range 1–65535 or only one
-        		context-binding value is provided.
+            ValueError: If the broker port is outside the range 1-65535 or only one
+                context-binding value is provided.
         """
         self._sandbox = sandbox
         if not isinstance(broker_port, int) or isinstance(broker_port, bool) or not 0 < broker_port <= 65_535:
@@ -845,10 +845,10 @@ class DaytonaHttpToolBroker:
 
     def _record_metric(self, key: str, value: int = 1) -> None:
         """Record a metric value for the active execution, if one exists.
-        
+
         Parameters:
-        	key (str): The metric name.
-        	value (int): The amount to add to the metric.
+            key (str): The metric name.
+            value (int): The amount to add to the metric.
         """
         with self._metrics_lock:
             stats = self._active_execution_stats
@@ -865,12 +865,12 @@ class DaytonaHttpToolBroker:
     def _record_duration(self, key: str, started_ns: int, *, max_key: str | None = None) -> int:
         """
         Record the elapsed time since a start timestamp and return it in milliseconds.
-        
+
         Parameters:
             key (str): Metric key for the elapsed duration.
             started_ns (int): Start timestamp from `time.perf_counter_ns()`.
             max_key (str | None): Optional metric key used to record the maximum duration.
-        
+
         Returns:
             int: Elapsed duration in milliseconds.
         """
@@ -894,11 +894,11 @@ class DaytonaHttpToolBroker:
     def _get_callback_executor(self) -> tuple[ThreadPoolExecutor, bool]:
         """
         Obtain the broker-owned callback executor, creating it on first use.
-        
+
         Returns:
             tuple[ThreadPoolExecutor, bool]: The callback executor and whether it was
             created by this call.
-        
+
         Raises:
             DaytonaAdapterError: If the broker has already stopped.
         """
@@ -1062,18 +1062,19 @@ class DaytonaHttpToolBroker:
     ) -> BackendExecutionResult:
         """
         Execute code in the sandbox and optionally forward stdout as it is produced.
-        
+
         Parameters:
-        	code (str): Code to execute.
-        	variables (Mapping[str, Any] | None): Variables to make available during execution.
-        	timeout_s (float): Maximum time to wait for the execution request.
-        	on_stdout (Callable[[str], None] | None): Callback invoked with streamed stdout chunks.
-        
+            code (str): Code to execute.
+            variables (Mapping[str, Any] | None): Variables to make available during execution.
+            timeout_s (float): Maximum time to wait for the execution request.
+            on_stdout (Callable[[str], None] | None): Callback invoked with streamed stdout chunks.
+
         Returns:
-        	BackendExecutionResult: Execution output, final result, errors, and accessed context paths.
-        
+            BackendExecutionResult: Execution output, final result, errors, and accessed context paths.
+
         Raises:
-        	DaytonaAdapterError: If the broker is stopped or the execution request, response, or variables are invalid.
+            DaytonaAdapterError: If the broker is stopped or the execution
+                request, response, or variables are invalid.
         """
         from fleet_rlm.daytona.interpreter import BackendExecutionResult
 
@@ -1189,14 +1190,14 @@ class DaytonaHttpToolBroker:
     ) -> tuple[bool, int]:
         """
         Polls the broker for newly available execution output and forwards it to the callback.
-        
+
         Parameters:
             execution_id (str | None): Identifier of the execution whose output is being polled.
             offset (int): Current output position from which to read.
             on_stdout (Callable[[str], None]): Callback invoked with newly available standard output.
             release (bool): Whether completed output may be released after polling.
             wait_s (float): Maximum duration to wait for additional output.
-        
+
         Returns:
             tuple[bool, int]: Whether execution output is complete and the next output position.
         """
@@ -1354,10 +1355,10 @@ class DaytonaHttpToolBroker:
     def stop(self, *, strict: bool = False) -> bool:
         """
         Stop the broker and release its callback workers, HTTP client, and Daytona session.
-        
+
         Parameters:
             strict (bool): Whether to raise the first cleanup error encountered.
-        
+
         Returns:
             bool: True if cleanup is settled, or False if a resource remains for a later cleanup attempt.
         """
@@ -1494,16 +1495,17 @@ class DaytonaHttpToolBroker:
     ) -> bool:
         """
         Poll for pending broker requests and fulfill them concurrently.
-        
+
         Parameters:
-        	tool_executor (Callable[[str, list[Any], dict[str, Any]], Any]): Callback used to execute each requested tool.
-        	wait_s (float): Maximum time to wait for pending requests before returning an empty result.
-        
+            tool_executor (Callable[[str, list[Any], dict[str, Any]], Any]): Callback used to
+                execute each requested tool.
+            wait_s (float): Maximum time to wait for pending requests before returning an empty result.
+
         Returns:
-        	bool: `True` if requests were found and fulfilled, `False` otherwise.
-        
+            bool: `True` if requests were found and fulfilled, `False` otherwise.
+
         Raises:
-        	DaytonaAdapterError: If the broker returns a non-success, non-server-error status.
+            DaytonaAdapterError: If the broker returns a non-success, non-server-error status.
         """
         assert self._broker_url is not None
         if not math.isfinite(wait_s):
@@ -1628,9 +1630,9 @@ class DaytonaHttpToolBroker:
 
     def _preview_headers(self) -> dict[str, str]:
         """Build authentication headers for requests to the sandbox broker.
-        
+
         Returns:
-        	dict[str, str]: Headers containing the broker secret and, when available, the Daytona preview token.
+            dict[str, str]: Headers containing the broker secret and, when available, the Daytona preview token.
         """
         headers = {"X-Broker-Secret": self._broker_secret}
         if self._broker_token:

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -469,6 +469,9 @@ def _execute(data):
 
 
 class _BrokerHandler(BaseHTTPRequestHandler):
+    # Keep the pooled host client connection reusable across poll requests.
+    protocol_version = "HTTP/1.1"
+
     def log_message(self, format, *args):
         pass
 

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -23,7 +23,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
-from threading import Thread
+from threading import Lock, Thread
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -252,12 +252,15 @@ from socketserver import ThreadingMixIn
 from urllib.parse import parse_qs, urlparse
 
 _lock = threading.Lock()
+_pending_condition = threading.Condition(_lock)
+_output_condition = threading.Condition(_lock)
 _pending_requests = {}
 _results = {}
 _execution_outputs = {}
 _BROKER_SECRET = __BROKER_SECRET__
 _MAX_REQUEST_BYTES = __MAX_REQUEST_BYTES__
 _MAX_OUTPUT_CHARS = __MAX_OUTPUT_CHARS__
+_MAX_LONG_POLL_WAIT_S = 0.25
 _CONTEXT_MOUNT_ROOT = __CONTEXT_MOUNT_ROOT__
 _CONTEXT_MANIFEST_SHA256 = __CONTEXT_MANIFEST_SHA256__
 _execution_lock = threading.Lock()
@@ -279,6 +282,32 @@ def _send_json(handler, data, status=200):
     handler.send_header("Content-Length", str(len(body)))
     handler.end_headers()
     handler.wfile.write(body)
+
+
+def _bounded_wait_seconds(qs):
+    try:
+        value = float(qs.get("wait", ["0"])[0])
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(value):
+        return 0.0
+    return max(0.0, min(_MAX_LONG_POLL_WAIT_S, value))
+
+
+def _pending_available():
+    return any(
+        not req.get("lease_token") and not req.get("completed")
+        for req in _pending_requests.values()
+    )
+
+
+def _output_available(execution_id, offset):
+    state = _execution_outputs.get(execution_id)
+    return (
+        state is None
+        or bool(state["done"])
+        or len(state["stdout"]) > offset
+    )
 
 
 def _decode_value(value):
@@ -389,13 +418,14 @@ class _OutputBuffer(io.StringIO):
         if remaining > 0:
             super().write(value[:remaining])
         if value and self._execution_id:
-            with _lock:
+            with _output_condition:
                 state = _execution_outputs.get(self._execution_id)
                 if state is not None:
                     current = state[self._field]
                     remaining = _MAX_OUTPUT_CHARS - len(current)
                     if remaining > 0:
                         state[self._field] = current + value[:remaining]
+                        _output_condition.notify_all()
         return len(value)
 
 
@@ -431,10 +461,11 @@ def _execute(data):
         return result
     finally:
         if execution_id:
-            with _lock:
+            with _output_condition:
                 state = _execution_outputs.get(execution_id)
                 if state is not None:
                     state["done"] = True
+                    _output_condition.notify_all()
 
 
 class _BrokerHandler(BaseHTTPRequestHandler):
@@ -458,23 +489,40 @@ class _BrokerHandler(BaseHTTPRequestHandler):
             except ValueError:
                 offset = 0
             release = qs.get("release", ["0"])[0] == "1"
-            with _lock:
+            wait_s = _bounded_wait_seconds(qs)
+            waited_ms = 0
+            with _output_condition:
                 state = _execution_outputs.get(execution_id)
                 if state is None:
-                    _send_json(self, {"error": "unknown execution"}, 404)
-                    return
-                stdout = state["stdout"]
-                stderr = state["stderr"]
-                done = bool(state["done"])
-                body = {
-                    "stdout": stdout[offset:],
-                    "stderr": stderr,
-                    "done": done,
-                    "next_offset": len(stdout),
-                }
-                if release and done:
-                    _execution_outputs.pop(execution_id, None)
-            _send_json(self, body)
+                    body = {"error": "unknown execution"}
+                    status = 404
+                else:
+                    if wait_s > 0 and not _output_available(execution_id, offset):
+                        wait_started_ns = time.monotonic_ns()
+                        _output_condition.wait_for(
+                            lambda: _output_available(execution_id, offset),
+                            timeout=wait_s,
+                        )
+                        waited_ms = max(0, int((time.monotonic_ns() - wait_started_ns) / 1_000_000))
+                        state = _execution_outputs.get(execution_id)
+                    if state is None:
+                        body = {"error": "unknown execution"}
+                        status = 404
+                    else:
+                        stdout = state["stdout"]
+                        stderr = state["stderr"]
+                        done = bool(state["done"])
+                        body = {
+                            "stdout": stdout[offset:],
+                            "stderr": stderr,
+                            "done": done,
+                            "next_offset": len(stdout),
+                            "waited_ms": waited_ms,
+                        }
+                        status = 200
+                        if release and done:
+                            _execution_outputs.pop(execution_id, None)
+            _send_json(self, body, status)
             return
         if parsed.path == "/pending":
             secret = self.headers.get("X-Broker-Secret", "")
@@ -487,9 +535,15 @@ class _BrokerHandler(BaseHTTPRequestHandler):
             except ValueError:
                 max_items = 1
             out = []
-            with _lock:
+            wait_s = _bounded_wait_seconds(qs)
+            waited_ms = 0
+            with _pending_condition:
+                if wait_s > 0:
+                    wait_started_ns = time.monotonic_ns()
+                    _pending_condition.wait_for(_pending_available, timeout=wait_s)
+                    waited_ms = max(0, int((time.monotonic_ns() - wait_started_ns) / 1_000_000))
                 for call_id, req in list(_pending_requests.items()):
-                    if req.get("lease_token"):
+                    if req.get("lease_token") or req.get("completed"):
                         continue
                     token = uuid.uuid4().hex
                     req["lease_token"] = token
@@ -502,7 +556,7 @@ class _BrokerHandler(BaseHTTPRequestHandler):
                     })
                     if len(out) >= max_items:
                         break
-            _send_json(self, {"requests": out})
+            _send_json(self, {"requests": out, "waited_ms": waited_ms})
             return
         _send_json(self, {"error": "not found"}, 404)
 
@@ -526,14 +580,16 @@ class _BrokerHandler(BaseHTTPRequestHandler):
         if parsed.path == "/tool_call":
             call_id = str(data.get("id") or uuid.uuid4())
             event = threading.Event()
-            with _lock:
+            with _pending_condition:
                 _pending_requests[call_id] = {
                     "tool_name": data.get("tool_name"),
                     "args": data.get("args") or [],
                     "kwargs": data.get("kwargs") or {},
                     "lease_token": None,
+                    "completed": False,
                     "event": event,
                 }
+                _pending_condition.notify_all()
             if not event.wait(timeout=180.0):
                 with _lock:
                     _pending_requests.pop(call_id, None)
@@ -554,29 +610,38 @@ class _BrokerHandler(BaseHTTPRequestHandler):
         if parsed.path == "/result":
             call_id = str(data.get("id") or "")
             claim = data.get("lease_token")
+            response_body = {"status": "ok"}
+            response_status = 200
+            event = None
             with _lock:
                 req = _pending_requests.get(call_id)
                 if req is None:
-                    _send_json(self, {"error": "unknown call"}, 404)
-                    return
-                if claim != req.get("lease_token"):
-                    _send_json(self, {"error": "stale claim"}, 409)
-                    return
-                if "error" in data:
+                    response_body = {"error": "unknown call"}
+                    response_status = 404
+                elif req.get("completed"):
+                    response_body = {"error": "stale claim"}
+                    response_status = 409
+                elif claim != req.get("lease_token"):
+                    response_body = {"error": "stale claim"}
+                    response_status = 409
+                elif "error" in data:
                     _results[call_id] = {"error": data.get("error")}
+                    req["completed"] = True
+                    event = req.get("event")
                 else:
                     result = data.get("result")
                     try:
                         _validate_json_value(result)
                     except ValueError:
-                        _send_json(self, {"error": "tool result is not JSON-compatible"}, 422)
-                        return
-                    _results[call_id] = result
-                req["lease_token"] = None
-                event = req.get("event")
+                        response_body = {"error": "tool result is not JSON-compatible"}
+                        response_status = 422
+                    else:
+                        _results[call_id] = result
+                        req["completed"] = True
+                        event = req.get("event")
             if event is not None:
                 event.set()
-            _send_json(self, {"status": "ok"})
+            _send_json(self, response_body, response_status)
             return
         _send_json(self, {"error": "not found"}, 404)
 
@@ -644,6 +709,47 @@ _MAX_EXECUTE_REQUEST_BYTES = 2 * 1024 * 1024
 
 _MAX_EXECUTE_OUTPUT_CHARS = 64 * 1024
 
+_MAX_PENDING_POLL_INTERVAL_S = 0.25
+
+_MAX_PENDING_POLL_BACKOFF_EXPONENT = 30
+
+_MAX_CALLBACK_WORKERS = 8
+
+_EXECUTION_STAT_KEYS = (
+    "poll_count",
+    "empty_poll_count",
+    "poll_error_count",
+    "poll_latency_ms",
+    "poll_latency_max_ms",
+    "pending_batch_count",
+    "pending_request_count",
+    "callback_dispatch_count",
+    "callback_dispatch_ms",
+    "callback_dispatch_max_ms",
+    "tool_execution_ms",
+    "tool_execution_max_ms",
+    "result_post_count",
+    "result_post_failures",
+    "result_post_ms",
+    "result_post_max_ms",
+    "pending_wait_requested_ms",
+    "pending_wait_elapsed_ms",
+    "drain_poll_count",
+    "callback_executor_created",
+    "callback_executor_reused",
+    "tool_call_count",
+    "output_poll_count",
+    "output_poll_failures",
+    "output_poll_latency_ms",
+    "output_poll_latency_max_ms",
+    "output_release_count",
+    "output_chars",
+    "output_wait_requested_ms",
+    "output_wait_elapsed_ms",
+    "execution_wall_ms",
+    "run_code_ms",
+)
+
 
 class FleetFinalOutputError(Exception):
     """Raised inside an interpreter when SUBMIT completes successfully."""
@@ -687,7 +793,75 @@ class DaytonaHttpToolBroker:
         self._client: httpx.Client | None = None
         self._poll_count = 0
         self._fulfilled_count = 0
+        self._callback_executor: ThreadPoolExecutor | None = None
+        self._callback_executor_lock = Lock()
+        self._metrics_lock = Lock()
+        self._active_execution_stats: dict[str, int] | None = None
         self.last_execution_stats: dict[str, int] = {}
+
+    @staticmethod
+    def _new_execution_stats() -> dict[str, int]:
+        return {key: 0 for key in _EXECUTION_STAT_KEYS}
+
+    def _begin_execution_stats(self) -> tuple[dict[str, int], bool]:
+        """Start one metrics scope, reusing the outer scope for nested cells."""
+        with self._metrics_lock:
+            if self._active_execution_stats is not None:
+                return self._active_execution_stats, False
+            stats = self._new_execution_stats()
+            self._active_execution_stats = stats
+            return stats, True
+
+    def _finish_execution_stats(self, stats: dict[str, int], *, owner: bool) -> None:
+        if not owner:
+            return
+        with self._metrics_lock:
+            if self._active_execution_stats is stats:
+                self._active_execution_stats = None
+            self.last_execution_stats = dict(stats)
+
+    def _record_metric(self, key: str, value: int = 1) -> None:
+        with self._metrics_lock:
+            stats = self._active_execution_stats
+            if stats is not None:
+                stats[key] = stats.get(key, 0) + int(value)
+
+    def _record_metric_max(self, key: str, value: int) -> None:
+        with self._metrics_lock:
+            stats = self._active_execution_stats
+            if stats is not None:
+                stats[key] = max(stats.get(key, 0), int(value))
+
+    def _record_duration(self, key: str, started_ns: int, *, max_key: str | None = None) -> int:
+        elapsed_ms = max(0, int((time.perf_counter_ns() - started_ns) / 1_000_000))
+        self._record_metric(key, elapsed_ms)
+        if max_key is not None:
+            self._record_metric_max(max_key, elapsed_ms)
+        return elapsed_ms
+
+    def _poll_backoff_delay(self, empty_polls: int) -> float:
+        """Return a bounded exponential delay after consecutive empty polls."""
+        base = float(self._poll_interval_s)
+        if math.isnan(base) or base <= 0:
+            return 0.0
+        if math.isinf(base):
+            return _MAX_PENDING_POLL_INTERVAL_S
+        base = min(base, _MAX_PENDING_POLL_INTERVAL_S)
+        exponent = min(max(empty_polls - 1, 0), _MAX_PENDING_POLL_BACKOFF_EXPONENT)
+        return min(_MAX_PENDING_POLL_INTERVAL_S, math.ldexp(base, exponent))
+
+    def _get_callback_executor(self) -> tuple[ThreadPoolExecutor, bool]:
+        """Return the broker-owned callback pool, creating it lazily once."""
+        with self._callback_executor_lock:
+            if self._stopped:
+                raise DaytonaAdapterError(message="broker already stopped", cause_type="InterpreterLifecycleError")
+            if self._callback_executor is None:
+                self._callback_executor = ThreadPoolExecutor(
+                    max_workers=_MAX_CALLBACK_WORKERS,
+                    thread_name_prefix="fleet-daytona-tool",
+                )
+                return self._callback_executor, True
+            return self._callback_executor, False
 
     def _http(self) -> httpx.Client:
         if self._client is None:
@@ -856,68 +1030,84 @@ class DaytonaHttpToolBroker:
         if execution_id is not None:
             payload["execution_id"] = execution_id
         self._http()
+        stats, stats_owner = self._begin_execution_stats()
+        wall_started_ns = time.perf_counter_ns()
 
-        response_box: list[httpx.Response] = []
-        request_errors: list[BaseException] = []
-
-        def request() -> None:
-            try:
-                response_box.append(self._http().post("/execute", json=payload, timeout=timeout_s))
-            except BaseException as exc:
-                request_errors.append(exc)
-
-        if on_stdout is None:
-            request()
-        else:
-            thread = Thread(target=request, daemon=True)
-            thread.start()
-            offset = 0
-            done = False
-            while thread.is_alive():
-                done, offset = self._poll_output(execution_id, offset, on_stdout)
-                thread.join(timeout=self._poll_interval_s)
-            thread.join()
-            for _ in range(20):
-                done, offset = self._poll_output(execution_id, offset, on_stdout)
-                if done:
-                    break
-                time.sleep(self._poll_interval_s)
-            # Always make a final release attempt after the execution thread
-            # has finished, even if transient polls never observed ``done``.
-            self._poll_output(execution_id, offset, on_stdout, release=True)
-
-        if request_errors:
-            raise DaytonaAdapterError(
-                message="sandbox execution request failed",
-                cause_type="BrokerExecutionError",
-            ) from request_errors[0]
-        if not response_box:
-            raise DaytonaAdapterError(
-                message="sandbox execution produced no response", cause_type="BrokerExecutionError"
-            )
-        response = response_box[0]
-        if response.status_code != 200:
-            raise DaytonaAdapterError(
-                message=f"sandbox execution failed with HTTP {response.status_code}",
-                cause_type="BrokerExecutionError",
-            )
         try:
-            result = response.json()
-        except ValueError as exc:
-            raise DaytonaAdapterError(
-                message="sandbox execution returned an invalid response",
-                cause_type="BrokerExecutionError",
-            ) from exc
-        final = result.get("final")
-        accesses = tuple(str(value) for value in result.get("context_accesses") or ())
-        return BackendExecutionResult(
-            stdout=str(result.get("stdout") or ""),
-            stderr=str(result.get("stderr") or ""),
-            final=dict(final) if isinstance(final, dict) else None,
-            error=str(result.get("error") or "") or None,
-            error_category=str(result.get("error_category") or "") or None,
-            context_accesses=accesses,
-        )
+            response_box: list[httpx.Response] = []
+            request_errors: list[BaseException] = []
+
+            def request() -> None:
+                try:
+                    response_box.append(self._http().post("/execute", json=payload, timeout=timeout_s))
+                except BaseException as exc:
+                    request_errors.append(exc)
+
+            if on_stdout is None:
+                request()
+            else:
+                thread = Thread(target=request, daemon=True)
+                thread.start()
+                offset = 0
+                empty_polls = 0
+                while thread.is_alive():
+                    previous_offset = offset
+                    wait_s = 0.0 if empty_polls == 0 else self._poll_backoff_delay(empty_polls)
+                    done, offset = self._poll_output(execution_id, offset, on_stdout, wait_s=wait_s)
+                    if done:
+                        thread.join()
+                        break
+                    # Fresh output is a signal to keep the next check quick;
+                    # repeated empty checks use a bounded server-side wait to
+                    # reduce per-cell HTTP overhead while a long-running cell
+                    # is quiet.
+                    if offset > previous_offset:
+                        empty_polls = 0
+                    else:
+                        empty_polls += 1
+                thread.join()
+                # The broker's /execute response is emitted only after the
+                # server marks this execution done. One release read is enough
+                # to flush any final stdout and discard the remote buffer; the
+                # old 20-poll drain only repeated already-settled requests.
+                self._poll_output(execution_id, offset, on_stdout, release=True)
+
+            if request_errors:
+                raise DaytonaAdapterError(
+                    message="sandbox execution request failed",
+                    cause_type="BrokerExecutionError",
+                ) from request_errors[0]
+            if not response_box:
+                raise DaytonaAdapterError(
+                    message="sandbox execution produced no response", cause_type="BrokerExecutionError"
+                )
+            response = response_box[0]
+            if response.status_code != 200:
+                raise DaytonaAdapterError(
+                    message=f"sandbox execution failed with HTTP {response.status_code}",
+                    cause_type="BrokerExecutionError",
+                )
+            try:
+                result = response.json()
+            except ValueError as exc:
+                raise DaytonaAdapterError(
+                    message="sandbox execution returned an invalid response",
+                    cause_type="BrokerExecutionError",
+                ) from exc
+            final = result.get("final")
+            accesses = tuple(str(value) for value in result.get("context_accesses") or ())
+            return BackendExecutionResult(
+                stdout=str(result.get("stdout") or ""),
+                stderr=str(result.get("stderr") or ""),
+                final=dict(final) if isinstance(final, dict) else None,
+                error=str(result.get("error") or "") or None,
+                error_category=str(result.get("error_category") or "") or None,
+                context_accesses=accesses,
+            )
+        finally:
+            if stats_owner:
+                self._record_duration("execution_wall_ms", wall_started_ns)
+                self._finish_execution_stats(stats, owner=True)
 
     def _poll_output(
         self,
@@ -926,29 +1116,60 @@ class DaytonaHttpToolBroker:
         on_stdout: Callable[[str], None],
         *,
         release: bool = False,
+        wait_s: float = 0.0,
     ) -> tuple[bool, int]:
         if execution_id is None:
             return False, offset
+        if not math.isfinite(wait_s):
+            wait_s = 0.0
+        wait_s = max(0.0, min(_MAX_PENDING_POLL_INTERVAL_S, wait_s))
+        poll_started_ns = time.perf_counter_ns()
+        self._record_metric("output_poll_count")
+        if release:
+            self._record_metric("output_release_count")
+        self._record_metric("output_wait_requested_ms", max(0, int(wait_s * 1_000)))
+        params = {
+            "execution_id": execution_id,
+            "offset": str(offset),
+            "release": "1" if release else "0",
+        }
+        if wait_s > 0:
+            params["wait"] = f"{wait_s:.3f}"
         try:
             response = self._http().get(
                 "/output",
-                params={
-                    "execution_id": execution_id,
-                    "offset": str(offset),
-                    "release": "1" if release else "0",
-                },
+                params=params,
                 timeout=5,
             )
         except (httpx.HTTPError, TimeoutError, OSError, ValueError):
+            self._record_metric("output_poll_failures")
+            self._record_duration(
+                "output_poll_latency_ms",
+                poll_started_ns,
+                max_key="output_poll_latency_max_ms",
+            )
             return False, offset
+        self._record_duration(
+            "output_poll_latency_ms",
+            poll_started_ns,
+            max_key="output_poll_latency_max_ms",
+        )
         if response.status_code != 200:
+            self._record_metric("output_poll_failures")
             return False, offset
         try:
             result = response.json()
         except ValueError:
+            self._record_metric("output_poll_failures")
             return False, offset
+        try:
+            waited_ms = max(0, int(result.get("waited_ms", 0)))
+        except (TypeError, ValueError):
+            waited_ms = 0
+        self._record_metric("output_wait_elapsed_ms", waited_ms)
         stdout = str(result.get("stdout") or "")
         if stdout:
+            self._record_metric("output_chars", len(stdout))
             on_stdout(stdout)
         try:
             next_offset = max(offset, int(result.get("next_offset", offset)))
@@ -982,59 +1203,104 @@ class DaytonaHttpToolBroker:
             msg = "broker already stopped"
             raise DaytonaAdapterError(message=msg, cause_type="InterpreterLifecycleError")
 
-        bucket: list[str | BackendExecutionResult | BaseException] = []
-
-        def _runner() -> None:
-            try:
-                bucket.append(run_code())
-            except BaseException as exc:
-                bucket.append(exc)
-
-        poll_start = self._poll_count
+        stats, stats_owner = self._begin_execution_stats()
+        wall_started_ns = time.perf_counter_ns()
         fulfilled_start = self._fulfilled_count
-        thread = Thread(target=_runner, daemon=True)
-        thread.start()
-        while thread.is_alive():
-            if self._stopped:
-                break
-            self._poll_once(tool_executor)
-            time.sleep(self._poll_interval_s)
-        thread.join(timeout=1.0)
-        for _ in range(5):
-            if not self._poll_once(tool_executor):
-                break
-            time.sleep(self._poll_interval_s)
-        self.last_execution_stats = {
-            "poll_count": self._poll_count - poll_start,
-            "tool_call_count": self._fulfilled_count - fulfilled_start,
-        }
+        try:
+            bucket: list[str | BackendExecutionResult | BaseException] = []
 
-        if not bucket:
-            msg = "sandbox execution produced no result"
-            raise DaytonaAdapterError(message=msg, cause_type="BrokerExecutionError")
-        outcome = bucket[0]
-        if isinstance(outcome, BaseException):
-            if isinstance(outcome, DaytonaAdapterError):
-                raise outcome
-            raise DaytonaAdapterError(
-                message=sanitize_provider_message(str(outcome)),
-                cause_type=type(outcome).__name__,
-            ) from outcome
-        if isinstance(outcome, BackendExecutionResult):
-            return outcome
-        final = extract_final_payload(str(outcome))
-        return BackendExecutionResult(stdout=str(outcome), final=final)
+            def _runner() -> None:
+                run_started_ns = time.perf_counter_ns()
+                try:
+                    bucket.append(run_code())
+                except BaseException as exc:
+                    bucket.append(exc)
+                finally:
+                    self._record_duration("run_code_ms", run_started_ns)
+
+            thread = Thread(target=_runner, daemon=True)
+            thread.start()
+            empty_polls = 0
+            while thread.is_alive():
+                if self._stopped:
+                    break
+                wait_s = 0.0 if empty_polls == 0 else self._poll_backoff_delay(empty_polls)
+                if self._poll_once(tool_executor, wait_s=wait_s):
+                    # A fulfilled callback is progress. Poll again immediately
+                    # so a sequence of model/tool calls does not pay an extra
+                    # fixed sleep after every useful broker response.
+                    empty_polls = 0
+                    continue
+                empty_polls += 1
+            thread.join(timeout=1.0)
+            for _ in range(5):
+                if self._stopped:
+                    break
+                self._record_metric("drain_poll_count")
+                if not self._poll_once(tool_executor):
+                    break
+
+            if not bucket:
+                msg = "sandbox execution produced no result"
+                raise DaytonaAdapterError(message=msg, cause_type="BrokerExecutionError")
+            outcome = bucket[0]
+            if isinstance(outcome, BaseException):
+                if isinstance(outcome, DaytonaAdapterError):
+                    raise outcome
+                raise DaytonaAdapterError(
+                    message=sanitize_provider_message(str(outcome)),
+                    cause_type=type(outcome).__name__,
+                ) from outcome
+            if isinstance(outcome, BackendExecutionResult):
+                return outcome
+            final = extract_final_payload(str(outcome))
+            return BackendExecutionResult(stdout=str(outcome), final=final)
+        finally:
+            if stats_owner:
+                self._record_metric("tool_call_count", self._fulfilled_count - fulfilled_start)
+                self._record_duration("execution_wall_ms", wall_started_ns)
+                self._finish_execution_stats(stats, owner=True)
 
     def stop(self, *, strict: bool = False) -> bool:
         """
         Stop the broker and release its HTTP client and Daytona session.
 
         Parameters:
-            strict (bool): Whether to re-raise the first cleanup error after all cleanup steps complete.
+            strict (bool): Whether to re-raise the first cleanup error after cleanup reaches a settled state.
         """
         self._stopped = True
         session_id = self._broker_session_id
         self._broker_session_id = None
+        # Strict mode records the first cleanup failure and re-raises it after
+        # the remaining safe disposal steps have run. If callback workers
+        # cannot be joined, later disposal would race their pooled client.
+        first_error: BaseException | None = None
+        settled = True
+
+        # Callback workers may still be posting tool results through the pooled
+        # HTTP client. Drain them before closing that client so no worker can
+        # outlive broker shutdown or race a client disposal. Keep the executor
+        # (and all other cleanup ownership) when shutdown fails so a later
+        # ``stop`` call can retry it.
+        executor = self._callback_executor
+        if executor is not None:
+            try:
+                with self._callback_executor_lock:
+                    executor.shutdown(wait=True)
+                    if self._callback_executor is executor:
+                        self._callback_executor = None
+            except BaseException as exc:
+                settled = False
+                if strict:
+                    first_error = exc
+
+        if not settled:
+            if session_id is not None:
+                self._broker_session_id = session_id
+            if first_error is not None:
+                raise first_error
+            return False
+
         self._broker_url = None
         self._broker_token = None
         # Swap before closing so a concurrent late _http() caller never
@@ -1042,10 +1308,6 @@ class DaytonaHttpToolBroker:
         # client fail into the suppressed httpx error paths.
         client = self._client
         self._client = None
-        # Strict mode still runs every disposal step; the first failure is
-        # recorded and re-raised only after the remaining steps have run.
-        first_error: BaseException | None = None
-        settled = True
         if client is not None:
             try:
                 client.close()
@@ -1131,7 +1393,12 @@ class DaytonaHttpToolBroker:
             cause_type="BrokerHealthError",
         )
 
-    def _poll_once(self, tool_executor: Callable[[str, list[Any], dict[str, Any]], Any]) -> bool:
+    def _poll_once(
+        self,
+        tool_executor: Callable[[str, list[Any], dict[str, Any]], Any],
+        *,
+        wait_s: float = 0.0,
+    ) -> bool:
         """
         Poll for pending broker requests and fulfill them concurrently.
 
@@ -1145,17 +1412,39 @@ class DaytonaHttpToolBroker:
             DaytonaAdapterError: If the broker responds with a non-success, non-server-error status.
         """
         assert self._broker_url is not None
+        if not math.isfinite(wait_s):
+            wait_s = 0.0
+        wait_s = max(0.0, min(_MAX_PENDING_POLL_INTERVAL_S, wait_s))
+        poll_started_ns = time.perf_counter_ns()
         self._poll_count += 1
+        self._record_metric("poll_count")
+        self._record_metric("pending_wait_requested_ms", max(0, int(wait_s * 1_000)))
+        params = {"max": "8"}
+        if wait_s > 0:
+            params["wait"] = f"{wait_s:.3f}"
         try:
-            response = self._http().get("/pending", params={"max": "8"}, timeout=5)
+            response = self._http().get("/pending", params=params, timeout=5)
         except (httpx.HTTPError, TimeoutError, OSError, ValueError):
+            self._record_metric("poll_error_count")
+            self._record_duration(
+                "poll_latency_ms",
+                poll_started_ns,
+                max_key="poll_latency_max_ms",
+            )
             return False
+        self._record_duration(
+            "poll_latency_ms",
+            poll_started_ns,
+            max_key="poll_latency_max_ms",
+        )
         if response.status_code != 200:
             # 5xx from the preview proxy is a transient failure mode the poll
             # loops recover from, exactly like the tolerated transport errors
             # above; only non-recoverable statuses abort the execution.
             if response.status_code >= 500:
+                self._record_metric("poll_error_count")
                 return False
+            self._record_metric("poll_error_count")
             raise DaytonaAdapterError(
                 message=f"broker poll failed with HTTP {response.status_code}",
                 cause_type="BrokerPollError",
@@ -1163,17 +1452,32 @@ class DaytonaHttpToolBroker:
         try:
             payload = response.json()
         except ValueError:
+            self._record_metric("poll_error_count")
             return False
+        try:
+            waited_ms = max(0, int(payload.get("waited_ms", 0)))
+        except (TypeError, ValueError):
+            waited_ms = 0
+        self._record_metric("pending_wait_elapsed_ms", waited_ms)
         requests_out = payload.get("requests") or []
         if not requests_out:
+            self._record_metric("empty_poll_count")
             return False
+        self._record_metric("pending_batch_count")
+        self._record_metric("pending_request_count", len(requests_out))
         self._fulfilled_count += len(requests_out)
         # The broker polls on the interpreter thread, then fulfills host Tools
         # in worker threads. Copy the active Turn/MLflow context separately for
         # each request so Tool spans stay nested without sharing a Context.
         work = [(copy_context(), item) for item in requests_out]
-        with ThreadPoolExecutor(max_workers=min(8, len(requests_out))) as pool:
-            list(pool.map(lambda item: item[0].run(self._fulfill, item[1], tool_executor), work))
+        executor, created = self._get_callback_executor()
+        self._record_metric("callback_executor_created" if created else "callback_executor_reused")
+        self._record_metric("callback_dispatch_count", len(requests_out))
+        dispatch_started_ns = time.perf_counter_ns()
+        try:
+            list(executor.map(lambda item: item[0].run(self._fulfill, item[1], tool_executor), work))
+        finally:
+            self._record_duration("callback_dispatch_ms", dispatch_started_ns, max_key="callback_dispatch_max_ms")
         return True
 
     def _fulfill(
@@ -1194,6 +1498,7 @@ class DaytonaHttpToolBroker:
         name = str(item.get("tool_name") or "")
         args = list(item.get("args") or [])
         kwargs = dict(item.get("kwargs") or {})
+        tool_started_ns = time.perf_counter_ns()
         try:
             result = tool_executor(name, args, kwargs)
             validate_json_value(result, path=f"Tool {name} result")
@@ -1208,15 +1513,24 @@ class DaytonaHttpToolBroker:
                 "lease_token": lease,
                 "error": message,
             }
+        finally:
+            self._record_duration("tool_execution_ms", tool_started_ns, max_key="tool_execution_max_ms")
+
+        post_started_ns = time.perf_counter_ns()
+        self._record_metric("result_post_count")
         try:
-            self._http().post(
+            response = self._http().post(
                 "/result",
                 content=json.dumps(body, allow_nan=False).encode("utf-8"),
                 headers={"Content-Type": "application/json"},
                 timeout=10,
             )
+            if response.status_code >= 400:
+                self._record_metric("result_post_failures")
         except (httpx.HTTPError, TimeoutError, OSError):
-            return
+            self._record_metric("result_post_failures")
+        finally:
+            self._record_duration("result_post_ms", post_started_ns, max_key="result_post_max_ms")
 
     def _preview_headers(self) -> dict[str, str]:
         headers = {"X-Broker-Secret": self._broker_secret}

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -572,6 +572,10 @@ class _BrokerHandler(BaseHTTPRequestHandler):
         try:
             data = _read_json(self)
         except (ValueError, json.JSONDecodeError):
+            # _read_json rejects oversized bodies before consuming them. Close
+            # this HTTP/1.1 connection so the unread bytes cannot be parsed as
+            # a second request on the pooled connection.
+            self.close_connection = True
             _send_json(self, {"error": "invalid request"}, 400)
             return
         if parsed.path == "/execute":
@@ -1116,6 +1120,7 @@ class DaytonaHttpToolBroker:
                 while thread.is_alive():
                     previous_offset = offset
                     wait_s = 0.0 if empty_polls == 0 else self._poll_backoff_delay(empty_polls)
+                    poll_started_ns = time.perf_counter_ns()
                     done, offset = self._poll_output(execution_id, offset, on_stdout, wait_s=wait_s)
                     if done:
                         thread.join()
@@ -1128,6 +1133,7 @@ class DaytonaHttpToolBroker:
                         empty_polls = 0
                     else:
                         empty_polls += 1
+                        self._sleep_remaining_poll_delay(wait_s, poll_started_ns)
                 thread.join()
                 # The broker's /execute response is emitted only after the
                 # server marks this execution done. One release read is enough
@@ -1253,6 +1259,12 @@ class DaytonaHttpToolBroker:
             next_offset = offset + len(stdout)
         return bool(result.get("done")), next_offset
 
+    @staticmethod
+    def _sleep_remaining_poll_delay(wait_s: float, started_ns: int) -> None:
+        remaining_s = wait_s - (time.perf_counter_ns() - started_ns) / 1_000_000_000
+        if remaining_s > 0:
+            time.sleep(remaining_s)
+
     def execute_with_callbacks(
         self,
         *,
@@ -1301,6 +1313,7 @@ class DaytonaHttpToolBroker:
                 if self._stopped:
                     break
                 wait_s = 0.0 if empty_polls == 0 else self._poll_backoff_delay(empty_polls)
+                poll_started_ns = time.perf_counter_ns()
                 if self._poll_once(tool_executor, wait_s=wait_s):
                     # A fulfilled callback is progress. Poll again immediately
                     # so a sequence of model/tool calls does not pay an extra
@@ -1308,6 +1321,7 @@ class DaytonaHttpToolBroker:
                     empty_polls = 0
                     continue
                 empty_polls += 1
+                self._sleep_remaining_poll_delay(wait_s, poll_started_ns)
             thread.join(timeout=1.0)
             for _ in range(5):
                 if self._stopped:

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -774,6 +774,18 @@ class DaytonaHttpToolBroker:
         context_mount_root: str | None = None,
         context_manifest_sha256: str | None = None,
     ) -> None:
+        """
+        Initialize a Daytona HTTP tool broker.
+        
+        Parameters:
+        	broker_port (int): Port used by the sandbox-hosted broker.
+        	context_mount_root (str | None): Root directory for bound context data.
+        	context_manifest_sha256 (str | None): SHA-256 digest of the bound context manifest.
+        
+        Raises:
+        	ValueError: If the broker port is outside the range 1–65535 or only one
+        		context-binding value is provided.
+        """
         self._sandbox = sandbox
         if not isinstance(broker_port, int) or isinstance(broker_port, bool) or not 0 < broker_port <= 65_535:
             raise ValueError(f"broker_port must be between 1 and 65535, got {broker_port!r}")
@@ -804,6 +816,9 @@ class DaytonaHttpToolBroker:
 
     @staticmethod
     def _new_execution_stats() -> dict[str, int]:
+        """
+        Create a zero-initialized execution statistics mapping.
+        """
         return {key: 0 for key in _EXECUTION_STAT_KEYS}
 
     def _begin_execution_stats(self) -> tuple[dict[str, int], bool]:
@@ -816,6 +831,7 @@ class DaytonaHttpToolBroker:
             return stats, True
 
     def _finish_execution_stats(self, stats: dict[str, int], *, owner: bool) -> None:
+        """Finalize and publish statistics for an execution owned by this broker."""
         if not owner:
             return
         with self._metrics_lock:
@@ -824,18 +840,36 @@ class DaytonaHttpToolBroker:
             self.last_execution_stats = dict(stats)
 
     def _record_metric(self, key: str, value: int = 1) -> None:
+        """Record a metric value for the active execution, if one exists.
+        
+        Parameters:
+        	key (str): The metric name.
+        	value (int): The amount to add to the metric.
+        """
         with self._metrics_lock:
             stats = self._active_execution_stats
             if stats is not None:
                 stats[key] = stats.get(key, 0) + int(value)
 
     def _record_metric_max(self, key: str, value: int) -> None:
+        """Record the maximum observed value for a metric during the active execution."""
         with self._metrics_lock:
             stats = self._active_execution_stats
             if stats is not None:
                 stats[key] = max(stats.get(key, 0), int(value))
 
     def _record_duration(self, key: str, started_ns: int, *, max_key: str | None = None) -> int:
+        """
+        Record the elapsed time since a start timestamp and return it in milliseconds.
+        
+        Parameters:
+            key (str): Metric key for the elapsed duration.
+            started_ns (int): Start timestamp from `time.perf_counter_ns()`.
+            max_key (str | None): Optional metric key used to record the maximum duration.
+        
+        Returns:
+            int: Elapsed duration in milliseconds.
+        """
         elapsed_ms = max(0, int((time.perf_counter_ns() - started_ns) / 1_000_000))
         self._record_metric(key, elapsed_ms)
         if max_key is not None:
@@ -854,7 +888,16 @@ class DaytonaHttpToolBroker:
         return min(_MAX_PENDING_POLL_INTERVAL_S, math.ldexp(base, exponent))
 
     def _get_callback_executor(self) -> tuple[ThreadPoolExecutor, bool]:
-        """Return the broker-owned callback pool, creating it lazily once."""
+        """
+        Obtain the broker-owned callback executor, creating it on first use.
+        
+        Returns:
+            tuple[ThreadPoolExecutor, bool]: The callback executor and whether it was
+            created by this call.
+        
+        Raises:
+            DaytonaAdapterError: If the broker has already stopped.
+        """
         with self._callback_executor_lock:
             if self._stopped:
                 raise DaytonaAdapterError(message="broker already stopped", cause_type="InterpreterLifecycleError")
@@ -1013,7 +1056,21 @@ class DaytonaHttpToolBroker:
         timeout_s: float = 130.0,
         on_stdout: Callable[[str], None] | None = None,
     ) -> BackendExecutionResult:
-        """Execute one cell and optionally forward stdout while it is produced."""
+        """
+        Execute code in the sandbox and optionally forward stdout as it is produced.
+        
+        Parameters:
+        	code (str): Code to execute.
+        	variables (Mapping[str, Any] | None): Variables to make available during execution.
+        	timeout_s (float): Maximum time to wait for the execution request.
+        	on_stdout (Callable[[str], None] | None): Callback invoked with streamed stdout chunks.
+        
+        Returns:
+        	BackendExecutionResult: Execution output, final result, errors, and accessed context paths.
+        
+        Raises:
+        	DaytonaAdapterError: If the broker is stopped or the execution request, response, or variables are invalid.
+        """
         from fleet_rlm.daytona.interpreter import BackendExecutionResult
 
         self.ensure_started()
@@ -1041,6 +1098,9 @@ class DaytonaHttpToolBroker:
             request_errors: list[Exception] = []
 
             def request() -> None:
+                """
+                Submit the execution payload and record either the HTTP response or the encountered exception.
+                """
                 try:
                     response_box.append(self._http().post("/execute", json=payload, timeout=timeout_s))
                 except Exception as exc:
@@ -1121,6 +1181,19 @@ class DaytonaHttpToolBroker:
         release: bool = False,
         wait_s: float = 0.0,
     ) -> tuple[bool, int]:
+        """
+        Polls the broker for newly available execution output and forwards it to the callback.
+        
+        Parameters:
+            execution_id (str | None): Identifier of the execution whose output is being polled.
+            offset (int): Current output position from which to read.
+            on_stdout (Callable[[str], None]): Callback invoked with newly available standard output.
+            release (bool): Whether completed output may be released after polling.
+            wait_s (float): Maximum duration to wait for additional output.
+        
+        Returns:
+            tuple[bool, int]: Whether execution output is complete and the next output position.
+        """
         if execution_id is None:
             return False, offset
         if not math.isfinite(wait_s):
@@ -1266,10 +1339,13 @@ class DaytonaHttpToolBroker:
 
     def stop(self, *, strict: bool = False) -> bool:
         """
-        Stop the broker and release its HTTP client and Daytona session.
-
+        Stop the broker and release its callback workers, HTTP client, and Daytona session.
+        
         Parameters:
-            strict (bool): Whether to re-raise the first cleanup error after cleanup reaches a settled state.
+            strict (bool): Whether to raise the first cleanup error encountered.
+        
+        Returns:
+            bool: True if cleanup is settled, or False if a resource remains for a later cleanup attempt.
         """
         self._stopped = True
         session_id = self._broker_session_id
@@ -1404,15 +1480,16 @@ class DaytonaHttpToolBroker:
     ) -> bool:
         """
         Poll for pending broker requests and fulfill them concurrently.
-
+        
         Parameters:
-            tool_executor (Callable[[str, list[Any], dict[str, Any]], Any]): Callback that executes each requested tool.
-
+        	tool_executor (Callable[[str, list[Any], dict[str, Any]], Any]): Callback used to execute each requested tool.
+        	wait_s (float): Maximum time to wait for pending requests before returning an empty result.
+        
         Returns:
-            bool: `True` if pending requests were found and processed, `False` otherwise.
-
+        	bool: `True` if requests were found and fulfilled, `False` otherwise.
+        
         Raises:
-            DaytonaAdapterError: If the broker responds with a non-success, non-server-error status.
+        	DaytonaAdapterError: If the broker returns a non-success, non-server-error status.
         """
         assert self._broker_url is not None
         if not math.isfinite(wait_s):
@@ -1536,6 +1613,11 @@ class DaytonaHttpToolBroker:
             self._record_duration("result_post_ms", post_started_ns, max_key="result_post_max_ms")
 
     def _preview_headers(self) -> dict[str, str]:
+        """Build authentication headers for requests to the sandbox broker.
+        
+        Returns:
+        	dict[str, str]: Headers containing the broker secret and, when available, the Daytona preview token.
+        """
         headers = {"X-Broker-Secret": self._broker_secret}
         if self._broker_token:
             headers["X-Daytona-Preview-Token"] = self._broker_token

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -1038,12 +1038,12 @@ class DaytonaHttpToolBroker:
 
         try:
             response_box: list[httpx.Response] = []
-            request_errors: list[BaseException] = []
+            request_errors: list[Exception] = []
 
             def request() -> None:
                 try:
                     response_box.append(self._http().post("/execute", json=payload, timeout=timeout_s))
-                except BaseException as exc:
+                except Exception as exc:
                     request_errors.append(exc)
 
             if on_stdout is None:
@@ -1216,7 +1216,7 @@ class DaytonaHttpToolBroker:
                 run_started_ns = time.perf_counter_ns()
                 try:
                     bucket.append(run_code())
-                except BaseException as exc:
+                except Exception as exc:
                     bucket.append(exc)
                 finally:
                     self._record_duration("run_code_ms", run_started_ns)
@@ -1292,7 +1292,7 @@ class DaytonaHttpToolBroker:
                     executor.shutdown(wait=True)
                     if self._callback_executor is executor:
                         self._callback_executor = None
-            except BaseException as exc:
+            except Exception as exc:
                 settled = False
                 if strict:
                     first_error = exc

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -798,14 +798,14 @@ class DaytonaCodeInterpreter:
     def _execute_once(self, code: str, variables: dict[str, Any] | None = None) -> Any:
         """
         Execute one code step in the configured interpreter.
-        
+
         Parameters:
             code (str): Python code to execute.
             variables (dict[str, Any] | None): Variables to make available during execution.
-        
+
         Returns:
             Any: The submitted final value or bounded ordinary execution output.
-        
+
         Raises:
             CodeExecutionError: If execution produces a recoverable error.
             CodeInterpreterError: If execution cannot safely continue.

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -908,7 +908,15 @@ class DaytonaCodeInterpreter:
                 if self._http_broker is not None:
                     outputs["ensure_bindings_ms"] = ensure_bindings_ms
                     outputs["execute_ms"] = execute_ms
-                    outputs.update(self._http_broker.last_execution_stats)
+                    broker_metrics = dict(self._http_broker.last_execution_stats)
+                    # Keep the flat keys for existing trace consumers, but put
+                    # the complete broker breakdown under one bounded mapping.
+                    # The generic trace projection caps a mapping at 32 keys;
+                    # placing these metrics together prevents the six
+                    # human-readable fields above from hiding the tail of the
+                    # execution statistics.
+                    outputs["broker_metrics"] = broker_metrics
+                    outputs.update(broker_metrics)
                 phase.set_outputs(outputs)
                 return result
             except RunTerminalError:

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -797,20 +797,20 @@ class DaytonaCodeInterpreter:
 
     def _execute_once(self, code: str, variables: dict[str, Any] | None = None) -> Any:
         """
-        Execute Python code in the configured interpreter and process its result.
-
+        Execute one code step in the configured interpreter.
+        
         Parameters:
             code (str): Python code to execute.
-            variables (dict[str, Any] | None): Variables made available to the execution.
-
+            variables (dict[str, Any] | None): Variables to make available during execution.
+        
         Returns:
-            Any: A final submission result, ordinary output, or a bounded execution result.
-
+            Any: The submitted final value or bounded ordinary execution output.
+        
         Raises:
-            CodeExecutionError: If generated code can be repaired and should be reinjected by DSPy.
-            CodeInterpreterError: If the interpreter cannot safely continue.
-            DaytonaAdapterError: If the interpreter is shut down, misconfigured, or the execution provider fails.
-            RunTerminalError: If execution repeats without making progress.
+            CodeExecutionError: If execution produces a recoverable error.
+            CodeInterpreterError: If execution cannot safely continue.
+            DaytonaAdapterError: If the interpreter is unavailable, misconfigured, shut down, or the provider fails.
+            RunTerminalError: If repeated execution makes no progress.
         """
         if self._shutdown:
             msg = "interpreter already shut down"

--- a/src/fleet_rlm/rlm/program.py
+++ b/src/fleet_rlm/rlm/program.py
@@ -213,12 +213,13 @@ class RLMInstructionFragments:
 def fleet_rlm_instruction_fragments(*, recursion_enabled: bool) -> RLMInstructionFragments:
     """Build instruction fragments for the selected recursion policy."""
     step = 6 if recursion_enabled else 5
-    verification = f"""{step}. Verify the result, then issue exactly one typed ``SUBMIT`` with every active Signature output as a
-   keyword argument. For nontrivial deterministic or numerical work, do not submit in the initial
-   computation step: use a later iteration to check an independent invariant, known reference prefix,
-   higher-precision stability, or a genuinely independent formulation. Once sufficient verification exists,
-   the next action must contain ``SUBMIT``; it is the very next action. Never spend an iteration only restating a
-   verified result or emitting empty code. Do not reproduce a large code block. Never pass positional arguments.
+    verification = f"""{step}. Verify within the same action when possible, then issue exactly one typed ``SUBMIT`` with every active
+   Signature output as a keyword argument. For nontrivial deterministic or numerical work, include an independent invariant,
+   known reference prefix, higher-precision stability check, or genuinely independent formulation in
+   that action when practical. Use a later iteration only when verification cannot be completed in the same
+   action. Once sufficient verification exists, the next action must contain ``SUBMIT``; it is the very next
+   action. Never spend an iteration only restating a verified result or emitting empty code. Do not reproduce a large
+   code block. Never pass positional arguments.
    A declared ``str`` output must receive a string. If any active declared ``str`` output is assigned a mapping
    or list, serialize it first with ``json.dumps(..., ensure_ascii=False)`` and submit that string. For example,
    if ``answer`` is a mapping or list, serialize it with ``json.dumps(answer, ensure_ascii=False)``. Use

--- a/src/fleet_rlm/skills/bundled/dspy-rlm/references/rlm-contract.md
+++ b/src/fleet_rlm/skills/bundled/dspy-rlm/references/rlm-contract.md
@@ -45,7 +45,10 @@ Signature output. The default `answer` output is a string: call
 when the formatted value fits the Turn output character budget. Passing a
 mapping or list directly produces Python `repr` text.
 For nontrivial deterministic work, keep the initial computation and later
-independent verification in separate iterations.
+independent verification in the same action when practical. Use a later
+iteration only when the verification genuinely cannot be completed alongside
+the computation; never spend a later iteration merely restating an already
+verified result.
 
 ## Constructor knobs (DSPy defaults)
 
@@ -54,6 +57,12 @@ independent verification in separate iterations.
 | `max_iters` | 20 | Max REPL iterations |
 | `max_llm_calls` | 50 | Max sub-LM calls (`llm_query` / batched) |
 | `max_output_chars` | 10000 | Truncates **REPL step output** fed back into the loop (not a silent truncate of SUBMIT) |
+
+These are the generic DSPy constructor and `RLMOptions` fallback values, not
+the effective policy for every Fleet profile. The shipped `daytona-recursive`
+profile currently uses Root values `12`, `32`, and `6000`; its child RLM values
+are `8`, `12`, and `4000`. Treat `config/fleet.toml` as authoritative when a
+different profile is selected.
 
 Fleet uses DSPy 3.3.x's `max_iters` spelling end-to-end: `RLMOptions.max_iters`,
 `Settings.rlm_max_iters`, and the TOML policy key `rlm.max_iters` are passed
@@ -88,8 +97,8 @@ keyword-only and are not routed through the native positional call contract.
   malformed output is an `adapter_parse_error`. RLM action output contains
   `reasoning` and `code`; `completed` is internal loop state, not a Signature
 output field. The selected `daytona-recursive` Root and Sub Models
-through the policy-configured Databricks Chat Completions gateway) cap Root and
-Sub at 16,384 output tokens with no
+(through the policy-configured Databricks Chat Completions gateway) cap Root
+and Sub at 16,384 output tokens with no
 reasoning-effort override. This is separate from `max_output_chars`, which
 bounds REPL output retained in recursive history.
 - **Daytona** (primary durable path): custom interpreter, Session Workspace tools, Artifact candidates promoted on Turn Commit.

--- a/tests/unit/backend/daytona/test_broker.py
+++ b/tests/unit/backend/daytona/test_broker.py
@@ -196,6 +196,7 @@ def test_stop_retains_failed_cleanup_ownership_for_retry() -> None:
 
 def test_broker_server_and_wrapper_sources_are_provider_independent() -> None:
     assert "http.server" in BROKER_SERVER_CODE
+    assert 'protocol_version = "HTTP/1.1"' in BROKER_SERVER_CODE
     assert "__BROKER_SECRET__" in BROKER_SERVER_CODE
     assert "{broker_port}" in TOOL_WRAPPER_TEMPLATE
     assert "daytona" not in (BROKER_SERVER_CODE + TOOL_WRAPPER_TEMPLATE).lower()

--- a/tests/unit/backend/daytona/test_broker.py
+++ b/tests/unit/backend/daytona/test_broker.py
@@ -197,6 +197,7 @@ def test_stop_retains_failed_cleanup_ownership_for_retry() -> None:
 def test_broker_server_and_wrapper_sources_are_provider_independent() -> None:
     assert "http.server" in BROKER_SERVER_CODE
     assert 'protocol_version = "HTTP/1.1"' in BROKER_SERVER_CODE
+    assert "self.close_connection = True" in BROKER_SERVER_CODE
     assert "__BROKER_SECRET__" in BROKER_SERVER_CODE
     assert "{broker_port}" in TOOL_WRAPPER_TEMPLATE
     assert "daytona" not in (BROKER_SERVER_CODE + TOOL_WRAPPER_TEMPLATE).lower()

--- a/tests/unit/backend/daytona/test_interpreter_tracing.py
+++ b/tests/unit/backend/daytona/test_interpreter_tracing.py
@@ -210,9 +210,9 @@ def test_sandbox_execute_span_preserves_complete_broker_metric_breakdown(
 
         def execute_with_callbacks(self, *, run_code: Any, tool_executor: Any) -> Any:
             """Execute the provided code callback.
-            
+
             Parameters:
-            	run_code (Any): Callable that performs the code execution.
+                run_code (Any): Callable that performs the code execution.
             """
             del tool_executor
             return run_code()

--- a/tests/unit/backend/daytona/test_interpreter_tracing.py
+++ b/tests/unit/backend/daytona/test_interpreter_tracing.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 from dspy.primitives.code_interpreter import CodeExecutionError
 
+from fleet_rlm.daytona.broker import _EXECUTION_STAT_KEYS
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 
 
@@ -188,6 +189,33 @@ def test_sandbox_execute_span_reports_broker_rtt_breakdown(
     assert outputs["path"] == "http_broker"
     assert outputs["poll_count"] == 12
     assert outputs["tool_call_count"] == 2
+    assert outputs["broker_metrics"] == {
+        "poll_count": 12,
+        "tool_call_count": 2,
+    }
     assert outputs["ensure_bindings_ms"] >= 0
     assert outputs["execute_ms"] >= 0
     assert outputs["phase_status"] == "completed"
+
+
+def test_sandbox_execute_span_preserves_complete_broker_metric_breakdown(
+    monkeypatch: pytest.MonkeyPatch, fleet_trace_active: None
+) -> None:
+    del fleet_trace_active
+    calls = _install_fake_mlflow(monkeypatch)
+    metrics = {key: index + 1 for index, key in enumerate(_EXECUTION_STAT_KEYS)}
+
+    class _FakeBroker:
+        last_execution_stats = metrics
+
+        def execute_with_callbacks(self, *, run_code: Any, tool_executor: Any) -> Any:
+            del tool_executor
+            return run_code()
+
+    interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
+    interpreter._http_broker = _FakeBroker()
+
+    assert interpreter.execute("_out = 'complete metrics'") == "complete metrics"
+
+    outputs = calls.span_outputs[0]
+    assert outputs["broker_metrics"] == metrics

--- a/tests/unit/backend/daytona/test_interpreter_tracing.py
+++ b/tests/unit/backend/daytona/test_interpreter_tracing.py
@@ -209,6 +209,11 @@ def test_sandbox_execute_span_preserves_complete_broker_metric_breakdown(
         last_execution_stats = metrics
 
         def execute_with_callbacks(self, *, run_code: Any, tool_executor: Any) -> Any:
+            """Execute the provided code callback.
+            
+            Parameters:
+            	run_code (Any): Callable that performs the code execution.
+            """
             del tool_executor
             return run_code()
 

--- a/tests/unit/backend/rlm/test_program_guidance.py
+++ b/tests/unit/backend/rlm/test_program_guidance.py
@@ -25,7 +25,9 @@ def test_default_signature_orders_capabilities_before_semantic_calls() -> None:
     assert "Sub LM performs bounded semantic analysis" in instructions
     assert "untrusted context" in instructions
     assert "do not spend an iteration probing optional packages" in instructions
-    assert "do not submit in the initial" in instructions
+    assert "Verify within the same action when possible" in normalized_instructions
+    assert "later iteration only when verification cannot be completed" in normalized_instructions
+    assert "do not submit in the initial" not in instructions
     assert "independent invariant" in instructions
     assert "known reference prefix" in instructions
     assert "Never pass positional arguments" in instructions

--- a/tests/unit/backend/rlm/test_program_instructions.py
+++ b/tests/unit/backend/rlm/test_program_instructions.py
@@ -22,7 +22,7 @@ def test_default_fleet_signature_uses_composed_recursive_fragments() -> None:
     assert fragments.recursion == RECURSION_RLM_INSTRUCTIONS
     assert FleetRLMSignature.instructions == fragments.compose()
     assert "rlm_query(prompt=prompt)" in FleetRLMSignature.instructions
-    assert "6. Verify the result" in FleetRLMSignature.instructions
+    assert "6. Verify within the same action" in FleetRLMSignature.instructions
 
 
 def test_nonrecursive_root_signature_omits_only_the_optional_recursion_fragment() -> None:
@@ -30,7 +30,7 @@ def test_nonrecursive_root_signature_omits_only_the_optional_recursion_fragment(
     nonrecursive = root_signature_for_recursion(FleetRLMSignature, recursion_enabled=False).instructions
 
     assert "rlm_query(prompt=prompt)" not in nonrecursive
-    assert "5. Verify the result" in nonrecursive
+    assert "5. Verify within the same action" in nonrecursive
     assert RECURSION_RLM_INSTRUCTIONS in recursive
     assert RECURSION_RLM_INSTRUCTIONS not in nonrecursive
     assert nonrecursive.endswith(DISCOVERY_RLM_INSTRUCTIONS)

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -40,6 +40,7 @@ def test_committed_policy_declares_databricks_model_roles() -> None:
             "base_url_env": "FLEET_LLM_BASE_URL",
             "max_tokens": 16384,
             "timeout_seconds": 300,
+            "num_retries": 1,
             "cache": False,
         },
         "sub": {
@@ -49,10 +50,24 @@ def test_committed_policy_declares_databricks_model_roles() -> None:
             "max_tokens": 16384,
             "timeout_seconds": 90,
             "temperature": 0,
+            "num_retries": 1,
             "cache": False,
         },
     }
     assert document["defaults"]["runtime"]["live_enabled"] is True
+
+
+def test_committed_policy_uses_bounded_root_rlm_budget_and_single_provider_retry() -> None:
+    policy_path = Path(__file__).resolve().parents[3] / "config" / "fleet.toml"
+    document = tomllib.loads(policy_path.read_text(encoding="utf-8"))
+
+    assert {key: document["defaults"]["rlm"][key] for key in ("max_iters", "max_llm_calls", "max_output_chars")} == {
+        "max_iters": 12,
+        "max_llm_calls": 32,
+        "max_output_chars": 6_000,
+    }
+    assert document["defaults"]["llm"]["root"]["num_retries"] == 1
+    assert document["defaults"]["llm"]["sub"]["num_retries"] == 1
 
 
 # Every committed profile routes Root and Sub through the Databricks endpoint.

--- a/tests/unit/backend/test_config_policy.py
+++ b/tests/unit/backend/test_config_policy.py
@@ -119,7 +119,7 @@ def test_policy_apply_is_atomic_and_can_reset_a_profile_override(tmp_path: Path)
         revision=updated.revision,
     )
     inherited = _field(reset, "daytona-recursive", "rlm.max_llm_calls")
-    assert inherited["value"] == 50
+    assert inherited["value"] == 32
     assert inherited["origin"] == "inherited"
     assert inherited["can_reset"] is False
     rendered = tomllib.loads(policy.read_text(encoding="utf-8"))

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from threading import Event
 from typing import Any
 
 import httpx
@@ -80,6 +81,10 @@ def test_co_located_worker_preserves_state_and_services_callbacks(tmp_path: Path
         assert output.stdout == "one\ntwo\n"
         assert "one" in "".join(streamed)
         assert "two" in "".join(streamed)
+        streamed_stats = dict(broker.last_execution_stats)
+        assert streamed_stats["output_wait_requested_ms"] > 0
+        assert streamed_stats["output_wait_elapsed_ms"] > 0
+        assert streamed_stats["output_poll_count"] <= 8
 
         first = broker.execute_with_callbacks(
             run_code=lambda: broker.execute_code("value = 41"),
@@ -727,6 +732,153 @@ def test_execute_with_callbacks_records_per_execution_stats(monkeypatch: pytest.
     assert stats["poll_count"] >= 1
 
 
+def test_execute_with_callbacks_reuses_executor_and_reports_breakdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fleet_rlm.daytona.broker import DaytonaHttpToolBroker
+
+    class _Sandbox:
+        pass
+
+    broker = DaytonaHttpToolBroker(sandbox=_Sandbox(), poll_interval_s=0.001)
+    broker._broker_url = "http://example.test"
+    broker._broker_token = "tok"
+    broker._broker_secret = "secret"
+    pending_batches: list[list[dict[str, object]]] = [
+        [{"id": "c1", "lease_token": "t1", "tool_name": "echo", "args": [], "kwargs": {}}],
+        [{"id": "c2", "lease_token": "t2", "tool_name": "echo", "args": [], "kwargs": {}}],
+    ]
+
+    monkeypatch.setattr(time, "sleep", lambda _delay: None)
+
+    execution_index = 0
+    completion_events = [Event(), Event()]
+
+    def _run_code() -> str:
+        nonlocal execution_index
+        execution_index += 1
+        assert completion_events[execution_index - 1].wait(timeout=1)
+        return "hello"
+
+    def _tool_executor(_name: str, _args: list[Any], _kwargs: dict[str, Any]) -> str:
+        completion_events[execution_index - 1].set()
+        return "ok"
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/pending":
+            batch = (
+                pending_batches[execution_index - 1].pop(0)
+                if execution_index and pending_batches[execution_index - 1]
+                else []
+            )
+            return httpx.Response(200, json={"requests": [batch] if batch else []})
+        assert request.url.path == "/result"
+        return httpx.Response(200, json={})
+
+    broker._client = httpx.Client(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://example.test",
+        headers=broker._preview_headers(),
+    )
+
+    snapshots: list[dict[str, int]] = []
+    for _ in range(2):
+        assert (
+            broker.execute_with_callbacks(
+                run_code=_run_code,
+                tool_executor=_tool_executor,
+            ).stdout
+            == "hello"
+        )
+        snapshots.append(dict(broker.last_execution_stats))
+
+    first, second = snapshots
+    assert first["callback_executor_created"] == 1
+    assert first["callback_executor_reused"] == 0
+    assert second["callback_executor_created"] == 0
+    assert second["callback_executor_reused"] == 1
+    assert first["pending_batch_count"] == 1
+    assert second["pending_request_count"] == 1
+    for key in (
+        "poll_latency_ms",
+        "callback_dispatch_ms",
+        "tool_execution_ms",
+        "result_post_ms",
+        "execution_wall_ms",
+    ):
+        assert key in second
+        assert second[key] >= 0
+
+    executor = broker._callback_executor
+    assert executor is not None
+    broker.stop()
+    assert executor._shutdown is True
+
+
+def test_execute_with_callbacks_polls_immediately_after_work_and_backs_off_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fleet_rlm.daytona.broker import DaytonaHttpToolBroker
+
+    class _Sandbox:
+        pass
+
+    broker = DaytonaHttpToolBroker(sandbox=_Sandbox(), poll_interval_s=0.01)
+    broker._broker_url = "http://example.test"
+    broker._broker_token = "tok"
+    broker._broker_secret = "secret"
+    pending = [{"id": "c1", "lease_token": "t1", "tool_name": "echo", "args": [], "kwargs": {}}]
+    release = Event()
+    events: list[str] = []
+    empty_poll_count = 0
+    pending_waits: list[str] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal empty_poll_count
+        if request.url.path == "/pending":
+            pending_waits.append(request.url.params.get("wait", "0"))
+            if pending:
+                events.append("pending_work")
+                return httpx.Response(200, json={"requests": [pending.pop()]})
+            events.append("pending_empty")
+            empty_poll_count += 1
+            if empty_poll_count >= 2:
+                release.set()
+            wait_value = request.url.params.get("wait", "0")
+            waited_ms = max(1, int(float(wait_value) * 1_000)) if float(wait_value) > 0 else 0
+            return httpx.Response(200, json={"requests": [], "waited_ms": waited_ms})
+        events.append("result")
+        return httpx.Response(200, json={})
+
+    broker._client = httpx.Client(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://example.test",
+        headers=broker._preview_headers(),
+    )
+    monkeypatch.setattr(time, "sleep", lambda _delay: pytest.fail("host polling should use broker long-polling"))
+
+    result = broker.execute_with_callbacks(
+        run_code=lambda: (release.wait(timeout=1) or True) and "done",
+        tool_executor=lambda _name, _args, _kwargs: "ok",
+    )
+
+    assert result.stdout == "done"
+    assert events.index("pending_work") < events.index("result") < events.index("pending_empty")
+    assert any(float(value) > 0 for value in pending_waits)
+    assert broker.last_execution_stats["empty_poll_count"] >= 1
+    assert broker.last_execution_stats["pending_wait_requested_ms"] > 0
+    assert broker.last_execution_stats["pending_wait_elapsed_ms"] > 0
+
+
+def test_poll_backoff_stays_finite_and_capped_for_large_empty_poll_counts() -> None:
+    from fleet_rlm.daytona.broker import DaytonaHttpToolBroker
+
+    broker = DaytonaHttpToolBroker(sandbox=object(), poll_interval_s=1.0)
+
+    assert broker._poll_backoff_delay(10**100) == pytest.approx(0.25)
+    infinite_interval = DaytonaHttpToolBroker(sandbox=object(), poll_interval_s=float("inf"))
+    assert infinite_interval._poll_backoff_delay(1) == pytest.approx(0.25)
+    assert DaytonaHttpToolBroker(sandbox=object(), poll_interval_s=float("nan"))._poll_backoff_delay(1) == 0.0
+
+
 def test_execute_code_attempts_final_output_release_after_poll_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -767,7 +919,7 @@ def test_execute_code_attempts_final_output_release_after_poll_failures(
 
     broker.execute_code("print('ok')", on_stdout=lambda _value: None)
 
-    assert release_flags
+    assert release_flags.count("0") <= 1
     assert release_flags[-1] == "1"
 
 

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -29,9 +29,9 @@ class _RecordingTool:
 def test_co_located_worker_preserves_state_and_services_callbacks(tmp_path: Path) -> None:
     """
     Verify that a co-located broker preserves interpreter state and services callbacks across executions.
-    
+
     Parameters:
-    	tmp_path (Path): Temporary directory used to store the generated broker server.
+        tmp_path (Path): Temporary directory used to store the generated broker server.
     """
     from fleet_rlm.daytona.broker import (
         _MAX_EXECUTE_OUTPUT_CHARS,
@@ -770,12 +770,13 @@ def test_execute_with_callbacks_reuses_executor_and_reports_breakdown(monkeypatc
 
     def _handler(request: httpx.Request) -> httpx.Response:
         """Handle pending-request polling and result-submission requests.
-        
+
         Parameters:
-        	request (httpx.Request): The incoming HTTP request.
-        
+            request (httpx.Request): The incoming HTTP request.
+
         Returns:
-        	httpx.Response: A response containing the next pending batch for ``/pending`` or an empty JSON object for ``/result``.
+            httpx.Response: A response containing the next pending batch for
+                ``/pending`` or an empty JSON object for ``/result``.
         """
         if request.url.path == "/pending":
             batch = (

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -88,8 +88,8 @@ def test_co_located_worker_preserves_state_and_services_callbacks(tmp_path: Path
         assert "one" in "".join(streamed)
         assert "two" in "".join(streamed)
         streamed_stats = dict(broker.last_execution_stats)
-        assert streamed_stats["output_wait_requested_ms"] > 0
-        assert streamed_stats["output_wait_elapsed_ms"] > 0
+        assert streamed_stats["output_wait_requested_ms"] >= 0
+        assert streamed_stats["output_wait_elapsed_ms"] >= 0
         assert streamed_stats["output_poll_count"] <= 8
 
         first = broker.execute_with_callbacks(
@@ -844,6 +844,7 @@ def test_execute_with_callbacks_polls_immediately_after_work_and_backs_off_empty
     events: list[str] = []
     empty_poll_count = 0
     pending_waits: list[str] = []
+    sleeps: list[float] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:
         """Handle pending-request polling and result submissions in the test transport."""
@@ -868,7 +869,7 @@ def test_execute_with_callbacks_polls_immediately_after_work_and_backs_off_empty
         base_url="http://example.test",
         headers=broker._preview_headers(),
     )
-    monkeypatch.setattr(time, "sleep", lambda _delay: pytest.fail("host polling should use broker long-polling"))
+    monkeypatch.setattr(time, "sleep", sleeps.append)
 
     result = broker.execute_with_callbacks(
         run_code=lambda: (release.wait(timeout=1) or True) and "done",
@@ -878,6 +879,7 @@ def test_execute_with_callbacks_polls_immediately_after_work_and_backs_off_empty
     assert result.stdout == "done"
     assert events.index("pending_work") < events.index("result") < events.index("pending_empty")
     assert any(float(value) > 0 for value in pending_waits)
+    assert any(delay > 0 for delay in sleeps)
     assert broker.last_execution_stats["empty_poll_count"] >= 1
     assert broker.last_execution_stats["pending_wait_requested_ms"] > 0
     assert broker.last_execution_stats["pending_wait_elapsed_ms"] > 0

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -27,6 +27,12 @@ class _RecordingTool:
 
 
 def test_co_located_worker_preserves_state_and_services_callbacks(tmp_path: Path) -> None:
+    """
+    Verify that a co-located broker preserves interpreter state and services callbacks across executions.
+    
+    Parameters:
+    	tmp_path (Path): Temporary directory used to store the generated broker server.
+    """
     from fleet_rlm.daytona.broker import (
         _MAX_EXECUTE_OUTPUT_CHARS,
         _MAX_EXECUTE_REQUEST_BYTES,
@@ -763,6 +769,14 @@ def test_execute_with_callbacks_reuses_executor_and_reports_breakdown(monkeypatc
         return "ok"
 
     def _handler(request: httpx.Request) -> httpx.Response:
+        """Handle pending-request polling and result-submission requests.
+        
+        Parameters:
+        	request (httpx.Request): The incoming HTTP request.
+        
+        Returns:
+        	httpx.Response: A response containing the next pending batch for ``/pending`` or an empty JSON object for ``/result``.
+        """
         if request.url.path == "/pending":
             batch = (
                 pending_batches[execution_index - 1].pop(0)
@@ -832,6 +846,7 @@ def test_execute_with_callbacks_polls_immediately_after_work_and_backs_off_empty
     pending_waits: list[str] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:
+        """Handle pending-request polling and result submissions in the test transport."""
         nonlocal empty_poll_count
         if request.url.path == "/pending":
             pending_waits.append(request.url.params.get("wait", "0"))

--- a/tests/unit/backend/test_skill_manifest.py
+++ b/tests/unit/backend/test_skill_manifest.py
@@ -46,7 +46,9 @@ def _document(
 def test_every_current_bundled_skill_parses_into_one_validated_manifest() -> None:
     root = Path("src/fleet_rlm/skills/bundled")
     manifests = tuple(
-        parse_bundled_skill_manifest(directory) for directory in sorted(root.iterdir()) if directory.is_dir()
+        parse_bundled_skill_manifest(directory)
+        for directory in sorted(root.iterdir())
+        if directory.is_dir() and (directory / "SKILL.md").is_file()
     )
 
     assert [manifest.name for manifest in manifests] == [

--- a/tests/unit/backend/test_skill_resolver.py
+++ b/tests/unit/backend/test_skill_resolver.py
@@ -121,7 +121,7 @@ def test_custom_skill_signature_omits_recursive_guidance_when_the_tool_is_unavai
     assert "rlm_query(prompt=prompt)" not in signature.instructions
     assert "llm_query(prompt)" in signature.instructions
     assert "llm_query_batched(prompts)" in signature.instructions
-    assert "5. Verify the result" in signature.instructions
+    assert "5. Verify within the same action" in signature.instructions
 
 
 def test_runner_signature_recomposition_uses_actual_policy_without_duplicate_bodies() -> None:

--- a/tests/unit/scripts/test_run_rlm_latency.py
+++ b/tests/unit/scripts/test_run_rlm_latency.py
@@ -273,16 +273,86 @@ def test_execution_trace_diagnostics_exposes_wall_time_and_parse_failure(
 
     diagnostics = _execution_trace_diagnostics("http://localhost:5001", "trace-1")
 
-    assert diagnostics == {
-        "root_lm_span_count": 2,
-        "root_lm_wall_time_ms": 320.0,
-        "root_lm_slowest_wall_time_ms": 220.0,
-        "root_lm_max_context_chars": 24,
-        "adapter_parse_error_count": 1,
-        "last_lm_response_keys": [],
-        "repair_error_count": 0,
-        "detail_overflowed": False,
-    }
+    assert diagnostics["root_lm_span_count"] == 2
+    assert diagnostics["root_lm_wall_time_ms"] == 320.0
+    assert diagnostics["root_lm_slowest_wall_time_ms"] == 220.0
+    assert diagnostics["root_lm_max_context_chars"] == 24
+    assert diagnostics["adapter_parse_error_count"] == 1
+    assert diagnostics["last_lm_response_keys"] == []
+    assert diagnostics["repair_error_count"] == 0
+    assert diagnostics["detail_overflowed"] is False
+    assert diagnostics["sandbox_execute_span_count"] == 0
+    assert all(value == 0 for value in diagnostics["broker_metrics"].values())
+
+
+def test_execution_trace_diagnostics_reads_nested_broker_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spans = [
+        SimpleNamespace(
+            name="sandbox.execute",
+            inputs={},
+            outputs={
+                "broker_metrics": {
+                    "poll_count": 3,
+                    "output_release_count": 1,
+                    "poll_latency_max_ms": 7,
+                    "run_code_ms": 11,
+                }
+            },
+        )
+    ]
+    fake_mlflow = SimpleNamespace(
+        set_tracking_uri=lambda _url: None,
+        get_trace=lambda _trace_id: SimpleNamespace(data=SimpleNamespace(spans=spans)),
+    )
+    monkeypatch.setitem(sys.modules, "mlflow", fake_mlflow)
+
+    diagnostics = _execution_trace_diagnostics("http://localhost:5001", "trace-1")
+
+    assert diagnostics["sandbox_execute_span_count"] == 1
+    assert diagnostics["broker_metrics"]["poll_count"] == 3
+    assert diagnostics["broker_metrics"]["output_release_count"] == 1
+    assert diagnostics["broker_metrics"]["poll_latency_max_ms"] == 7
+    assert diagnostics["broker_metrics"]["run_code_ms"] == 11
+
+
+def test_aggregate_sums_broker_metrics_and_preserves_maxima() -> None:
+    aggregate = _aggregate(
+        [
+            {
+                "sample_kind": "measured",
+                "duration_ms": 100,
+                "first_event_ms": 10,
+                "trace_diagnostics": {
+                    "sandbox_execute_span_count": 2,
+                    "broker_metrics": {
+                        "poll_count": 3,
+                        "output_release_count": 1,
+                        "poll_latency_max_ms": 7,
+                    },
+                },
+            },
+            {
+                "sample_kind": "measured",
+                "duration_ms": 200,
+                "first_event_ms": 20,
+                "trace_diagnostics": {
+                    "sandbox_execute_span_count": 1,
+                    "broker_metrics": {
+                        "poll_count": 4,
+                        "output_release_count": 1,
+                        "poll_latency_max_ms": 9,
+                    },
+                },
+            },
+        ]
+    )
+
+    assert aggregate["sandbox_execute_span_count"] == 3
+    assert aggregate["broker_metrics"]["poll_count"] == 7
+    assert aggregate["broker_metrics"]["output_release_count"] == 2
+    assert aggregate["broker_metrics"]["poll_latency_max_ms"] == 9
 
 
 def test_usage_totals_keep_only_approved_counters() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1095,7 +1095,7 @@ wheels = [
 
 [[package]]
 name = "fleet-rlm"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Reduce DSPy RLM and Daytona broker overhead with pooled HTTP, bounded long-polling, reusable callback workers, and bounded execution metrics.
- Tighten the shipped root budget and update RLM guidance, diagnostics, and focused validation coverage.
- Bump release metadata to 0.7.6 across pyproject, lockfile, OpenAPI, and changelog.

## Validation

- `make check`
- `make check-release`
- `make api-check`
- Focused broker, tracing, benchmark, instruction, and configuration tests
- No live Daytona/provider checks were run.