### PR TITLE
feat(runtime): Establish governed RLM runtime foundation

### DIFF
--- a/.circleci/deploy.yml
+++ b/.circleci/deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - run:
           name: Plan release
           command: |
-            circleci run release plan \
+            circleci run release plan deploy-pypi \
               --environment-name=${ENVIRONMENT_NAME} \
               --component-name=${COMPONENT_NAME} \
               --target-version=${TARGET_VERSION}
@@ -79,7 +79,7 @@ jobs:
           no_output_timeout: 45m
       - run:
           name: Update deployment status to failed
-          command: circleci run release update --status=FAILED
+          command: circleci run release update deploy-pypi --status=FAILED
           when: on_fail
   cancel-deploy-pypi:
     docker:

--- a/.circleci/rollback.yml
+++ b/.circleci/rollback.yml
@@ -51,8 +51,8 @@ jobs:
       - run:
           name: Perform rollback
           command: |
-            # TODO: add rollback logic using ${TARGET_VERSION}
-            echo "Rolling back fleet-rlm to ${TARGET_VERSION}"
+            echo "Automatic PyPI rollback is not supported for fleet-rlm; target version ${TARGET_VERSION} requires an explicit operator procedure." >&2
+            exit 1
       - run:
           name: Update deployment status to failed
           command: circleci run release update deploy-pypi-rollback --status=FAILED

--- a/.scratch/refined-runtime-roadmap.md
+++ b/.scratch/refined-runtime-roadmap.md
@@ -1,10 +1,10 @@
 # Refined runtime roadmap
 
 Status: implementation in progress on branch `feat/runtime-roadmap` (0.7.6).
-Implementation commits are recorded below. Pre-existing agent-instruction edits
-remain uncommitted and outside these implementation commits. ADR 004/005 were
-created here because this checkout lacked them.
-No phase is closed. Phase 2 budget integration and adapter contraction remain open;
+Implementation commits are recorded below, including the existing agent-instruction
+changes requested by the operator. ADR 004/005 were created here because this
+checkout lacked them. PR 2E is complete in the deterministic protocol lane.
+No phase is closed. Phase 2 global budget integration remains open;
 live semantic baseline and Postgres evidence remain pending operator authorization.
 
 Implemented so far: explicit legacy selector and rejection tests; architecture
@@ -12,20 +12,19 @@ target ADRs; composite database lineage with preflight and reversible migration;
 immediate SQLite FK enforcement and corrected fixtures; narrowly allowlisted claim
 race reconciliation; scripted benchmark execution, digests and comparison; native
 FleetProgramSpec/tool catalog; deadline LM proxy replacing instance method assignment;
-TurnBudget atomic reservation primitive and provider-proxy accounting;
+TurnBudget atomic reservations and provider-proxy accounting, including adapter
+corrections, DSPy schema fallback, and provider retries;
 FleetOutputContract replacing private `_inject_execution_context` monkey-patching;
 DSPy compatibility implementation and consumers migrated to `compat_3_3_1.py`;
 and comprehensive tests for caller-owned interpreter, tool injection, output metadata,
 SandboxSerializable, async invocation, and trajectory shape.
-Latest implementation validation: `make check` passed (78.45% backend coverage;
-538 TUI tests), with output in `.scratch/roadmap-compat-check.log`.
-The earlier factory/native-contract/SUBMIT suite passed all 85 tests.
-The adapter suite now passes 29 tests, including five sync/async parity cases
-and cancellation cleanup. The RLM/tracer/version-guard suite passed 546 tests
-before the final single-home guard was added and covered by `make check`.
-Follow-up: corrected three vacuous source-root guards, added source-file existence
-assertions, and extracted SUBMIT syntax validation into `rlm/submit_validation.py`
-with 14 direct test cases. This validator is not a runtime safety sandbox.
+Latest implementation validation: `make check` passed (78.58% backend coverage;
+538 TUI tests), with output in `.scratch/contract-adapter-final-check.log`.
+The adapter-budget integration suite has 29 cases; the adapter behavior suite has
+29 cases. Runtime-v2 comparison tests cover receipt integrity, both invocation
+modes, attempt accounting, and repair-policy ablations. Source-root guards inspect
+the actual backend tree. SUBMIT syntax validation is separately tested and is not
+a runtime safety sandbox.
 The 15-Turn receipt is `.scratch/runtime-v2-scripted-baseline.json`; it is explicitly
 scripted lifecycle evidence, not a sealed live legacy semantic baseline.
 
@@ -133,7 +132,8 @@ accounting until usage is reliably available before further calls for hard admis
 - [ ] Add concurrency-safe child reservations and complete budget-path tests.
 
 Integration evidence: production reservations currently cover provider attempts only.
-Tool/child/output-byte admission, configured limits, finalization capability, and
+PR 2E now supplies call-local finalization capability and tests root-only reserved
+provider attempts. Tool/child/output-byte admission, configured global limits, and
 settlement wiring still need implementation and end-to-end budget-path tests.
 
 ### PR 2C — Replace LM monkey-patching
@@ -159,14 +159,53 @@ and a regression test verifies that the implementation has one home.
 
 ### PR 2E — Contract FleetJSONAdapter
 
-- [ ] Compare stock JSONAdapter against Fleet's adapter using benchmark v2.
-- [ ] Keep only measured repair behavior.
-- [ ] Move deadlines and attempt limits to TurnBudget/LM proxy.
+Complete for deterministic protocol behavior; not a live semantic or provider-cost
+claim. Implementation: `8752eb2a`.
+
+- [x] Compare stock JSONAdapter against Fleet's adapter using benchmark v2.
+- [x] Keep only measured repair behavior: retain two bounded parse corrections,
+  reserve-boundary transition, and SUBMIT-only finalization correction. Removing
+  or reducing parse repairs loses expected outcomes in the replay fixtures.
+- [x] Move deadlines and attempt limits to the budget layer/LM proxy. AdapterBudget
+  uses the shared TurnBudget; DeadlineLMProxy enforces each provider admission.
 - [x] Extract SUBMIT validation into a small validator.
 - [x] Use one state machine for sync and async. Requests, error transitions,
   wrap-up metadata, and cancellation cleanup are regression-tested.
-- [ ] Debit all corrective calls from the global budget.
-- [ ] Keep finalization reserve independently testable.
+- [x] Debit all corrective calls from the global provider ledger, including native
+  schema fallback and transport retries; reject mismatched Turn budgets.
+- [x] Keep finalization reserve independently testable. Finalization slots count
+  physical admissions, not just adapter requests; children cannot spend Root's
+  reserved attempts. Late responses are reclassified without double debit.
+
+#### Comparison evidence
+
+```bash
+uv run python -m scripts.benchmarks.runtime_v2 compare-adapters \
+  --repetitions 5 --output .scratch/runtime-v2-adapter-comparison-sealed.json
+```
+
+The local receipt was generated from clean commit `8752eb2a`: 14 fixtures ×
+4 adapter settings × 2 invocation modes × 5 repetitions = 560 replays.
+Use a new output filename when rerunning; sealed files are never overwritten.
+
+| Adapter setting | Expected outcomes | Provider admissions | Local p50 / p95 |
+| --- | --- | --- | --- |
+| Stock JSONAdapter | 40/140 | 160 | 0.292 / 0.724 ms |
+| Fleet, no parse repairs | 100/140 | 220 | 0.539 / 1.360 ms |
+| Fleet, one parse repair | 130/140 | 270 | 0.757 / 1.373 ms |
+| Fleet, two parse repairs | 140/140 | 290 | 0.920 / 1.516 ms |
+
+All gates pass: Fleet expected outcomes/attempt ceilings, provider accounting,
+sync/async parity, and no extra calls for valid output. Fixtures cover empty,
+invalid, and missing-field responses; exhausted repair; non-SUBMIT finalization;
+late responses and provider timeout; transport retry; and DSPy schema fallback.
+These are scripted protocol outcomes, not answer-quality scores. Recorded latency
+is local replay overhead, not production inference latency. No provider, Daytona,
+Postgres, or MLflow server was contacted.
+
+Receipt digest: `0a13fe7e6dde8bc1ad89304b3d39bde0908fc7b1b24dfc3647f71203480229cf`.
+The receipt includes dataset, scorer, and implementation digests. Raw local
+receipts/logs stay ignored; fixtures, replay code, tests, and this summary are tracked.
 
 ### Exit criteria
 
@@ -182,13 +221,14 @@ and a regression test verifies that the implementation has one home.
    finalization reserve and tests exercising root, child, and corrective calls.
 2. Close PR 2C retry accounting with end-to-end admission evidence; do not treat
    primitive-only tests as completion evidence.
-3. Complete PR 2E adapter comparison and budget integration, preserving existing
-   repair behavior until measurements justify policy changes.
-4. Define Phase 3 feasibility experiments and exit gates before snapshot work.
-5. When explicitly authorized, capture the live legacy baseline and Postgres
+3. Define Phase 3 feasibility experiments and exit gates before snapshot work.
+4. When explicitly authorized, capture the live legacy baseline and Postgres
    contention evidence. Scripted receipts do not satisfy either live gate.
 
 ## Implementation commits
+
+- `35067612` — Commit the existing repository/TUI agent-instruction changes.
+- `8752eb2a` — Complete PR 2E budget/proxy contraction and adapter comparison.
 
 - `9c2526dc` — Extract finalization syntax validation.
 - `577f0c84` — Share sync/async repair policy and test parity/cancellation.

--- a/.scratch/refined-runtime-roadmap.md
+++ b/.scratch/refined-runtime-roadmap.md
@@ -1,0 +1,209 @@
+# Refined runtime roadmap
+
+Status: implementation in progress on branch `feat/runtime-roadmap` (0.7.6).
+Implementation commits are recorded below. Pre-existing agent-instruction edits
+remain uncommitted and outside these implementation commits. ADR 004/005 were
+created here because this checkout lacked them.
+No phase is closed. Phase 2 budget integration and adapter contraction remain open;
+live semantic baseline and Postgres evidence remain pending operator authorization.
+
+Implemented so far: explicit legacy selector and rejection tests; architecture
+target ADRs; composite database lineage with preflight and reversible migration;
+immediate SQLite FK enforcement and corrected fixtures; narrowly allowlisted claim
+race reconciliation; scripted benchmark execution, digests and comparison; native
+FleetProgramSpec/tool catalog; deadline LM proxy replacing instance method assignment;
+TurnBudget atomic reservation primitive and provider-proxy accounting;
+FleetOutputContract replacing private `_inject_execution_context` monkey-patching;
+DSPy compatibility implementation and consumers migrated to `compat_3_3_1.py`;
+and comprehensive tests for caller-owned interpreter, tool injection, output metadata,
+SandboxSerializable, async invocation, and trajectory shape.
+Latest implementation validation: `make check` passed (78.45% backend coverage;
+538 TUI tests), with output in `.scratch/roadmap-compat-check.log`.
+The earlier factory/native-contract/SUBMIT suite passed all 85 tests.
+The adapter suite now passes 29 tests, including five sync/async parity cases
+and cancellation cleanup. The RLM/tracer/version-guard suite passed 546 tests
+before the final single-home guard was added and covered by `make check`.
+Follow-up: corrected three vacuous source-root guards, added source-file existence
+assertions, and extracted SUBMIT syntax validation into `rlm/submit_validation.py`
+with 14 direct test cases. This validator is not a runtime safety sandbox.
+The 15-Turn receipt is `.scratch/runtime-v2-scripted-baseline.json`; it is explicitly
+scripted lifecycle evidence, not a sealed live legacy semantic baseline.
+
+## Sequence
+
+1. Phase 1.1 — Close Phase 0/1.
+2. Phase 2 — DSPy execution core.
+3. Phase 3 — Daytona native-interpreter feasibility.
+4. Phase 4 — Daytona environment definitions and warm capacity.
+5. Phase 5 — Native Turn-scoped production cutover and subtraction.
+6. Phase 6 — Recursive RLM v2.
+7. Phase 7 — Evaluation, optimization, rollout, and final deletion.
+
+Prove the Daytona native execution architecture in Phase 3 before encoding its
+requirements in Phase 4 snapshots. Phases 3–7 have sequencing only in this revision;
+their detailed implementation scope and exit gates remain to be defined.
+
+## Phase 1.1 — Close the implemented foundation
+
+Objective: stabilize Phase 0/1 before introducing runtime alternatives.
+
+### PR 1.1A — Correct architecture contracts
+
+- [x] Amend ADR 004: InterpreterContext is fresh per Turn (target; legacy cutover pending).
+- [x] Define SemanticChild as Volume-less and warm-pool eligible.
+- [x] Define WorkspaceChild as the restricted-data child.
+- [x] Move BenchmarkSandbox into testing terminology.
+- [x] State that correctness cannot depend on interpreter globals surviving a Turn.
+- [x] Update diagrams and vocabulary checks.
+
+### PR 1.1B — Collapse migration selectors
+
+- [x] Introduce one `runtime.variant`; expose only implemented variants.
+- [x] Keep native and capsule absent from the settings editor until their owning phases land.
+- [x] Reject unsupported combinations at startup during migration.
+- [x] Record `runtime_variant` in lifecycle and scripted benchmark receipts.
+- [x] Update ADR 005 and test that the default cannot silently change.
+
+### PR 1.1C — Complete benchmark v2
+
+- [x] Rename the receipt-packaging command and add a real benchmark executor.
+- [x] Convert the scenario catalog into executable, versioned fixtures.
+- [x] Add explicit deterministic scorer IDs.
+- [ ] Add semantic scorer IDs and executable semantic scoring; the scripted receipt
+  currently records an empty `semantic_scorer_ids` list.
+- [x] Add repeated samples and p50/p95 distributions for the scripted lane.
+- [x] Record dataset/scorer digests and all relevant snapshot/profile identities.
+- [x] Generate Runtime Event fixtures from deterministic scripted Runs.
+- [ ] Seal one actual legacy 0.7.6 baseline receipt.
+- [x] Add a comparison command producing pass/fail migration gates.
+
+### PR 1.1D — Finish database lineage
+
+- [x] Add composite Turn-to-Run Session lineage.
+- [x] Enforce immediate SQLite FKs; no global deferral existed in this checkout.
+- [x] Restrict claim reconciliation to expected claim constraints.
+- [x] Add dirty-data migration preflight and upgrade/downgrade tests.
+- [ ] Preserve live Postgres contention evidence.
+
+### Exit criteria
+
+- [x] One coherent runtime selector exists.
+- [x] Architecture no longer endorses cross-Turn interpreter state.
+- [x] A reproducible benchmark executes rather than merely packages receipts.
+- [ ] A real legacy baseline exists.
+- [x] Turn/Run Session lineage is database-enforced.
+- [x] SQLite and Postgres FK timing semantics align where practical.
+
+## Phase 2 — DSPy execution core
+
+Objective: simplify the DSPy boundary without changing Daytona lifecycle.
+
+Evolve the existing RLMFactory into a FleetProgramFactory driven by an immutable
+FleetProgramSpec and returning native `dspy.RLM`. Do not add a redundant
+`FleetProgram(dspy.Module)`: RLM is already a Module. A wrapper becomes justified
+only by an evaluated deterministic pipeline such as route → retrieve → RLM →
+verify → revise.
+
+Compatibility premise to verify against official DSPy documentation and the exact
+3.3.1 pin before implementation: experimental RLM exposes its public constructor,
+native `llm_query`, `llm_query_batched`, `print`, `SUBMIT`, custom tools, configurable
+`sub_lm`, and a caller-owned CodeInterpreter that may be passed positionally and
+remains caller-managed.
+
+### PR 2A — Program specification and tool ownership
+
+- [x] Define immutable FleetProgramSpec and one builder returning native `dspy.RLM`.
+- [x] Keep Daytona, database, Run authority, and event-stream objects out of the spec.
+- [x] Introduce one immutable FleetToolCatalog (membership and authority; DSPy Tool objects remain runtime objects).
+- [x] Classify tools as sandbox-local, host-authorized, recursive, or settlement-only.
+- [x] Never expose catalog settlement-only tools to the model.
+- [x] Reject collisions with DSPy built-ins, including a runtime assertion against
+  the final constructed namespace rather than only an AST vocabulary check.
+
+### PR 2B — Global TurnBudget
+
+Enforce absolute deadline, provider attempts, tool calls, recursive children,
+execution output bytes, and finalization reserve. Token counts remain observed
+accounting until usage is reliably available before further calls for hard admission.
+
+- [x] Define TurnBudget with atomic reservations and explicit exhaustion categories.
+- [ ] Reserve finalization capacity before exploration.
+- [ ] Share the budget across root action calls, DSPy built-in sub-LM calls, parse
+  repair, extraction, child root/sub-LM calls, and provider retries.
+- [ ] Add concurrency-safe child reservations and complete budget-path tests.
+
+Integration evidence: production reservations currently cover provider attempts only.
+Tool/child/output-byte admission, configured limits, finalization capability, and
+settlement wiring still need implementation and end-to-end budget-path tests.
+
+### PR 2C — Replace LM monkey-patching
+
+- [x] Introduce a real budget/deadline LM proxy.
+- [x] Stop assigning replacement `forward`/`aforward` methods to LM instances.
+- [ ] Establish one retry owner; debit every physical provider attempt.
+- [x] Preserve model role, usage, and callback visibility.
+- [x] Test synchronous and asynchronous DSPy paths under the exact 3.3.1 pin.
+
+### PR 2D — Remove private RLM mutation
+
+- [x] Remove replacement of `_inject_execution_context`.
+- [x] Introduce FleetOutputContract; let the interpreter adapter bind output metadata.
+- [x] Isolate unavoidable DSPy 3.3.1 compatibility in `compat_3_3_1.py`.
+- [x] Prohibit private DSPy imports elsewhere.
+- [x] Directly test caller-owned interpreter, tool injection, output metadata,
+  SandboxSerializable, async invocation, final output, and trajectory shape.
+
+Compatibility status: implementation and consumers now use `compat_3_3_1.py`;
+`_dspy_compat.py` is removed. The import guards allow only the versioned module,
+and a regression test verifies that the implementation has one home.
+
+### PR 2E — Contract FleetJSONAdapter
+
+- [ ] Compare stock JSONAdapter against Fleet's adapter using benchmark v2.
+- [ ] Keep only measured repair behavior.
+- [ ] Move deadlines and attempt limits to TurnBudget/LM proxy.
+- [x] Extract SUBMIT validation into a small validator.
+- [x] Use one state machine for sync and async. Requests, error transitions,
+  wrap-up metadata, and cancellation cleanup are regression-tested.
+- [ ] Debit all corrective calls from the global budget.
+- [ ] Keep finalization reserve independently testable.
+
+### Exit criteria
+
+- [x] Native DSPy RLM built-ins remain unmodified.
+- [x] No LM method assignment or private RLM method replacement remains.
+- [ ] Every model/provider attempt is globally accounted for.
+- [x] DSPy core can be tested without Daytona or the database.
+- [x] Public Turn output and Runtime Event fixtures remain unchanged.
+
+## Next implementation steps
+
+1. Complete PR 2B admission and settlement wiring, including independently usable
+   finalization reserve and tests exercising root, child, and corrective calls.
+2. Close PR 2C retry accounting with end-to-end admission evidence; do not treat
+   primitive-only tests as completion evidence.
+3. Complete PR 2E adapter comparison and budget integration, preserving existing
+   repair behavior until measurements justify policy changes.
+4. Define Phase 3 feasibility experiments and exit gates before snapshot work.
+5. When explicitly authorized, capture the live legacy baseline and Postgres
+   contention evidence. Scripted receipts do not satisfy either live gate.
+
+## Implementation commits
+
+- `9c2526dc` — Extract finalization syntax validation.
+- `577f0c84` — Share sync/async repair policy and test parity/cancellation.
+- `8ee6ff65` — Native program/tool boundaries, budget primitives, output contracts,
+  and actual exact-version compatibility relocation.
+- `597c5396` — Database lineage, immediate SQLite FKs, and claim reconciliation.
+- `ec582393` — Legacy runtime selector, target ADRs, and scripted migration receipts.
+
+## Evidence and execution boundaries
+
+The roadmap is explicitly tracked for review despite the `.scratch/` ignore rule;
+local logs and benchmark receipts remain ignored. No phase is closed.
+Commits on `feat/runtime-roadmap` are authorized. Pushes, PR creation, production
+cutover, and credentialed live execution have not been authorized.
+
+Close checkboxes only with implementation and validation receipts. Live baseline,
+provider, Daytona, and Postgres tests require explicit operator authorization.
+Creating this roadmap does not authorize commits, PR creation, or live execution.

--- a/.scratch/refined-runtime-roadmap.md
+++ b/.scratch/refined-runtime-roadmap.md
@@ -26,8 +26,14 @@ checks also pass. Runtime-v2 comparison tests cover receipt integrity, both
 invocation modes, attempt accounting, semantic scorer evidence, and repair-policy
 ablations. Source-root guards inspect the actual backend tree. SUBMIT syntax
 validation is separately tested and is not a runtime safety sandbox.
-The 15-Turn receipt is `.scratch/runtime-v2-scripted-baseline.json`; it is explicitly
-scripted lifecycle evidence, not a sealed live legacy semantic baseline.
+The clean 15-Turn scripted receipts are
+`.scratch/runtime-v2-scripted-baseline-semantic-ff24757b.json` (digest
+`d0c3b8fed7d9c61cbada149f40539cd6197263fe77cd68d3612d5bb1c5ad70ad`) and
+`.scratch/runtime-v2-scripted-candidate-semantic-ff24757b.json` (digest
+`cf39453a3071b572a60e1a3e5f32b619a0901231f734b9196eab3c22d17f77aa`); both
+passed lifecycle comparison with `semantic-keywords/v1`, `source_dirty: false`,
+and `live_semantic_gate: not_exercised`. They are explicitly scripted lifecycle
+evidence, not a sealed live legacy semantic baseline.
 
 ## Sequence
 
@@ -199,7 +205,8 @@ Objective: stabilize Phase 0/1 before introducing runtime alternatives.
 - [x] Add repeated samples and p50/p95 distributions for the scripted lane.
 - [x] Record dataset/scorer digests and all relevant snapshot/profile identities.
 - [x] Generate Runtime Event fixtures from deterministic scripted Runs.
-- [ ] Seal one actual legacy 0.7.6 baseline receipt.
+- [x] Regenerate clean scripted baseline/candidate receipts with semantic scorer IDs.
+- [ ] Seal one actual live legacy 0.7.6 semantic baseline receipt (operator-authorized).
 - [x] Add a comparison command producing pass/fail migration gates.
 
 ### PR 1.1D — Finish database lineage
@@ -347,8 +354,8 @@ receipts/logs stay ignored; fixtures, replay code, tests, and this summary are t
 ## Next implementation steps
 
 1. Complete: run the post-fix `make check` and review the resulting diff.
-2. Regenerate clean scripted baseline/candidate receipts with semantic scorer IDs
-   after this change is committed; these remain lifecycle evidence only.
+2. Complete: regenerate clean scripted baseline/candidate receipts with semantic
+   scorer IDs; these remain lifecycle evidence only.
 3. When explicitly authorized, capture the live legacy semantic baseline and
    Postgres contention evidence. Scripted receipts do not satisfy either live gate.
 4. Execute Phase 3 gates, starting with the credential-free parity lane and then

--- a/.scratch/refined-runtime-roadmap.md
+++ b/.scratch/refined-runtime-roadmap.md
@@ -3,28 +3,29 @@
 Status: implementation in progress on branch `feat/runtime-roadmap` (0.7.6).
 Implementation commits are recorded below, including the existing agent-instruction
 changes requested by the operator. ADR 004/005 were created here because this
-checkout lacked them. PR 2E is complete in the deterministic protocol lane.
-No phase is closed. Phase 2 global budget integration remains open;
-live semantic baseline and Postgres evidence remain pending operator authorization.
+checkout lacked them. PR 2E and the production Phase 2 budget wiring are complete
+as implementation work; no phase is closed. The live semantic baseline and
+Postgres contention evidence remain pending operator authorization.
 
 Implemented so far: explicit legacy selector and rejection tests; architecture
 target ADRs; composite database lineage with preflight and reversible migration;
 immediate SQLite FK enforcement and corrected fixtures; narrowly allowlisted claim
-race reconciliation; scripted benchmark execution, digests and comparison; native
-FleetProgramSpec/tool catalog; deadline LM proxy replacing instance method assignment;
-TurnBudget atomic reservations and provider-proxy accounting, including adapter
-corrections, DSPy schema fallback, and provider retries;
+race reconciliation; scripted benchmark execution, deterministic semantic scoring,
+digests and comparison; native FleetProgramSpec/tool catalog; deadline LM proxy
+replacing instance method assignment; TurnBudget atomic reservations and
+provider-proxy accounting, including adapter corrections, DSPy schema fallback,
+provider retries, tool/child/output admission, and finalization settlement;
 FleetOutputContract replacing private `_inject_execution_context` monkey-patching;
 DSPy compatibility implementation and consumers migrated to `compat_3_3_1.py`;
-and comprehensive tests for caller-owned interpreter, tool injection, output metadata,
-SandboxSerializable, async invocation, and trajectory shape.
-Latest implementation validation: `make check` passed (78.58% backend coverage;
-538 TUI tests), with output in `.scratch/contract-adapter-final-check.log`.
-The adapter-budget integration suite has 29 cases; the adapter behavior suite has
-29 cases. Runtime-v2 comparison tests cover receipt integrity, both invocation
-modes, attempt accounting, and repair-policy ablations. Source-root guards inspect
-the actual backend tree. SUBMIT syntax validation is separately tested and is not
-a runtime safety sandbox.
+composition-owned async Tool bridging; and comprehensive tests for caller-owned
+interpreter, tool injection, output metadata, SandboxSerializable, async invocation,
+output caps, budget paths, and trajectory shape.
+Post-fix `make check` passes with 78.60% backend coverage and 538 TUI tests;
+Ruff, ty, generated-contract, dependency-boundary, documentation, and harness
+checks also pass. Runtime-v2 comparison tests cover receipt integrity, both
+invocation modes, attempt accounting, semantic scorer evidence, and repair-policy
+ablations. Source-root guards inspect the actual backend tree. SUBMIT syntax
+validation is separately tested and is not a runtime safety sandbox.
 The 15-Turn receipt is `.scratch/runtime-v2-scripted-baseline.json`; it is explicitly
 scripted lifecycle evidence, not a sealed live legacy semantic baseline.
 
@@ -39,8 +40,131 @@ scripted lifecycle evidence, not a sealed live legacy semantic baseline.
 7. Phase 7 — Evaluation, optimization, rollout, and final deletion.
 
 Prove the Daytona native execution architecture in Phase 3 before encoding its
-requirements in Phase 4 snapshots. Phases 3–7 have sequencing only in this revision;
-their detailed implementation scope and exit gates remain to be defined.
+requirements in Phase 4 snapshots. The experiments and exit gates for Phases 3–7
+are defined below; a gate is closed only by the named executable receipt or test
+and not by a design assertion.
+
+## Phase 3 — Daytona native-interpreter feasibility
+
+Objective: prove that a caller-owned native DSPy interpreter can execute one
+Turn safely on Daytona before any warm-pool or snapshot policy is committed.
+
+### Experiments
+
+- **P3-E1 — Native call boundary:** run the pinned DSPy 3.3.1 `dspy.RLM` with a
+  caller-owned `InterpreterContext`, typed `SUBMIT`, the Fleet output contract,
+  host Tools, and the normal Runtime Event projection. Record the exact candidate,
+  dependency versions, selected policy/profile, and bounded event assertions;
+  never record prompts, answers, code, credentials, Sandbox IDs, or provider
+  responses.
+- **P3-E2 — Turn isolation:** execute two sequential and two overlapping Turns
+  using fresh interpreter contexts and distinct Run bindings. Verify no globals,
+  Tool aliases, output metadata, context capsules, or callbacks cross the Turn
+  boundary. Include a legacy Session-reuse control so the difference is measured.
+- **P3-E3 — Cancellation and cleanup:** cancel during interpreter execution,
+  provider wait, and finalization. Verify the worker is joined, the interpreter
+  lease remains owned until cleanup settles, no success or Artifact is published,
+  and the durable Turn reaches the typed failure state.
+- **P3-E4 — Protocol and budget parity:** replay empty, malformed, missing-field,
+  late, retry, output-cap, and finalization responses through sync and async paths.
+  Compare Runtime Event shape, provider admissions, and shared budget snapshots
+  against the sealed deterministic adapter fixtures.
+- **P3-E5 — Live feasibility canary:** when explicitly authorized, run the narrow
+  Phase 1 Daytona stream canary, then the Phase 2 recursive-child canary only
+  after the Phase 1 receipt and retrospective. Compare cold-start, first-action,
+  cleanup, and failure timings against bounded policy thresholds; this is a
+  feasibility result, not release or semantic-quality evidence.
+
+### Phase 3 exit gates
+
+- [ ] P3-G1: P3-E1 receipt proves caller-owned native execution and typed output on
+  the exact pinned dependency set.
+- [ ] P3-G2: P3-E2 proves fresh Turn context and no cross-Turn mutable state in
+  sequential and overlapping execution.
+- [ ] P3-G3: P3-E3 proves cancellation, timeout, claim loss, and cleanup ownership
+  with no detached mutation or successful durable settlement.
+- [ ] P3-G4: P3-E4 passes protocol parity, global admission, output-cap, and
+  Runtime Event assertions in the credential-free lane.
+- [ ] P3-G5: the authorized Daytona canary passes on a clean committed candidate;
+  otherwise Phase 4 snapshot work does not start.
+
+## Phase 4 — Daytona environment definitions and warm capacity
+
+Objective: turn the proven native boundary into explicit environment contracts
+without hiding cold-start or capacity costs.
+
+### Experiments and gates
+
+- Define immutable `daytona-recursive` snapshot contents, mount policy, network
+  policy, and interpreter bootstrap; reject drift at startup.
+- Compare per-Turn creation, retained Session root, and bounded warm-pool candidates
+  using the same P3 scenario mix. Measure readiness, first action, idle reuse,
+  replacement, and cleanup distributions; do not optimize before correctness.
+- Exercise capacity admission, provider outages, stale bindings, snapshot mismatch,
+  and disposal with pending owners. Verify no capacity mode bypasses Run claims,
+  deadlines, or cleanup fencing.
+- **Exit:** [ ] snapshot identity and policy are immutable; [ ] cold/warm choice
+  has a retained receipt with thresholds; [ ] capacity/replacement cleanup passes;
+  [ ] no warm mode changes public Runtime Events or durable semantics.
+
+## Phase 5 — Native Turn-scoped production cutover and subtraction
+
+Objective: migrate production from legacy Session reuse to the native Turn-scoped
+architecture with a reversible, observable rollout.
+
+### Experiments and gates
+
+- Run a shadow or canary cohort with the same requests through legacy and native
+  paths, comparing terminal status, committed output schema, Runtime Events,
+  Tool effects, Artifact candidates, latency, provider admissions, and cleanup.
+- Roll back on any integrity, authorization, event-order, budget, or durability
+  mismatch; preserve the legacy selector until the native candidate is proven.
+- Switch the default only after the canary is stable across restart, cancellation,
+  claim loss, provider failure, and Session concurrency, then delete the legacy
+  reuse path and its compatibility-only tests in a separate reviewed change.
+- **Exit:** [ ] native canary meets parity/error/latency thresholds; [ ] rollback
+  drill succeeds; [ ] operator sign-off records the cutover; [ ] legacy subtraction
+  leaves no supported selector or stale lifecycle owner.
+
+## Phase 6 — Recursive RLM v2
+
+Objective: extend the proven Turn-scoped boundary to isolated recursive children,
+without allowing child work to become final authority or escape the parent deadline.
+
+### Experiments and gates
+
+- Measure one direct SemanticChild and one restricted WorkspaceChild with fresh
+  child interpreters, explicit Volume scope, bounded child calls, and Root
+  verification/synthesis.
+- Compare sequential and ordered all-or-nothing batches under child, Tool, provider,
+  output, cancellation, and cleanup budgets. Inject child timeout, authorization
+  revocation, partial acquisition, and late cleanup failures.
+- Verify depth-one enforcement, Sub-LM fallback, prompt/answer bounds, no parent
+  interpreter globals in children, and no child lease after parent settlement.
+- **Exit:** [ ] child isolation and Volume policy pass; [ ] ordered batch and shared
+  budget receipts pass; [ ] failure/quarantine cleanup is bounded; [ ] Root remains
+  the only final authority.
+
+## Phase 7 — Evaluation, optimization, rollout, and final deletion
+
+Objective: use semantic and operational evidence to optimize only after correctness
+and lifecycle gates are closed, then remove migration scaffolding.
+
+### Experiments and gates
+
+- Capture a clean legacy semantic baseline with explicit scorer IDs and model/profile
+  identity, followed by the equivalent native candidate; keep deterministic
+  lifecycle scores separate from live judge quality.
+- Run the MLflow evaluation dataset/scorers, align judges with SME labels, and
+  record quality, latency, provider admissions, tool/recursive counts, and costs
+  under named configurations. No live scores are inferred from scripted receipts.
+- Optimize one bounded dimension at a time (prompt, routing, batching, snapshot,
+  or capacity), retain reproducible candidate receipts, and reject regressions in
+  correctness, safety, durability, or budget ceilings.
+- **Exit:** [ ] semantic quality and lifecycle parity meet the signed thresholds;
+  [ ] rollout/rollback and observability are rehearsed; [ ] best configuration is
+  promoted through the repository release process; [ ] legacy selector, adapter
+  shims, and obsolete tests/docs are deleted only after final evidence is archived.
 
 ## Phase 1.1 — Close the implemented foundation
 
@@ -68,8 +192,10 @@ Objective: stabilize Phase 0/1 before introducing runtime alternatives.
 - [x] Rename the receipt-packaging command and add a real benchmark executor.
 - [x] Convert the scenario catalog into executable, versioned fixtures.
 - [x] Add explicit deterministic scorer IDs.
-- [ ] Add semantic scorer IDs and executable semantic scoring; the scripted receipt
-  currently records an empty `semantic_scorer_ids` list.
+- [x] Add semantic scorer IDs and executable deterministic semantic scoring. The
+  `semantic-keywords/v1` scorer normalizes Unicode/case/whitespace and checks
+  expected concept markers without a provider call; the live semantic gate remains
+  explicitly unexercised.
 - [x] Add repeated samples and p50/p95 distributions for the scripted lane.
 - [x] Record dataset/scorer digests and all relevant snapshot/profile identities.
 - [x] Generate Runtime Event fixtures from deterministic scripted Runs.
@@ -126,21 +252,23 @@ execution output bytes, and finalization reserve. Token counts remain observed
 accounting until usage is reliably available before further calls for hard admission.
 
 - [x] Define TurnBudget with atomic reservations and explicit exhaustion categories.
-- [ ] Reserve finalization capacity before exploration.
-- [ ] Share the budget across root action calls, DSPy built-in sub-LM calls, parse
-  repair, extraction, child root/sub-LM calls, and provider retries.
-- [ ] Add concurrency-safe child reservations and complete budget-path tests.
+- [x] Reserve finalization capacity before exploration.
+- [x] Share the budget across root action calls, DSPy built-in sub-LM calls, parse
+  repair, extraction, child root/sub-LM calls, provider retries, host Tools, and
+  execution output bytes.
+- [x] Add concurrency-safe child reservations and complete budget-path tests.
 
-Integration evidence: production reservations currently cover provider attempts only.
-PR 2E now supplies call-local finalization capability and tests root-only reserved
-provider attempts. Tool/child/output-byte admission, configured global limits, and
-settlement wiring still need implementation and end-to-end budget-path tests.
+Integration evidence: `build_run_preparation` creates one TurnBudget from the
+configured `BudgetLimits`; the bound Root/Sub LMs, FleetJSONAdapter, host Tools,
+recursive children, Daytona output cap, and cleanup settlement share it. Explicit
+finalization limits reserve capacity away from exploration while invocation-local
+caps remain available for adapter-only compatibility seams.
 
 ### PR 2C — Replace LM monkey-patching
 
 - [x] Introduce a real budget/deadline LM proxy.
 - [x] Stop assigning replacement `forward`/`aforward` methods to LM instances.
-- [ ] Establish one retry owner; debit every physical provider attempt.
+- [x] Establish one retry owner; debit every physical provider attempt.
 - [x] Preserve model role, usage, and callback visibility.
 - [x] Test synchronous and asynchronous DSPy paths under the exact 3.3.1 pin.
 
@@ -211,19 +339,22 @@ receipts/logs stay ignored; fixtures, replay code, tests, and this summary are t
 
 - [x] Native DSPy RLM built-ins remain unmodified.
 - [x] No LM method assignment or private RLM method replacement remains.
-- [ ] Every model/provider attempt is globally accounted for.
+- [x] Every model/provider attempt is globally accounted for in the production
+  Turn wiring; live provider confirmation remains an operator gate.
 - [x] DSPy core can be tested without Daytona or the database.
 - [x] Public Turn output and Runtime Event fixtures remain unchanged.
 
 ## Next implementation steps
 
-1. Complete PR 2B admission and settlement wiring, including independently usable
-   finalization reserve and tests exercising root, child, and corrective calls.
-2. Close PR 2C retry accounting with end-to-end admission evidence; do not treat
-   primitive-only tests as completion evidence.
-3. Define Phase 3 feasibility experiments and exit gates before snapshot work.
-4. When explicitly authorized, capture the live legacy baseline and Postgres
-   contention evidence. Scripted receipts do not satisfy either live gate.
+1. Complete: run the post-fix `make check` and review the resulting diff.
+2. Regenerate clean scripted baseline/candidate receipts with semantic scorer IDs
+   after this change is committed; these remain lifecycle evidence only.
+3. When explicitly authorized, capture the live legacy semantic baseline and
+   Postgres contention evidence. Scripted receipts do not satisfy either live gate.
+4. Execute Phase 3 gates, starting with the credential-free parity lane and then
+   the authorized Daytona canary; do not begin snapshot work before P3-G5.
+5. Advance through the Phase 4–7 gates in order, retaining one bounded receipt per
+   experiment and keeping the legacy selector until native cutover is proven.
 
 ## Implementation commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,8 @@
 # Fleet RLM — Agent Instructions
 
-`fleet-rlm` is an RLM-native system built around DSPy, Daytona, FastAPI,
-durable Sessions/Turns, and a maintained terminal client under
-`tools/fleet-tui/`.
+`fleet-rlm` is an RLM-native system built around DSPy, Daytona, FastAPI, durable Sessions/Turns, and a maintained terminal client under `tools/fleet-tui/`.
 
-This file defines repository-wide execution rules. `tools/fleet-tui/AGENTS.md`
-adds rules specific to the terminal client.
+This file defines repository-wide execution rules. `tools/fleet-tui/AGENTS.md` adds rules specific to the terminal client.
 
 ## Working model
 
@@ -15,25 +12,29 @@ Before changing code:
 2. Search for existing implementations, helpers, and established boundaries before introducing new abstractions.
 3. Read `ARCHITECTURE.md` when the task affects ownership, lifecycle, dependencies, domain boundaries, or cross-component behavior.
 
-Treat current code, tests, `config/fleet.toml`, dependency pins, generated-contract
-checks, and executable validation as authoritative; documentation does not override
-executable contracts.
+Treat current code, tests, `config/fleet.toml`, dependency pins, generated-contract checks, and executable validation as authoritative; documentation does not override executable contracts.
 
 ## Execution
 
-For clear, reversible tasks, inspect the relevant context and proceed; prefer the
-simplest implementation that fully satisfies the request.
-Keep changes focused and reuse existing modules. Remove obsolete or superseded code
-only when safe, verified, and directly relevant. For architectural work, keep a
-concise task list and validate meaningful stages as you go. Use `uv run` for Python
-commands and do not modify unrelated files merely to make a diff cleaner.
+- Treat action requests as instructions to implement and validate through completion or a concrete blocker. Resolve routine, reversible choices from repository evidence and user intent.
+- For simple/local tasks, act directly; avoid long plans, routine tool narration, speculative exploration, and questions that repository evidence can answer.
+- Ask only when missing information materially changes the outcome or additional authority is needed. Prepare authorized, reviewable work before asking; do not ask again for authority already granted.
+- Keep changes focused, reuse existing modules, and prefer the simplest complete implementation. Remove obsolete code only when safe, verified, and directly relevant. Do not clean up unrelated files.
+- For architectural work, keep a concise task list and validate meaningful stages. Use `uv run` for Python commands.
+- Treat follow-ups as steering unless the user cancels or replaces the task. Answer status questions briefly, then continue.
+- Delegate only when explicitly requested or required by applicable instructions; assign bounded responsibilities and preserve others' edits.
+
+## Instructions and communication
+
+- Explicit user instructions take precedence over skill guidelines, subject to system and developer instructions. Apply skills to the actual task; guidance edits do not themselves require API credentials or live calls.
+- Distinguish the coding agent's authentication/model from Fleet's runtime provider configuration. Do not change either merely because the other is discussed.
+- If a skill blocks progress, cite its exact file and instruction, explain why it applies, and state the input needed. Do not infer extra approval requirements.
+- Use concise, plain language. Lead with results and evidence; state limits. Prefer short paragraphs and useful lists; avoid repeated summaries, stock phrases, and unnecessary formatting.
 
 ## Git and external effects
 
-Preserve pre-existing staged, unstaged, and untracked changes. Do not reset, clean,
-stash, overwrite, or revert changes you did not make.
-Do not commit, amend, push, open pull requests, deploy, publish, mutate shared
-infrastructure, or perform other externally visible actions unless explicitly requested.
+Preserve pre-existing staged, unstaged, and untracked changes. Do not reset, clean, stash, overwrite, or revert changes you did not make.
+Do not commit, amend, push, open pull requests, deploy, publish, mutate shared infrastructure, or perform other externally visible actions unless explicitly requested.
 Never expose credentials, tokens, `.env` values, provider secrets, or raw infrastructure errors.
 
 ## Hard architecture invariants
@@ -68,11 +69,12 @@ When their source contract changes, regenerate them using repository commands an
 ## Validation
 
 Use the smallest validation lane that proves the change, then escalate when the affected contract requires it.
+Repeat or broaden passing checks only for new changes, failures, or unresolved concerns. Add tests for meaningful behavior or regression risks, not to restate implementation.
+For documentation or agent-instruction-only changes, run `make check-docs` and `git diff --check`. Code lanes below apply when their code or executable contracts change.
 
 ### Focused Python changes
 
-Run relevant tests and checks: `uv run pytest <relevant-tests> -q`, `uv run ruff
-check <changed-paths>`, and `uv run ruff format --check <changed-paths>`.
+Run relevant tests and checks: `uv run pytest <relevant-tests> -q`, `uv run ruff check <changed-paths>`, and `uv run ruff format --check <changed-paths>`.
 
 Run `uv run ty check src` when typed application interfaces or implementations change.
 
@@ -87,11 +89,9 @@ make api-check
 
 ### TUI
 
-For changes under `tools/fleet-tui/`:
+For code changes under `tools/fleet-tui/`:
 
-```bash
-make tui-check
-```
+Run `make tui-check`.
 
 Follow `tools/fleet-tui/AGENTS.md`.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,6 +191,13 @@ remain transport-neutral until the API SSE adapter projects them.
 
 ## DSPy RLM contract
 
+The migration target uses a fresh InterpreterContext per Turn and distinguishes
+Volume-less SemanticChild from restricted-data WorkspaceChild. See
+[ADR 004](docs/decisions/004-turn-interpreter-context.md). These are target
+contracts; the selected `legacy` runtime retains its existing Session reuse
+until the native cutover gates pass. [ADR 005](docs/decisions/005-runtime-variant.md)
+defines the single execution-architecture selector.
+
 Fleet uses the repository-pinned DSPy implementation as the behavioral source
 of truth. A native RLM invocation receives the declared request, committed
 history, bounded Session context, authorized Skill metadata, and bounded

--- a/config/fleet.toml
+++ b/config/fleet.toml
@@ -44,10 +44,14 @@ cache = false
 [defaults.rlm]
 max_iters = 12
 max_llm_calls = 32
+max_provider_attempts = 2048
+max_tool_calls = 256
 max_output_chars = 6000
 max_execution_output_chars = 4000
+max_execution_output_bytes = 2000000
 execution_timeout_s = 300
 wrap_up_seconds = 300
+finalization_attempts = 2
 recursion_enabled = true
 recursion_max_calls = 4
 recursion_max_prompt_chars = 50000

--- a/config/fleet.toml
+++ b/config/fleet.toml
@@ -6,6 +6,7 @@ default_profile = "daytona-recursive"
 name = "fleet-rlm"
 
 [defaults.runtime]
+variant = "legacy"
 environment = "daytona"
 live_enabled = true
 turn_timeout_seconds = 1800

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,8 @@
 * [P42 Session-state behavior freeze](reference/p42-session-state-behavior-freeze.md)
 * [P42 module-subtraction ledger](reference/p42-module-subtraction-ledger.md)
 * [Session-scoped RLM state ADR](decisions/ADR-session-scoped-rlm-state.md)
+* [Turn interpreter context target (ADR 004)](decisions/004-turn-interpreter-context.md)
+* [Runtime variant (ADR 005)](decisions/005-runtime-variant.md)
 * [Reference](reference/index.md)
   * [Configuration](reference/configuration.md)
   * [Runtime Profile Matrix](reference/profile-matrix.md)

--- a/docs/decisions/004-turn-interpreter-context.md
+++ b/docs/decisions/004-turn-interpreter-context.md
@@ -1,0 +1,44 @@
+# ADR 004: Turn interpreter context and child data authority
+
+Status: accepted target; production cutover is gated by native-interpreter
+feasibility and benchmark parity. The legacy variant still implements the
+[Session runtime ADR](ADR-session-scoped-rlm-state.md).
+
+## Decision
+
+InterpreterContext is fresh per Turn. No correctness may depend on Python globals
+surviving a Turn. Durable Session conversation, Workspace files, Memory,
+Attachments, and committed Artifacts are the sources for rehydration.
+Sandbox capacity may be warm or reused only when a fresh interpreter context and
+the correct data authority can be established; capacity reuse does not imply
+interpreter-state reuse.
+
+| Resource role | Data authority | Capacity policy |
+| --- | --- | --- |
+| Root | Authorized Workspace data for the current Turn | Fresh context per Turn |
+| SemanticChild | Explicit bounded input only; no Volume | Warm-pool eligible after isolation is proved |
+| WorkspaceChild | Explicit restricted Workspace data capability | Mount/access restrictions verified before execution |
+
+BenchmarkSandbox is testing terminology, not a production runtime role or selector.
+Settlement remains host-owned; children return evidence and cannot publish a Turn.
+
+```text
+Durable Session + authorized Workspace state
+  -> Turn admission
+  -> fresh InterpreterContext
+  -> Root execution
+       -> SemanticChild (no Volume)
+       -> WorkspaceChild (restricted data)
+  -> host settlement
+  -> context disposal
+```
+
+## Migration gates
+
+Phase 3 proves caller-owned native interpreter execution, context isolation,
+tool/output binding, cancellation, and cleanup before Phase 4 defines snapshots
+and warm capacity. Phase 5 cuts production over and deletes legacy reuse only
+after executable benchmark and public Runtime Event parity gates pass.
+
+This decision supersedes cross-Turn globals as a target contract, but does not
+claim that the legacy implementation has already been removed.

--- a/docs/decisions/005-runtime-variant.md
+++ b/docs/decisions/005-runtime-variant.md
@@ -1,0 +1,18 @@
+# ADR 005: One execution-architecture selector
+
+Status: implemented for the legacy runtime.
+
+`runtime.variant` is the sole migration selector. Its default and only supported
+value is `legacy`. `runtime.environment` identifies the provider environment
+(`daytona`), not an alternate execution architecture. `runtime.live_enabled`
+controls operator admission, not architecture selection.
+
+Settings validation rejects unsupported variants before runtime composition.
+The schema-derived settings editor exposes only implemented choices. Native and
+capsule are not selectable until their owning implementation and validation gates
+land. Unknown legacy selector keys remain rejected by the policy schema.
+
+Omitted variant values resolve to `legacy` for existing policy compatibility;
+the committed policy names it explicitly. Tests pin both defaults and editor
+rejection without writes. Lifecycle benchmark receipts record `runtime_variant`.
+Future benchmark formats must carry the same identity for comparisons.

--- a/docs/decisions/ADR-session-scoped-rlm-state.md
+++ b/docs/decisions/ADR-session-scoped-rlm-state.md
@@ -14,6 +14,10 @@ records this change.
 
 ## Decision
 
+Migration note: [ADR 004](004-turn-interpreter-context.md) supersedes cross-Turn
+interpreter globals as the target architecture. The behavior below describes the
+selectable legacy implementation until the gated production cutover.
+
 Fleet distinguishes these four state classes:
 
 | State | Scope | Required behavior |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ FastAPI/SSE contract backed by DSPy, Daytona, and SQLAlchemy/Alembic.
 15. [P42 Session-state behavior freeze](reference/p42-session-state-behavior-freeze.md)
 16. [P42 module-subtraction ledger](reference/p42-module-subtraction-ledger.md)
 17. [Session-scoped RLM state ADR](decisions/ADR-session-scoped-rlm-state.md)
+18. [Turn interpreter context target (ADR 004)](decisions/004-turn-interpreter-context.md)
+19. [Runtime variant (ADR 005)](decisions/005-runtime-variant.md)
 
 ## Reference
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -124,8 +124,12 @@ still governed by the native trajectory. The generic `RLMOptions` and DSPy
 constructor fallback values for Root are `20`, `50`, and `10000`; the shipped
 `daytona-recursive` policy deliberately lowers the effective Root values to
 `12`, `32`, and `6000`. Its child values remain `8`, `12`, and `4000`.
-`max_execution_output_chars`, the Turn deadline, and recursive call/concurrency
-limits are separate Fleet controls. There is no configurable recursive depth;
+`max_execution_output_chars`, `max_execution_output_bytes`, the Turn deadline,
+provider-attempt, Tool-call, finalization, and recursive call/concurrency limits
+are separate Fleet controls. `max_provider_attempts` counts physical provider
+admissions, including retries and adapter repairs; `max_tool_calls` and
+`max_execution_output_bytes` are Turn-wide ceilings. There is no configurable
+recursive depth;
 `RLM_NATIVE_CHILD_DEPTH = 1` is a fixed product invariant.
 
 The `[rlm]` recursion settings include `recursion_enabled` and bound the native

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -38,6 +38,12 @@ applies migrations; use `uv run python scripts/db_init.py` or Alembic directly.
 
 ## Policy settings
 
+`runtime.variant` selects the execution architecture. Its default and only
+implemented value is `legacy`; `native` and `capsule` are rejected at startup
+and are absent from the settings editor. Existing policies that omit it keep
+the legacy behavior. `runtime.environment = "daytona"` selects the provider
+environment independently. See [ADR 005](../decisions/005-runtime-variant.md).
+
 `config/fleet.toml` deep-merges `[defaults]` into the selected
 `[profiles.<name>]`. It centralizes application identity; runtime timeouts,
 leases, liveness, and the credentialed-command live switch; Root/Sub model ids,

--- a/migrations/versions/019fdb010001_enforce_turn_run_session_lineage.py
+++ b/migrations/versions/019fdb010001_enforce_turn_run_session_lineage.py
@@ -16,6 +16,11 @@ depends_on = None
 
 
 def upgrade() -> None:
+    """Enforce matching run and session references for all turns.
+    
+    Raises:
+        RuntimeError: If any turn lacks a run with the same ID and session ID.
+    """
     connection = op.get_bind()
     if connection.dialect.name == "postgresql":
         connection.execute(sa.text("LOCK TABLE fleet_runs, fleet_turns IN SHARE ROW EXCLUSIVE MODE"))
@@ -42,6 +47,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    """
+    Remove the composite turn-to-run foreign key and its supporting unique index.
+    """
     with op.batch_alter_table("fleet_turns") as batch:
         batch.drop_constraint("fk_fleet_turns_run_session", type_="foreignkey")
     op.drop_index("uq_fleet_runs_id_session", table_name="fleet_runs")

--- a/migrations/versions/019fdb010001_enforce_turn_run_session_lineage.py
+++ b/migrations/versions/019fdb010001_enforce_turn_run_session_lineage.py
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade() -> None:
     """Enforce matching run and session references for all turns.
-    
+
     Raises:
         RuntimeError: If any turn lacks a run with the same ID and session ID.
     """

--- a/migrations/versions/019fdb010001_enforce_turn_run_session_lineage.py
+++ b/migrations/versions/019fdb010001_enforce_turn_run_session_lineage.py
@@ -1,0 +1,47 @@
+"""Enforce Turn-to-Run Session lineage.
+
+Revision ID: 019fdb010001
+Revises: 019fa2e4b7c1
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "019fdb010001"
+down_revision = "019fa2e4b7c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    if connection.dialect.name == "postgresql":
+        connection.execute(sa.text("LOCK TABLE fleet_runs, fleet_turns IN SHARE ROW EXCLUSIVE MODE"))
+    # Check before any DDL. Never delete or repair operator data implicitly.
+    invalid = connection.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM fleet_turns t LEFT JOIN fleet_runs r "
+            "ON r.id = t.run_id AND r.session_id = t.session_id WHERE r.id IS NULL"
+        )
+    ).scalar_one()
+    if invalid:
+        raise RuntimeError("Turn/Run Session lineage preflight failed; repair orphaned or mismatched Turns first")
+    # A unique index is a valid composite FK parent on SQLite and PostgreSQL,
+    # and avoids rebuilding fleet_runs while other tables reference it.
+    op.create_index("uq_fleet_runs_id_session", "fleet_runs", ["id", "session_id"], unique=True)
+    with op.batch_alter_table("fleet_turns") as batch:
+        batch.create_foreign_key(
+            "fk_fleet_turns_run_session",
+            "fleet_runs",
+            ["run_id", "session_id"],
+            ["id", "session_id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("fleet_turns") as batch:
+        batch.drop_constraint("fk_fleet_turns_run_session", type_="foreignkey")
+    op.drop_index("uq_fleet_runs_id_session", table_name="fleet_runs")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,7 @@
 
 | Script | Purpose |
 | --- | --- |
+| `benchmarks/runtime_v2.py` | Execute repeated scripted Turns and compare sealed lifecycle migration receipts; no live semantic or Daytona guarantee |
 | `db_init.py` | Upgrade a fresh `FLEET_DATABASE_URL` database to Alembic head |
 | `openapi_tools.py` | Generate or check backend-only `openapi.yaml` |
 | `generate_stream_fixture.py` | Generate or check the deterministic TUI turn-stream golden fixture |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,3 +115,20 @@ The Databricks-backed quality loop composes three opt-in steps that all require
    SME labeling session, distills judge guidelines with MemAlign, and re-runs
    the aligned baseline under a named run.
 See `docs/how-to-guides/evaluation-optimization.md` for the full workflow.
+
+## Runtime v2 adapter protocol comparison
+
+Run the credential-free DSPy 3.3.1 protocol replay from the repository root:
+
+```bash
+uv run python -m scripts.benchmarks.runtime_v2 compare-adapters \
+  --repetitions 5 --output .scratch/runtime-v2-adapter-comparison.json
+```
+
+The command executes stock JSONAdapter and Fleet adapters with zero, one, and
+two parse repairs over versioned response fixtures, in both sync and async modes.
+It records outcomes, physical provider admissions, latency distributions, source
+and fixture digests, and fail-closed contract gates. Output creation is exclusive;
+choose a new filename for each receipt. The comparison does not call a provider,
+Daytona, Postgres, or an MLflow server. Its scores measure deterministic protocol
+behavior, not semantic answer quality or production latency/cost.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -128,7 +128,10 @@ uv run python -m scripts.benchmarks.runtime_v2 compare-adapters \
 The command executes stock JSONAdapter and Fleet adapters with zero, one, and
 two parse repairs over versioned response fixtures, in both sync and async modes.
 It records outcomes, physical provider admissions, latency distributions, source
-and fixture digests, and fail-closed contract gates. Output creation is exclusive;
-choose a new filename for each receipt. The comparison does not call a provider,
-Daytona, Postgres, or an MLflow server. Its scores measure deterministic protocol
-behavior, not semantic answer quality or production latency/cost.
+and fixture digests, and fail-closed contract gates. The scripted Turn lane also
+runs the deterministic `semantic-keywords/v1` content-presence scorer; this is not
+an LLM quality judgment, and `live_semantic_gate` remains `not_exercised`. Output
+creation is exclusive; choose a new filename for each receipt. The comparison does
+not call a provider, Daytona, Postgres, or an MLflow server. Its scores measure
+deterministic lifecycle/protocol behavior, not live semantic quality or production
+latency/cost.

--- a/scripts/benchmark_daytona_lifecycle.py
+++ b/scripts/benchmark_daytona_lifecycle.py
@@ -268,6 +268,7 @@ async def run_benchmark(settings: Any) -> dict[str, object]:
         decision = benchmark_decision(p95_seconds=p95, deleted=deleted, measured=len(measured))
         return {
             "schema": RECEIPT_SCHEMA,
+            "runtime_variant": settings.runtime_variant,
             "started_at": started_at,
             "finished_at": datetime.now(UTC).isoformat(),
             "versions": _versions(),

--- a/scripts/benchmark_daytona_lifecycle.py
+++ b/scripts/benchmark_daytona_lifecycle.py
@@ -231,12 +231,13 @@ async def _run_cycle(
 async def run_benchmark(settings: Any) -> dict[str, object]:
     """
     Run warmup and measured lifecycle cycles and produce a bounded benchmark receipt.
-    
+
     Parameters:
-    	settings (Any): Benchmark configuration, including the runtime variant and Daytona settings.
-    
+        settings (Any): Benchmark configuration, including the runtime variant and Daytona settings.
+
     Returns:
-    	dict[str, object]: Receipt containing cycle results, timing summaries, threshold decision, and any benchmark failure information.
+        dict[str, object]: Receipt containing cycle results, timing summaries, threshold
+            decision, and any benchmark failure information.
     """
     client = build_daytona_client(settings)
     spec = sandbox_spec_from_settings(settings)

--- a/scripts/benchmark_daytona_lifecycle.py
+++ b/scripts/benchmark_daytona_lifecycle.py
@@ -229,7 +229,15 @@ async def _run_cycle(
 
 
 async def run_benchmark(settings: Any) -> dict[str, object]:
-    """Run warmups and measured cycles, returning only bounded evidence."""
+    """
+    Run warmup and measured lifecycle cycles and produce a bounded benchmark receipt.
+    
+    Parameters:
+    	settings (Any): Benchmark configuration, including the runtime variant and Daytona settings.
+    
+    Returns:
+    	dict[str, object]: Receipt containing cycle results, timing summaries, threshold decision, and any benchmark failure information.
+    """
     client = build_daytona_client(settings)
     spec = sandbox_spec_from_settings(settings)
     platform = LiveDaytonaPlatform(client, spec)

--- a/scripts/benchmarks/adapter_replay.py
+++ b/scripts/benchmarks/adapter_replay.py
@@ -1,0 +1,184 @@
+"""Credential-free protocol replay for runtime benchmark v2, not semantic evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import dspy
+from dspy.utils.exceptions import AdapterParseError, LMServerError, LMTimeoutError
+
+from fleet_rlm.rlm.budget import BudgetLimits, TurnBudget
+from fleet_rlm.rlm.compat_3_3_1 import FleetJSONAdapter, assert_dspy_version
+from fleet_rlm.rlm.program import DeadlineLMProxy
+
+DATASET = Path(__file__).with_name("runtime_v2_adapter_cases.json")
+SCORERS = ("adapter-outcome/v1", "provider-accounting/v1", "fleet-attempt-ceiling/v1")
+
+
+class ActionSignature(dspy.Signature):
+    iteration: str = dspy.InputField()
+    reasoning: str = dspy.OutputField()
+    code: str = dspy.OutputField()
+
+
+class ReplayLM(dspy.BaseLM):
+    """Scripted provider responses; never performs network I/O or caches calls."""
+
+    forward_contract = "legacy"
+
+    def __init__(self, case: dict[str, Any], clock: list[float]) -> None:
+        super().__init__("test/adapter-replay", cache=False, num_retries=0)
+        self.case = case
+        self.clock = clock
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def supported_params(self) -> set[str]:
+        return {"response_format"} if self.case.get("structured") else set()
+
+    @property
+    def supports_response_schema(self) -> bool:
+        return bool(self.case.get("structured"))
+
+    def forward(self, prompt=None, messages=None, **kwargs):
+        self.calls.append({"prompt": prompt, "messages": messages, "kwargs": kwargs})
+        responses = self.case["responses"]
+        text = responses[min(len(self.calls) - 1, len(responses) - 1)]
+        if self.case.get("late"):
+            self.clock[0] = 109.5
+        if text == "provider-timeout":
+            raise LMTimeoutError("scripted timeout")
+        if text == "retryable-server-error":
+            raise LMServerError("scripted retry")
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=text, tool_calls=None), finish_reason="stop")],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            model=self.model,
+        )
+
+    async def aforward(self, **kwargs):
+        return self.forward(**kwargs)
+
+
+def replay(case: dict[str, Any], *, variant: str, asynchronous: bool) -> dict[str, Any]:
+    clock = [109.5 if case.get("reserve") else 100.0]
+    turn = TurnBudget(deadline=110.0, limits=BudgetLimits(provider_attempts=10))
+    source = ReplayLM(case, clock)
+    lm = DeadlineLMProxy(
+        source,
+        deadline=110.0,
+        reserve_seconds=0.0,
+        retries=case.get("provider_retries", 0),
+        error_message="replay deadline",
+        budget=turn,
+    )
+    adapter: dspy.JSONAdapter
+    if variant == "stock":
+        adapter = dspy.JSONAdapter()
+    else:
+        retries = {"fleet": 2, "fleet-no-parse-repair": 0, "fleet-one-parse-repair": 1}[variant]
+        adapter = FleetJSONAdapter(deadline=110.0, wrap_up_seconds=1.0, max_parse_retries=retries, budget=turn)
+    started = time.perf_counter()
+    with patch("fleet_rlm.rlm.budget.time.monotonic", lambda: clock[0]):
+        try:
+            if asynchronous:
+                result = asyncio.run(adapter.acall(lm, {}, ActionSignature, [], {"iteration": "1/3"}))
+            else:
+                result = adapter(lm, {}, ActionSignature, [], {"iteration": "1/3"})
+            outcome = "submit" if result[0]["code"] == "SUBMIT(answer=1)" else "other-action"
+        except (AdapterParseError, LMTimeoutError, TimeoutError) as exc:
+            outcome = type(exc).__name__
+    return {
+        "case": case["id"],
+        "variant": variant,
+        "mode": "async" if asynchronous else "sync",
+        "seconds": time.perf_counter() - started,
+        "outcome": outcome,
+        "provider_attempts": len(source.calls),
+        "budget_attempts": turn.snapshot()["provider_attempts"],
+        "scores": {
+            "adapter-outcome/v1": outcome == case["expected"],
+            "provider-accounting/v1": turn.snapshot()["provider_attempts"] == len(source.calls),
+            "fleet-attempt-ceiling/v1": variant != "fleet" or len(source.calls) == case["fleet_attempts"],
+        },
+    }
+
+
+def run_adapter_comparison(*, repetitions: int = 5) -> dict[str, Any]:
+    """Use runtime-v2 sealing and distributions for an explicitly narrower lane."""
+    from scripts.benchmarks.runtime_v2 import digest, percentile, seal
+
+    assert_dspy_version()
+    if repetitions < 2:
+        raise ValueError("adapter comparison requires at least two repetitions")
+    dataset = json.loads(DATASET.read_text())
+    variants = ("stock", "fleet", "fleet-no-parse-repair", "fleet-one-parse-repair")
+    samples = []
+    for repetition in range(repetitions):
+        for case in dataset["cases"]:
+            for variant in variants:
+                for asynchronous in (False, True):
+                    samples.append(
+                        {**replay(case, variant=variant, asynchronous=asynchronous), "repetition": repetition}
+                    )
+    summary = {}
+    for variant in variants:
+        selected = [sample for sample in samples if sample["variant"] == variant]
+        durations = [sample["seconds"] for sample in selected]
+        summary[variant] = {
+            "samples": len(selected),
+            "correct": sum(sample["scores"]["adapter-outcome/v1"] for sample in selected),
+            "provider_attempts": sum(sample["provider_attempts"] for sample in selected),
+            "latency_seconds": {"p50": percentile(durations, 50), "p95": percentile(durations, 95)},
+        }
+    paired = {}
+    parity = True
+    for sample in samples:
+        key = (sample["case"], sample["variant"], sample["repetition"])
+        result = (sample["outcome"], sample["provider_attempts"], sample["budget_attempts"])
+        if key in paired and paired[key] != result:
+            parity = False
+        paired[key] = result
+    gates = {
+        "fleet_contract": all(all(sample["scores"].values()) for sample in samples if sample["variant"] == "fleet"),
+        "all_attempts_accounted": all(sample["scores"]["provider-accounting/v1"] for sample in samples),
+        "sync_async_parity": parity,
+        "valid_output_no_extra_calls": all(
+            sample["provider_attempts"] == 1 for sample in samples if sample["case"] == "valid/v1"
+        ),
+    }
+    implementation_paths = (
+        Path(__file__),
+        Path("scripts/benchmarks/runtime_v2.py"),
+        Path("src/fleet_rlm/rlm/submit_validation.py"),
+        Path("src/fleet_rlm/rlm/compat_3_3_1.py"),
+        Path("src/fleet_rlm/rlm/budget.py"),
+        Path("src/fleet_rlm/rlm/program.py"),
+    )
+    return seal(
+        {
+            "schema": "fleet.runtime-adapter-comparison/v2",
+            "scope": "scripted-adapter-protocol-only",
+            "runtime_variant": "legacy",
+            "dspy_version": dspy.__version__,
+            "repetitions": repetitions,
+            "dataset_digest": digest(dataset),
+            "scorer_digest": digest({"ids": SCORERS, "source": Path(__file__).read_text()}),
+            "implementation_digest": digest({str(path): path.read_text() for path in implementation_paths}),
+            "source_revision": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+            "source_dirty": bool(subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()),
+            "semantic_gate": "not_exercised",
+            "scorer_ids": list(SCORERS),
+            "samples": samples,
+            "summary": summary,
+            "gates": gates,
+            "passed": all(gates.values()),
+        }
+    )

--- a/scripts/benchmarks/adapter_replay.py
+++ b/scripts/benchmarks/adapter_replay.py
@@ -34,6 +34,13 @@ class ReplayLM(dspy.BaseLM):
     forward_contract = "legacy"
 
     def __init__(self, case: dict[str, Any], clock: list[float]) -> None:
+        """
+        Initialize the scripted language model with a replay case and shared clock.
+        
+        Parameters:
+            case (dict[str, Any]): Dataset case containing the scripted responses and behavior.
+            clock (list[float]): Mutable clock value used to track simulated time.
+        """
         super().__init__("test/adapter-replay", cache=False, num_retries=0)
         self.case = case
         self.clock = clock
@@ -41,13 +48,31 @@ class ReplayLM(dspy.BaseLM):
 
     @property
     def supported_params(self) -> set[str]:
+        """
+        Return the provider parameters supported for the current replay case.
+        """
         return {"response_format"} if self.case.get("structured") else set()
 
     @property
     def supports_response_schema(self) -> bool:
+        """Indicate whether the scripted case supports structured responses.
+        
+        Returns:
+        	bool: `True` if the case is structured, `False` otherwise.
+        """
         return bool(self.case.get("structured"))
 
     def forward(self, prompt=None, messages=None, **kwargs):
+        """
+        Replay the next scripted language-model response and record the request.
+        
+        Raises:
+            LMTimeoutError: If the scripted response indicates a provider timeout.
+            LMServerError: If the scripted response indicates a retryable server error.
+        
+        Returns:
+            A response object containing the scripted content, usage data, and model name.
+        """
         self.calls.append({"prompt": prompt, "messages": messages, "kwargs": kwargs})
         responses = self.case["responses"]
         text = responses[min(len(self.calls) - 1, len(responses) - 1)]
@@ -64,10 +89,26 @@ class ReplayLM(dspy.BaseLM):
         )
 
     async def aforward(self, **kwargs):
+        """Produce the scripted response for a model call.
+        
+        Returns:
+            The scripted response.
+        """
         return self.forward(**kwargs)
 
 
 def replay(case: dict[str, Any], *, variant: str, asynchronous: bool) -> dict[str, Any]:
+    """
+    Replay one benchmark case through the selected JSON adapter configuration.
+    
+    Parameters:
+    	case (dict[str, Any]): Dataset case containing scripted responses and expected outcomes.
+    	variant (str): Adapter variant to exercise.
+    	asynchronous (bool): Whether to invoke the adapter asynchronously.
+    
+    Returns:
+    	dict[str, Any]: Recorded outcome, timing, provider-attempt counts, and scorer results.
+    """
     clock = [109.5 if case.get("reserve") else 100.0]
     turn = TurnBudget(deadline=110.0, limits=BudgetLimits(provider_attempts=10))
     source = ReplayLM(case, clock)
@@ -112,7 +153,19 @@ def replay(case: dict[str, Any], *, variant: str, asynchronous: bool) -> dict[st
 
 
 def run_adapter_comparison(*, repetitions: int = 5) -> dict[str, Any]:
-    """Use runtime-v2 sealing and distributions for an explicitly narrower lane."""
+    """
+    Run the scripted adapter comparison across configured variants and execution modes.
+    
+    Parameters:
+        repetitions (int): Number of times to execute each dataset case; must be at least 2.
+    
+    Returns:
+        dict[str, Any]: Sealed benchmark results containing samples, per-variant summaries,
+            validation gates, metadata, and the overall pass status.
+    
+    Raises:
+        ValueError: If repetitions is less than 2.
+    """
     from scripts.benchmarks.runtime_v2 import digest, percentile, seal
 
     assert_dspy_version()

--- a/scripts/benchmarks/adapter_replay.py
+++ b/scripts/benchmarks/adapter_replay.py
@@ -36,7 +36,7 @@ class ReplayLM(dspy.BaseLM):
     def __init__(self, case: dict[str, Any], clock: list[float]) -> None:
         """
         Initialize the scripted language model with a replay case and shared clock.
-        
+
         Parameters:
             case (dict[str, Any]): Dataset case containing the scripted responses and behavior.
             clock (list[float]): Mutable clock value used to track simulated time.
@@ -56,20 +56,20 @@ class ReplayLM(dspy.BaseLM):
     @property
     def supports_response_schema(self) -> bool:
         """Indicate whether the scripted case supports structured responses.
-        
+
         Returns:
-        	bool: `True` if the case is structured, `False` otherwise.
+                bool: `True` if the case is structured, `False` otherwise.
         """
         return bool(self.case.get("structured"))
 
     def forward(self, prompt=None, messages=None, **kwargs):
         """
         Replay the next scripted language-model response and record the request.
-        
+
         Raises:
             LMTimeoutError: If the scripted response indicates a provider timeout.
             LMServerError: If the scripted response indicates a retryable server error.
-        
+
         Returns:
             A response object containing the scripted content, usage data, and model name.
         """
@@ -90,7 +90,7 @@ class ReplayLM(dspy.BaseLM):
 
     async def aforward(self, **kwargs):
         """Produce the scripted response for a model call.
-        
+
         Returns:
             The scripted response.
         """
@@ -100,14 +100,14 @@ class ReplayLM(dspy.BaseLM):
 def replay(case: dict[str, Any], *, variant: str, asynchronous: bool) -> dict[str, Any]:
     """
     Replay one benchmark case through the selected JSON adapter configuration.
-    
+
     Parameters:
-    	case (dict[str, Any]): Dataset case containing scripted responses and expected outcomes.
-    	variant (str): Adapter variant to exercise.
-    	asynchronous (bool): Whether to invoke the adapter asynchronously.
-    
+        case (dict[str, Any]): Dataset case containing scripted responses and expected outcomes.
+        variant (str): Adapter variant to exercise.
+        asynchronous (bool): Whether to invoke the adapter asynchronously.
+
     Returns:
-    	dict[str, Any]: Recorded outcome, timing, provider-attempt counts, and scorer results.
+        dict[str, Any]: Recorded outcome, timing, provider-attempt counts, and scorer results.
     """
     clock = [109.5 if case.get("reserve") else 100.0]
     turn = TurnBudget(deadline=110.0, limits=BudgetLimits(provider_attempts=10))
@@ -155,14 +155,14 @@ def replay(case: dict[str, Any], *, variant: str, asynchronous: bool) -> dict[st
 def run_adapter_comparison(*, repetitions: int = 5) -> dict[str, Any]:
     """
     Run the scripted adapter comparison across configured variants and execution modes.
-    
+
     Parameters:
         repetitions (int): Number of times to execute each dataset case; must be at least 2.
-    
+
     Returns:
         dict[str, Any]: Sealed benchmark results containing samples, per-variant summaries,
             validation gates, metadata, and the overall pass status.
-    
+
     Raises:
         ValueError: If repetitions is less than 2.
     """

--- a/scripts/benchmarks/runtime_v2.py
+++ b/scripts/benchmarks/runtime_v2.py
@@ -30,10 +30,29 @@ SEMANTIC_SCORERS = ("semantic-keywords/v1",)
 
 
 def digest(value: Any) -> str:
+    """
+    Create a deterministic SHA-256 digest for a JSON-serializable value.
+    
+    Parameters:
+    	value (Any): The value to serialize and hash.
+    
+    Returns:
+    	str: The hexadecimal SHA-256 digest.
+    """
     return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
 def percentile(values: list[float], percent: int) -> float:
+    """
+    Compute a nearest-rank percentile from a collection of values.
+    
+    Parameters:
+    	values (list[float]): Values from which to calculate the percentile.
+    	percent (int): Percentile to calculate, expressed as a percentage.
+    
+    Returns:
+    	float: The value at the requested nearest-rank percentile.
+    """
     return sorted(values)[max(0, math.ceil(len(values) * percent / 100) - 1)]
 
 
@@ -43,11 +62,14 @@ def _semantic_text(value: object) -> str:
 
 
 def semantic_keywords_score(answer: str, keywords: object) -> bool:
-    """Require every expected concept marker without making a provider call.
-
-    This is intentionally a deterministic content-presence scorer, not an LLM
-    quality judgment. The live semantic gate remains separate and explicitly
-    unexercised by the scripted benchmark.
+    """
+    Determine whether an answer contains every expected keyword.
+    
+    Parameters:
+        keywords (object): A nonempty list of string keywords to find in the answer.
+    
+    Returns:
+        bool: `true` if every keyword occurs in the answer, `false` otherwise.
     """
     if not isinstance(keywords, list) or not keywords or not all(isinstance(item, str) for item in keywords):
         return False
@@ -56,10 +78,28 @@ def semantic_keywords_score(answer: str, keywords: object) -> bool:
 
 
 def seal(receipt: dict[str, Any]) -> dict[str, Any]:
+    """
+    Add a SHA-256 digest of the receipt contents.
+    
+    Parameters:
+    	receipt (dict[str, Any]): Receipt data to seal.
+    
+    Returns:
+    	dict[str, Any]: A copy of the receipt containing its digest.
+    """
     return {**receipt, "receipt_digest": digest(receipt)}
 
 
 def validate(receipt: dict[str, Any]) -> None:
+    """
+    Validate the schema, provenance, sample coverage, scores, latency summary, and verdict of a benchmark receipt.
+    
+    Parameters:
+    	receipt (dict[str, Any]): Benchmark receipt to validate.
+    
+    Raises:
+    	ValueError: If the receipt is malformed or internally inconsistent.
+    """
     body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
     if receipt.get("schema") != SCHEMA or receipt.get("receipt_digest") != digest(body):
         raise ValueError("invalid benchmark schema or receipt digest")
@@ -105,6 +145,18 @@ def validate(receipt: dict[str, Any]) -> None:
 
 
 def run(*, repetitions: int = 5) -> dict[str, Any]:
+    """
+    Run the scripted lifecycle benchmark repeatedly and return a sealed receipt of its results.
+    
+    Parameters:
+        repetitions (int): Number of times to execute each dataset scenario. Must be at least 2.
+    
+    Returns:
+        dict[str, Any]: Sealed benchmark receipt containing samples, scores, latency summaries, provenance, and pass status.
+    
+    Raises:
+        ValueError: If repetitions is less than 2.
+    """
     from fastapi.testclient import TestClient
 
     from fleet_rlm.composition.testing import create_testing_app
@@ -188,6 +240,20 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
 
 
 def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_ratio: float = 2.0) -> dict[str, Any]:
+    """
+    Compare baseline and candidate benchmark receipts against compatibility, integrity, parity, and latency gates.
+    
+    Parameters:
+        baseline (dict[str, Any]): Validated baseline benchmark receipt.
+        candidate (dict[str, Any]): Validated candidate benchmark receipt.
+        max_p95_ratio (float): Maximum permitted ratio of candidate to baseline p95 latency.
+    
+    Returns:
+        dict[str, Any]: Gate results and an overall pass status for the scripted lifecycle scope.
+    
+    Raises:
+        ValueError: If either receipt is invalid or the latency ratio is not finite and positive.
+    """
     validate(baseline)
     validate(candidate)
     if not math.isfinite(max_p95_ratio) or max_p95_ratio <= 0:
@@ -216,6 +282,12 @@ def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_rati
 
 
 def main() -> int:
+    """
+    Run the benchmark or compare sealed benchmark receipts from the command line.
+    
+    Returns:
+        int: Exit status code: 0 when the operation passes, otherwise 1.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
     execute = commands.add_parser("run", help="Execute real Turns using private deterministic adapters")

--- a/scripts/benchmarks/runtime_v2.py
+++ b/scripts/benchmarks/runtime_v2.py
@@ -1,0 +1,185 @@
+"""Execute repeated deterministic legacy Runs and compare sealed migration receipts.
+
+This lane exercises the production HTTP/Turn lifecycle with private scripted
+execution adapters. It proves lifecycle parity, not provider quality or Daytona
+performance. Live semantic and infrastructure evidence remain separate gates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "fleet.runtime-benchmark/v2"
+DATASET = Path(__file__).with_name("runtime_v2_scenarios.json")
+SCORERS = ("stream-terminal/v1", "echo-answer/v1", "durable-turn-pair/v1")
+
+
+def digest(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def percentile(values: list[float], percent: int) -> float:
+    return sorted(values)[max(0, math.ceil(len(values) * percent / 100) - 1)]
+
+
+def seal(receipt: dict[str, Any]) -> dict[str, Any]:
+    return {**receipt, "receipt_digest": digest(receipt)}
+
+
+def validate(receipt: dict[str, Any]) -> None:
+    body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    if receipt.get("schema") != SCHEMA or receipt.get("receipt_digest") != digest(body):
+        raise ValueError("invalid benchmark schema or receipt digest")
+    if not receipt.get("samples") or receipt.get("repetitions", 0) < 2:
+        raise ValueError("benchmark requires repeated samples")
+    expected = {
+        (scenario, repetition) for scenario in receipt["event_fixtures"] for repetition in range(receipt["repetitions"])
+    }
+    actual = {(sample["scenario"], sample["repetition"]) for sample in receipt["samples"]}
+    if actual != expected or len(actual) != len(receipt["samples"]):
+        raise ValueError("benchmark sample coverage is incomplete or duplicated")
+    for sample in receipt["samples"]:
+        if not math.isfinite(sample["seconds"]) or sample["seconds"] < 0:
+            raise ValueError("benchmark duration must be finite and nonnegative")
+        if set(sample["scores"]) != set(SCORERS) or any(type(value) is not bool for value in sample["scores"].values()):
+            raise ValueError("benchmark scorer results are incomplete")
+        if sample["event_types"] != receipt["event_fixtures"][sample["scenario"]]:
+            raise ValueError("benchmark event fixtures disagree with executed samples")
+    durations = [sample["seconds"] for sample in receipt["samples"]]
+    summary = {"p50": percentile(durations, 50), "p95": percentile(durations, 95)}
+    if receipt["latency_seconds"] != summary:
+        raise ValueError("benchmark latency summary disagrees with samples")
+    passed = all(all(sample["scores"].values()) for sample in receipt["samples"])
+    if receipt["passed"] is not passed:
+        raise ValueError("benchmark verdict disagrees with scores")
+
+
+def run(*, repetitions: int = 5) -> dict[str, Any]:
+    from fastapi.testclient import TestClient
+
+    from fleet_rlm.composition.testing import create_testing_app
+    from fleet_rlm.config.settings import Settings
+
+    if repetitions < 2:
+        raise ValueError("benchmark requires at least two repetitions")
+    dataset = json.loads(DATASET.read_text())
+    samples = []
+    fixtures = {}
+    with tempfile.TemporaryDirectory(prefix="fleet-benchmark-") as directory:
+        settings = Settings(data_root=directory, mlflow_tracing_enabled=False, posthog_enabled=False)
+        with TestClient(create_testing_app(settings=settings)) as client:
+            for scenario in dataset["scenarios"]:
+                for repetition in range(repetitions):
+                    session = client.post("/api/sessions", json={"title": scenario["id"]})
+                    session.raise_for_status()
+                    session_id = session.json()["id"]
+                    started = time.perf_counter()
+                    response = client.post(
+                        f"/api/sessions/{session_id}/turns",
+                        json={"text": scenario["text"]},
+                        headers={"Idempotency-Key": f"{scenario['id']}-{repetition}"},
+                    )
+                    elapsed = time.perf_counter() - started
+                    response.raise_for_status()
+                    frames = [line[6:] for line in response.text.splitlines() if line.startswith("data: ")]
+                    chunks = [json.loads(frame) for frame in frames if frame != "[DONE]"]
+                    types = [chunk["type"] for chunk in chunks]
+                    answer = "".join(chunk.get("delta", "") for chunk in chunks if chunk["type"] == "text-delta")
+                    durable = client.get(f"/api/sessions/{session_id}/turns")
+                    durable.raise_for_status()
+                    scores = {
+                        "stream-terminal/v1": frames[-1:] == ["[DONE]"]
+                        and types.count("start") == 1
+                        and types.count("finish") == 1
+                        and types[-1:] == ["finish"],
+                        "echo-answer/v1": answer == scenario["expected_answer"],
+                        "durable-turn-pair/v1": [item["role"] for item in durable.json()["items"]]
+                        == ["user", "assistant"],
+                    }
+                    fixtures.setdefault(scenario["id"], types)
+                    samples.append(
+                        {
+                            "scenario": scenario["id"],
+                            "repetition": repetition,
+                            "seconds": elapsed,
+                            "scores": scores,
+                            "event_types": types,
+                        }
+                    )
+    durations = [sample["seconds"] for sample in samples]
+    return seal(
+        {
+            "schema": SCHEMA,
+            "runtime_variant": settings.runtime_variant,
+            "execution_mode": "scripted",
+            "repetitions": repetitions,
+            "source_revision": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+            "source_dirty": bool(subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()),
+            "dataset_digest": digest(dataset),
+            "scorer_digest": digest({"ids": SCORERS, "implementation": Path(__file__).read_text()}),
+            "scorer_ids": list(SCORERS),
+            "semantic_scorer_ids": [],
+            "identities": {"profile": "private-testing", "snapshots": [], "provider": "scripted"},
+            "samples": samples,
+            "event_fixtures": fixtures,
+            "latency_seconds": {"p50": percentile(durations, 50), "p95": percentile(durations, 95)},
+            "passed": all(all(sample["scores"].values()) for sample in samples),
+            "live_semantic_gate": "not_exercised",
+        }
+    )
+
+
+def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_ratio: float = 2.0) -> dict[str, Any]:
+    validate(baseline)
+    validate(candidate)
+    if not math.isfinite(max_p95_ratio) or max_p95_ratio <= 0:
+        raise ValueError("p95 ratio must be finite and positive")
+    compatible = all(
+        baseline[key] == candidate[key]
+        for key in ("dataset_digest", "scorer_digest", "execution_mode", "repetitions", "identities")
+    )
+    gates = {
+        "comparable": compatible,
+        "baseline_passed": baseline["passed"],
+        "candidate_passed": candidate["passed"],
+        "event_parity": baseline["event_fixtures"] == candidate["event_fixtures"],
+        "p95": candidate["latency_seconds"]["p95"] <= baseline["latency_seconds"]["p95"] * max_p95_ratio,
+    }
+    return {"passed": all(gates.values()), "gates": gates, "scope": "scripted-lifecycle-only"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    execute = commands.add_parser("run", help="Execute real Turns using private deterministic adapters")
+    execute.add_argument("--repetitions", type=int, default=5)
+    execute.add_argument("--output", type=Path, required=True)
+    comparison = commands.add_parser("compare", help="Fail closed on incompatible receipts or regressions")
+    comparison.add_argument("baseline", type=Path)
+    comparison.add_argument("candidate", type=Path)
+    comparison.add_argument("--max-p95-ratio", type=float, default=2.0)
+    args = parser.parse_args()
+    if args.command == "run":
+        receipt = run(repetitions=args.repetitions)
+        # Exclusive creation prevents accidental replacement of sealed evidence.
+        with args.output.open("x") as stream:
+            json.dump(receipt, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+        return 0 if receipt["passed"] else 1
+    result = compare(
+        json.loads(args.baseline.read_text()), json.loads(args.candidate.read_text()), max_p95_ratio=args.max_p95_ratio
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/runtime_v2.py
+++ b/scripts/benchmarks/runtime_v2.py
@@ -12,10 +12,15 @@ import hashlib
 import json
 import math
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
 from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 SCHEMA = "fleet.runtime-benchmark/v2"
 DATASET = Path(__file__).with_name("runtime_v2_scenarios.json")
@@ -162,13 +167,21 @@ def main() -> int:
     execute = commands.add_parser("run", help="Execute real Turns using private deterministic adapters")
     execute.add_argument("--repetitions", type=int, default=5)
     execute.add_argument("--output", type=Path, required=True)
+    adapters = commands.add_parser("compare-adapters", help="Replay stock/Fleet DSPy adapter protocol fixtures offline")
+    adapters.add_argument("--repetitions", type=int, default=5)
+    adapters.add_argument("--output", type=Path, required=True)
     comparison = commands.add_parser("compare", help="Fail closed on incompatible receipts or regressions")
     comparison.add_argument("baseline", type=Path)
     comparison.add_argument("candidate", type=Path)
     comparison.add_argument("--max-p95-ratio", type=float, default=2.0)
     args = parser.parse_args()
-    if args.command == "run":
-        receipt = run(repetitions=args.repetitions)
+    if args.command in {"run", "compare-adapters"}:
+        if args.command == "compare-adapters":
+            from scripts.benchmarks.adapter_replay import run_adapter_comparison
+
+            receipt = run_adapter_comparison(repetitions=args.repetitions)
+        else:
+            receipt = run(repetitions=args.repetitions)
         # Exclusive creation prevents accidental replacement of sealed evidence.
         with args.output.open("x") as stream:
             json.dump(receipt, stream, indent=2, sort_keys=True)

--- a/scripts/benchmarks/runtime_v2.py
+++ b/scripts/benchmarks/runtime_v2.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,7 @@ if str(_REPO_ROOT) not in sys.path:
 SCHEMA = "fleet.runtime-benchmark/v2"
 DATASET = Path(__file__).with_name("runtime_v2_scenarios.json")
 SCORERS = ("stream-terminal/v1", "echo-answer/v1", "durable-turn-pair/v1")
+SEMANTIC_SCORERS = ("semantic-keywords/v1",)
 
 
 def digest(value: Any) -> str:
@@ -35,6 +37,24 @@ def percentile(values: list[float], percent: int) -> float:
     return sorted(values)[max(0, math.ceil(len(values) * percent / 100) - 1)]
 
 
+def _semantic_text(value: object) -> str:
+    """Normalize bounded answer text for the deterministic semantic proxy."""
+    return " ".join(unicodedata.normalize("NFKC", str(value)).casefold().split())
+
+
+def semantic_keywords_score(answer: str, keywords: object) -> bool:
+    """Require every expected concept marker without making a provider call.
+
+    This is intentionally a deterministic content-presence scorer, not an LLM
+    quality judgment. The live semantic gate remains separate and explicitly
+    unexercised by the scripted benchmark.
+    """
+    if not isinstance(keywords, list) or not keywords or not all(isinstance(item, str) for item in keywords):
+        return False
+    normalized_answer = _semantic_text(answer)
+    return all((keyword := _semantic_text(item)) and keyword in normalized_answer for item in keywords)
+
+
 def seal(receipt: dict[str, Any]) -> dict[str, Any]:
     return {**receipt, "receipt_digest": digest(receipt)}
 
@@ -43,6 +63,14 @@ def validate(receipt: dict[str, Any]) -> None:
     body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
     if receipt.get("schema") != SCHEMA or receipt.get("receipt_digest") != digest(body):
         raise ValueError("invalid benchmark schema or receipt digest")
+    if type(receipt.get("runtime_variant")) is not str or not receipt["runtime_variant"]:
+        raise ValueError("benchmark runtime variant is missing")
+    if type(receipt.get("source_dirty")) is not bool:
+        raise ValueError("benchmark source_dirty provenance is invalid")
+    if type(receipt.get("source_revision")) is not str or not receipt["source_revision"]:
+        raise ValueError("benchmark source revision is missing")
+    if receipt.get("semantic_scorer_ids") != list(SEMANTIC_SCORERS):
+        raise ValueError("benchmark semantic scorer IDs are incomplete")
     if not receipt.get("samples") or receipt.get("repetitions", 0) < 2:
         raise ValueError("benchmark requires repeated samples")
     expected = {
@@ -56,13 +84,22 @@ def validate(receipt: dict[str, Any]) -> None:
             raise ValueError("benchmark duration must be finite and nonnegative")
         if set(sample["scores"]) != set(SCORERS) or any(type(value) is not bool for value in sample["scores"].values()):
             raise ValueError("benchmark scorer results are incomplete")
+        semantic_scores = sample.get("semantic_scores")
+        if (
+            not isinstance(semantic_scores, dict)
+            or set(semantic_scores) != set(SEMANTIC_SCORERS)
+            or any(type(value) is not bool for value in semantic_scores.values())
+        ):
+            raise ValueError("benchmark semantic scorer results are incomplete")
         if sample["event_types"] != receipt["event_fixtures"][sample["scenario"]]:
             raise ValueError("benchmark event fixtures disagree with executed samples")
     durations = [sample["seconds"] for sample in receipt["samples"]]
     summary = {"p50": percentile(durations, 50), "p95": percentile(durations, 95)}
     if receipt["latency_seconds"] != summary:
         raise ValueError("benchmark latency summary disagrees with samples")
-    passed = all(all(sample["scores"].values()) for sample in receipt["samples"])
+    passed = all(
+        all(sample["scores"].values()) and all(sample["semantic_scores"].values()) for sample in receipt["samples"]
+    )
     if receipt["passed"] is not passed:
         raise ValueError("benchmark verdict disagrees with scores")
 
@@ -109,6 +146,9 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
                         "durable-turn-pair/v1": [item["role"] for item in durable.json()["items"]]
                         == ["user", "assistant"],
                     }
+                    semantic_scores = {
+                        "semantic-keywords/v1": semantic_keywords_score(answer, scenario.get("semantic_keywords")),
+                    }
                     fixtures.setdefault(scenario["id"], types)
                     samples.append(
                         {
@@ -116,6 +156,7 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
                             "repetition": repetition,
                             "seconds": elapsed,
                             "scores": scores,
+                            "semantic_scores": semantic_scores,
                             "event_types": types,
                         }
                     )
@@ -129,14 +170,18 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
             "source_revision": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
             "source_dirty": bool(subprocess.check_output(["git", "status", "--porcelain"], text=True).strip()),
             "dataset_digest": digest(dataset),
-            "scorer_digest": digest({"ids": SCORERS, "implementation": Path(__file__).read_text()}),
+            "scorer_digest": digest(
+                {"ids": SCORERS, "semantic_ids": SEMANTIC_SCORERS, "implementation": Path(__file__).read_text()}
+            ),
             "scorer_ids": list(SCORERS),
-            "semantic_scorer_ids": [],
+            "semantic_scorer_ids": list(SEMANTIC_SCORERS),
             "identities": {"profile": "private-testing", "snapshots": [], "provider": "scripted"},
             "samples": samples,
             "event_fixtures": fixtures,
             "latency_seconds": {"p50": percentile(durations, 50), "p95": percentile(durations, 95)},
-            "passed": all(all(sample["scores"].values()) for sample in samples),
+            "passed": all(
+                all(sample["scores"].values()) and all(sample["semantic_scores"].values()) for sample in samples
+            ),
             "live_semantic_gate": "not_exercised",
         }
     )
@@ -149,10 +194,19 @@ def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_rati
         raise ValueError("p95 ratio must be finite and positive")
     compatible = all(
         baseline[key] == candidate[key]
-        for key in ("dataset_digest", "scorer_digest", "execution_mode", "repetitions", "identities")
+        for key in (
+            "dataset_digest",
+            "scorer_digest",
+            "execution_mode",
+            "repetitions",
+            "identities",
+            "runtime_variant",
+            "semantic_scorer_ids",
+        )
     )
     gates = {
         "comparable": compatible,
+        "source_clean": not baseline["source_dirty"] and not candidate["source_dirty"],
         "baseline_passed": baseline["passed"],
         "candidate_passed": candidate["passed"],
         "event_parity": baseline["event_fixtures"] == candidate["event_fixtures"],

--- a/scripts/benchmarks/runtime_v2.py
+++ b/scripts/benchmarks/runtime_v2.py
@@ -213,7 +213,7 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
                         }
                     )
     durations = [sample["seconds"] for sample in samples]
-    return seal(
+    receipt = seal(
         {
             "schema": SCHEMA,
             "runtime_variant": settings.runtime_variant,
@@ -237,6 +237,8 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
             "live_semantic_gate": "not_exercised",
         }
     )
+    validate(receipt)
+    return receipt
 
 
 def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_ratio: float = 2.0) -> dict[str, Any]:

--- a/scripts/benchmarks/runtime_v2.py
+++ b/scripts/benchmarks/runtime_v2.py
@@ -32,12 +32,12 @@ SEMANTIC_SCORERS = ("semantic-keywords/v1",)
 def digest(value: Any) -> str:
     """
     Create a deterministic SHA-256 digest for a JSON-serializable value.
-    
+
     Parameters:
-    	value (Any): The value to serialize and hash.
-    
+        value (Any): The value to serialize and hash.
+
     Returns:
-    	str: The hexadecimal SHA-256 digest.
+        str: The hexadecimal SHA-256 digest.
     """
     return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
@@ -45,13 +45,13 @@ def digest(value: Any) -> str:
 def percentile(values: list[float], percent: int) -> float:
     """
     Compute a nearest-rank percentile from a collection of values.
-    
+
     Parameters:
-    	values (list[float]): Values from which to calculate the percentile.
-    	percent (int): Percentile to calculate, expressed as a percentage.
-    
+        values (list[float]): Values from which to calculate the percentile.
+        percent (int): Percentile to calculate, expressed as a percentage.
+
     Returns:
-    	float: The value at the requested nearest-rank percentile.
+        float: The value at the requested nearest-rank percentile.
     """
     return sorted(values)[max(0, math.ceil(len(values) * percent / 100) - 1)]
 
@@ -64,10 +64,10 @@ def _semantic_text(value: object) -> str:
 def semantic_keywords_score(answer: str, keywords: object) -> bool:
     """
     Determine whether an answer contains every expected keyword.
-    
+
     Parameters:
         keywords (object): A nonempty list of string keywords to find in the answer.
-    
+
     Returns:
         bool: `true` if every keyword occurs in the answer, `false` otherwise.
     """
@@ -80,12 +80,12 @@ def semantic_keywords_score(answer: str, keywords: object) -> bool:
 def seal(receipt: dict[str, Any]) -> dict[str, Any]:
     """
     Add a SHA-256 digest of the receipt contents.
-    
+
     Parameters:
-    	receipt (dict[str, Any]): Receipt data to seal.
-    
+        receipt (dict[str, Any]): Receipt data to seal.
+
     Returns:
-    	dict[str, Any]: A copy of the receipt containing its digest.
+        dict[str, Any]: A copy of the receipt containing its digest.
     """
     return {**receipt, "receipt_digest": digest(receipt)}
 
@@ -93,12 +93,12 @@ def seal(receipt: dict[str, Any]) -> dict[str, Any]:
 def validate(receipt: dict[str, Any]) -> None:
     """
     Validate the schema, provenance, sample coverage, scores, latency summary, and verdict of a benchmark receipt.
-    
+
     Parameters:
-    	receipt (dict[str, Any]): Benchmark receipt to validate.
-    
+        receipt (dict[str, Any]): Benchmark receipt to validate.
+
     Raises:
-    	ValueError: If the receipt is malformed or internally inconsistent.
+        ValueError: If the receipt is malformed or internally inconsistent.
     """
     body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
     if receipt.get("schema") != SCHEMA or receipt.get("receipt_digest") != digest(body):
@@ -147,13 +147,14 @@ def validate(receipt: dict[str, Any]) -> None:
 def run(*, repetitions: int = 5) -> dict[str, Any]:
     """
     Run the scripted lifecycle benchmark repeatedly and return a sealed receipt of its results.
-    
+
     Parameters:
         repetitions (int): Number of times to execute each dataset scenario. Must be at least 2.
-    
+
     Returns:
-        dict[str, Any]: Sealed benchmark receipt containing samples, scores, latency summaries, provenance, and pass status.
-    
+        dict[str, Any]: Sealed benchmark receipt containing samples, scores, latency
+            summaries, provenance, and pass status.
+
     Raises:
         ValueError: If repetitions is less than 2.
     """
@@ -244,15 +245,15 @@ def run(*, repetitions: int = 5) -> dict[str, Any]:
 def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_ratio: float = 2.0) -> dict[str, Any]:
     """
     Compare baseline and candidate benchmark receipts against compatibility, integrity, parity, and latency gates.
-    
+
     Parameters:
         baseline (dict[str, Any]): Validated baseline benchmark receipt.
         candidate (dict[str, Any]): Validated candidate benchmark receipt.
         max_p95_ratio (float): Maximum permitted ratio of candidate to baseline p95 latency.
-    
+
     Returns:
         dict[str, Any]: Gate results and an overall pass status for the scripted lifecycle scope.
-    
+
     Raises:
         ValueError: If either receipt is invalid or the latency ratio is not finite and positive.
     """
@@ -286,7 +287,7 @@ def compare(baseline: dict[str, Any], candidate: dict[str, Any], *, max_p95_rati
 def main() -> int:
     """
     Run the benchmark or compare sealed benchmark receipts from the command line.
-    
+
     Returns:
         int: Exit status code: 0 when the operation passes, otherwise 1.
     """

--- a/scripts/benchmarks/runtime_v2_adapter_cases.json
+++ b/scripts/benchmarks/runtime_v2_adapter_cases.json
@@ -1,0 +1,140 @@
+{
+  "schema": "fleet.adapter-replay-cases/v1",
+  "cases": [
+    {
+      "id": "valid/v1",
+      "responses": [
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "expected": "submit",
+      "fleet_attempts": 1
+    },
+    {
+      "id": "empty-repair/v1",
+      "responses": [
+        "",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "invalid-json-repair/v1",
+      "responses": [
+        "not json",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "missing-field-repair/v1",
+      "responses": [
+        "{\"reasoning\":\"missing code\"}",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "second-repair/v1",
+      "responses": [
+        "",
+        "",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "expected": "submit",
+      "fleet_attempts": 3
+    },
+    {
+      "id": "parse-ceiling/v1",
+      "responses": [
+        "",
+        "",
+        ""
+      ],
+      "expected": "AdapterParseError",
+      "fleet_attempts": 3
+    },
+    {
+      "id": "reserve-exploration/v1",
+      "responses": [
+        "{\"reasoning\":\"explore\",\"code\":\"lookup()\"}",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "reserve": true,
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "reserve-parse-repair/v1",
+      "responses": [
+        "",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "reserve": true,
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "reserve-ceiling/v1",
+      "responses": [
+        "{\"reasoning\":\"explore\",\"code\":\"lookup()\"}",
+        "{\"reasoning\":\"explore\",\"code\":\"lookup()\"}"
+      ],
+      "reserve": true,
+      "expected": "TimeoutError",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "late-exploration/v1",
+      "responses": [
+        "{\"reasoning\":\"explore\",\"code\":\"lookup()\"}",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "late": true,
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "provider-retry/v1",
+      "responses": [
+        "retryable-server-error",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "provider_retries": 1,
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "schema-fallback/v1",
+      "responses": [
+        "",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "structured": true,
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "timeout-at-reserve/v1",
+      "responses": [
+        "provider-timeout",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "late": true,
+      "expected": "submit",
+      "fleet_attempts": 2
+    },
+    {
+      "id": "late-parse-repair/v1",
+      "responses": [
+        "",
+        "{\"reasoning\":\"done\",\"code\":\"SUBMIT(answer=1)\"}"
+      ],
+      "late": true,
+      "expected": "submit",
+      "fleet_attempts": 2
+    }
+  ]
+}

--- a/scripts/benchmarks/runtime_v2_scenarios.json
+++ b/scripts/benchmarks/runtime_v2_scenarios.json
@@ -1,8 +1,8 @@
 {
   "schema": "fleet.scripted-runtime-scenarios/v1",
   "scenarios": [
-    {"id": "plain-answer/v1", "text": "hello", "expected_answer": "hello"},
-    {"id": "unicode-answer/v1", "text": "Résumé: 東京", "expected_answer": "Résumé: 東京"},
-    {"id": "multiline-answer/v1", "text": "first\nsecond", "expected_answer": "first\nsecond"}
+    {"id": "plain-answer/v1", "text": "hello", "expected_answer": "hello", "semantic_keywords": ["hello"]},
+    {"id": "unicode-answer/v1", "text": "Résumé: 東京", "expected_answer": "Résumé: 東京", "semantic_keywords": ["résumé", "東京"]},
+    {"id": "multiline-answer/v1", "text": "first\nsecond", "expected_answer": "first\nsecond", "semantic_keywords": ["first", "second"]}
   ]
 }

--- a/scripts/benchmarks/runtime_v2_scenarios.json
+++ b/scripts/benchmarks/runtime_v2_scenarios.json
@@ -1,0 +1,8 @@
+{
+  "schema": "fleet.scripted-runtime-scenarios/v1",
+  "scenarios": [
+    {"id": "plain-answer/v1", "text": "hello", "expected_answer": "hello"},
+    {"id": "unicode-answer/v1", "text": "Résumé: 東京", "expected_answer": "Résumé: 東京"},
+    {"id": "multiline-answer/v1", "text": "first\nsecond", "expected_answer": "first\nsecond"}
+  ]
+}

--- a/src/fleet_rlm/app.py
+++ b/src/fleet_rlm/app.py
@@ -167,7 +167,7 @@ def create_app(
     # The certified-DSPy runtime guard runs before any other startup work so a
     # rejected runtime can never reach provider, database, or Daytona resource
     # construction, nor bind a public listener.
-    from fleet_rlm.rlm._dspy_compat import assert_dspy_version
+    from fleet_rlm.rlm.compat_3_3_1 import assert_dspy_version
 
     assert_dspy_version()
     _reject_retired_environment_variables()

--- a/src/fleet_rlm/chat/preparation.py
+++ b/src/fleet_rlm/chat/preparation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
@@ -26,6 +27,8 @@ from fleet_rlm.chat.session_context import build_session_context_manifest
 from fleet_rlm.observability.tracing import turn_phase_span
 from fleet_rlm.persistence.database import DatabaseConnectionError
 from fleet_rlm.result_snapshot import ResultSnapshotSink
+from fleet_rlm.rlm.budget import BudgetLimits, TurnBudget
+from fleet_rlm.rlm.events import AsyncToolBridge
 from fleet_rlm.rlm.program import AttachmentContextCapsule, AttachmentContextEntry, RLMModelBundle, RLMOptions
 from fleet_rlm.rlm.recursion import ChildRuntimeFactory, RecursiveRLMOptions
 from fleet_rlm.rlm.result import empty_rlm_usage
@@ -250,6 +253,9 @@ class RunEnvironment:
     # Synchronous provider fence used when the resident RLM becomes tainted.
     # This is an internal lifecycle hook; it does not cross the HTTP/SSE seam.
     mark_tainted: Callable[[], None] | None = None
+    # Composition-owned loop bridge for async host Tools invoked through
+    # DSPy's synchronous interpreter seam.
+    async_bridge: AsyncToolBridge | None = None
 
 
 class RunEnvironmentProvider(Protocol):
@@ -291,6 +297,7 @@ class DefaultRunPreparer:
         recursive_options: RecursiveRLMOptions | None = None,
         session_runtime_registry: SessionRLMRegistry | None = None,
         wrap_up_seconds: float = 300.0,
+        budget_limits: BudgetLimits | None = None,
     ) -> None:
         self._models = models
         self._options = options
@@ -299,6 +306,7 @@ class DefaultRunPreparer:
         self._capabilities = capabilities
         self._recursive_options = recursive_options or RecursiveRLMOptions()
         self._wrap_up_seconds = max(0.0, float(wrap_up_seconds))
+        self._budget_limits = budget_limits or BudgetLimits()
         self._session_runtime_registry = session_runtime_registry
 
     async def prepare(self, run: ClaimedRun, *, deadline: float) -> PreparedTurn:
@@ -454,9 +462,14 @@ class DefaultRunPreparer:
         cleanups.extend((capabilities.aclose, remove_staged))
         resources = _PreparedTurnResources(tuple(cleanups))
         try:
+            turn_budget = TurnBudget(
+                deadline=deadline if math.isfinite(deadline) else None,
+                limits=self._budget_limits,
+            )
             turn_models = self._models.bind_turn_deadline(
                 deadline=deadline,
                 reserve_seconds=self._wrap_up_seconds,
+                budget=turn_budget,
             )
         except BaseException:
             # LM copies are part of preparation ownership. If a provider
@@ -509,6 +522,7 @@ class DefaultRunPreparer:
                 deadline=deadline,
                 wrap_up_seconds=self._wrap_up_seconds,
                 environment_release=environment_release,
+                async_bridge=environment.async_bridge,
             ),
             capabilities=capabilities,
             delegation=DelegationPolicy(

--- a/src/fleet_rlm/chat/turn_runtime.py
+++ b/src/fleet_rlm/chat/turn_runtime.py
@@ -1197,6 +1197,16 @@ class TurnRuntime:
             await shield_cleanup(inline_cleanup())
 
     async def _close_execution(self, prepared: PreparedTurn, state: _ExecutionState) -> None:
+        """
+        Clean up execution resources that remain owned by the current turn.
+        
+        Parameters:
+            prepared: Prepared turn whose execution budget and resources are cleaned up.
+            state: Execution state containing the stream, heartbeat, and cleanup ownership status.
+        
+        Raises:
+            BaseException: The first error encountered during owned-resource cleanup.
+        """
         with turn_phase_span("Turn.cleanup", inputs={"cleanup_owned": not state.cleanup_handed_off}):
             await self._cancel_pending_event(state)
             await self._stop_claim_waiter(state)
@@ -1287,6 +1297,22 @@ class TurnRuntime:
         claim_loss_usage: RLMUsage | None,
         late_claim_loss_window: bool,
     ) -> BaseException | None:
+        """
+        Complete cleanup for an execution whose ownership was transferred.
+        
+        Parameters:
+            run (ClaimedRun): The claimed run being cleaned up.
+            prepared (PreparedTurn): The prepared turn and its associated resources.
+            stream (RunEventStream | None): The provider event stream, if opened.
+            heartbeat (ClaimHeartbeat | None): The claim heartbeat, if active.
+            finalization_task (asyncio.Task[RunSettlement] | None): Pending settlement task, if any.
+            claim_lost (bool): Whether claim loss has already been detected.
+            claim_loss_usage (RLMUsage | None): Usage to record when revoking a lost claim.
+            late_claim_loss_window (bool): Whether to check for claim loss after resource cleanup.
+        
+        Returns:
+            BaseException | None: The first cleanup error, or `None` if cleanup succeeds.
+        """
         cleanup_error: BaseException | None = None
         committed = False
         claim_cleanup_attempted = False
@@ -1355,7 +1381,9 @@ class TurnRuntime:
 
     @staticmethod
     def _settle_turn_budget(prepared: PreparedTurn) -> None:
-        """Close shared admission before prepared resources are released."""
+        """
+        Settle the prepared turn's execution budget before releasing its resources.
+        """
         execution_context = getattr(prepared, "execution", None)
         execution_runtime = getattr(execution_context, "execution", None)
         budget = getattr(getattr(execution_runtime, "models", None), "budget", None)
@@ -1363,6 +1391,15 @@ class TurnRuntime:
             budget.settle()
 
     def _execution_deadline(self, prepared: PreparedTurn) -> float:
+        """
+        Determine the deadline for executing a prepared turn.
+        
+        Parameters:
+            prepared (PreparedTurn): The prepared turn whose execution deadline is used.
+        
+        Returns:
+            float: The execution deadline as a monotonic clock value.
+        """
         execution_runtime = getattr(prepared.execution, "execution", None)
         if execution_runtime is not None:
             return float(execution_runtime.deadline)

--- a/src/fleet_rlm/chat/turn_runtime.py
+++ b/src/fleet_rlm/chat/turn_runtime.py
@@ -1210,6 +1210,7 @@ class TurnRuntime:
 
                 try:
                     await _close_stream_owned(state.stream, remember)
+                    self._settle_turn_budget(prepared)
                     try:
                         await shield_cleanup(prepared.aclose())
                     except BaseException as exc:
@@ -1329,6 +1330,7 @@ class TurnRuntime:
             if finalization_task is not None:
                 with contextlib.suppress(BaseException):
                     await shield_cleanup(finalization_task)
+            self._settle_turn_budget(prepared)
             try:
                 await prepared.aclose()
             except BaseException as exc:
@@ -1350,6 +1352,15 @@ class TurnRuntime:
         finally:
             await stop_heartbeat(heartbeat)
         return cleanup_error
+
+    @staticmethod
+    def _settle_turn_budget(prepared: PreparedTurn) -> None:
+        """Close shared admission before prepared resources are released."""
+        execution_context = getattr(prepared, "execution", None)
+        execution_runtime = getattr(execution_context, "execution", None)
+        budget = getattr(getattr(execution_runtime, "models", None), "budget", None)
+        if budget is not None:
+            budget.settle()
 
     def _execution_deadline(self, prepared: PreparedTurn) -> float:
         execution_runtime = getattr(prepared.execution, "execution", None)

--- a/src/fleet_rlm/chat/turn_runtime.py
+++ b/src/fleet_rlm/chat/turn_runtime.py
@@ -1199,11 +1199,11 @@ class TurnRuntime:
     async def _close_execution(self, prepared: PreparedTurn, state: _ExecutionState) -> None:
         """
         Clean up execution resources that remain owned by the current turn.
-        
+
         Parameters:
             prepared: Prepared turn whose execution budget and resources are cleaned up.
             state: Execution state containing the stream, heartbeat, and cleanup ownership status.
-        
+
         Raises:
             BaseException: The first error encountered during owned-resource cleanup.
         """
@@ -1299,7 +1299,7 @@ class TurnRuntime:
     ) -> BaseException | None:
         """
         Complete cleanup for an execution whose ownership was transferred.
-        
+
         Parameters:
             run (ClaimedRun): The claimed run being cleaned up.
             prepared (PreparedTurn): The prepared turn and its associated resources.
@@ -1309,7 +1309,7 @@ class TurnRuntime:
             claim_lost (bool): Whether claim loss has already been detected.
             claim_loss_usage (RLMUsage | None): Usage to record when revoking a lost claim.
             late_claim_loss_window (bool): Whether to check for claim loss after resource cleanup.
-        
+
         Returns:
             BaseException | None: The first cleanup error, or `None` if cleanup succeeds.
         """
@@ -1393,10 +1393,10 @@ class TurnRuntime:
     def _execution_deadline(self, prepared: PreparedTurn) -> float:
         """
         Determine the deadline for executing a prepared turn.
-        
+
         Parameters:
             prepared (PreparedTurn): The prepared turn whose execution deadline is used.
-        
+
         Returns:
             float: The execution deadline as a monotonic clock value.
         """

--- a/src/fleet_rlm/cli/main.py
+++ b/src/fleet_rlm/cli/main.py
@@ -73,7 +73,7 @@ def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> 
     # any provider, database, or Daytona resource is constructed and before any
     # listener binds. Argument parsing (and --help) stay reachable on any
     # runtime; every serving/diagnostic command is guarded.
-    from fleet_rlm.rlm._dspy_compat import UncertifiedDSpyVersionError, assert_dspy_version
+    from fleet_rlm.rlm.compat_3_3_1 import UncertifiedDSpyVersionError, assert_dspy_version
 
     try:
         assert_dspy_version()

--- a/src/fleet_rlm/cli/main.py
+++ b/src/fleet_rlm/cli/main.py
@@ -68,6 +68,13 @@ def _single_command_parser(*, program: str, command: str) -> argparse.ArgumentPa
 
 
 def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> None:
+    """
+    Parse command-line arguments and run the requested diagnostic or serving command.
+    
+    Parameters:
+        parser (argparse.ArgumentParser): Parser configured for the CLI.
+        argv (Sequence[str] | None): Arguments to parse, or None to use the process command line.
+    """
     args = parser.parse_args(argv)
     # Certified-runtime guard: fail closed with a bounded public error before
     # any provider, database, or Daytona resource is constructed and before any

--- a/src/fleet_rlm/cli/main.py
+++ b/src/fleet_rlm/cli/main.py
@@ -70,7 +70,7 @@ def _single_command_parser(*, program: str, command: str) -> argparse.ArgumentPa
 def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> None:
     """
     Parse command-line arguments and run the requested diagnostic or serving command.
-    
+
     Parameters:
         parser (argparse.ArgumentParser): Parser configured for the CLI.
         argv (Sequence[str] | None): Arguments to parse, or None to use the process command line.

--- a/src/fleet_rlm/composition/live.py
+++ b/src/fleet_rlm/composition/live.py
@@ -38,6 +38,7 @@ from fleet_rlm.daytona.session_manager import DEFAULT_IDLE_STOP_SECONDS
 from fleet_rlm.persistence.database import ensure_database_compatible
 from fleet_rlm.persistence.repositories.outbox import SqlAlchemyMemoryPromotionOutbox
 from fleet_rlm.persistence.repositories.turns import ReconciliationSummary
+from fleet_rlm.rlm.budget import BudgetLimits
 from fleet_rlm.rlm.program import RLMModelBundle, rlm_options
 from fleet_rlm.rlm.recursion import recursive_rlm_options
 from fleet_rlm.rlm.session_runtime import SessionRLMRegistry
@@ -883,6 +884,14 @@ def build_run_preparation(
         options=rlm_options(settings),
         recursive_options=recursive_rlm_options(settings),
         wrap_up_seconds=settings.rlm_wrap_up_seconds,
+        budget_limits=BudgetLimits(
+            provider_attempts=settings.rlm_max_provider_attempts,
+            tool_calls=settings.rlm_max_tool_calls,
+            recursive_children=(settings.rlm_recursion_max_calls if settings.rlm_recursion_enabled else 0),
+            execution_output_bytes=settings.rlm_max_execution_output_bytes,
+            finalization_attempts=settings.rlm_finalization_attempts,
+            finalization_seconds=settings.rlm_wrap_up_seconds,
+        ),
         attachments=attachment_lifecycle,
         environments=_DaytonaEnvironmentProvider(resources, settings, session_runtime_registry),
         capabilities=_LiveCapabilityPreparer(settings, skill_catalog, volume_paths=resources.volume_paths),

--- a/src/fleet_rlm/composition/live.py
+++ b/src/fleet_rlm/composition/live.py
@@ -465,12 +465,12 @@ async def build_daytona_composition(
 ) -> RuntimeInventory:
     """
     Construct the Daytona runtime inventory and recover cleanly from initialization failures.
-    
+
     Parameters:
         settings (Settings): Configuration used to create and validate the runtime.
         skill_catalog (SkillCatalog): Catalog of skills available to the runtime.
         dispatcher (SyncBridgeDispatcher | None): Optional dispatcher for synchronous bridge operations.
-    
+
     Returns:
         RuntimeInventory: The initialized Daytona runtime services and background tasks.
     """
@@ -884,8 +884,9 @@ def build_run_preparation(
     session_runtime_registry: SessionRLMRegistry | None = None,
 ) -> DefaultRunPreparer:
     """
-    Create a Daytona run preparer configured with models, runtime limits, attachments, environments, and live capabilities.
-    
+    Create a Daytona run preparer configured with models, runtime limits,
+    attachments, environments, and live capabilities.
+
     Parameters:
         resources (DaytonaRuntimeResources): Daytona resources used to provide run environments and volume paths.
         attachment_lifecycle (Any): Attachment lifecycle used during run preparation.
@@ -893,7 +894,7 @@ def build_run_preparation(
         settings (Settings): Runtime and budget configuration.
         models (RLMModelBundle): Models used for run execution.
         session_runtime_registry (SessionRLMRegistry | None): Optional registry for session-scoped runtime state.
-    
+
     Returns:
         DefaultRunPreparer: The configured run preparer.
     """

--- a/src/fleet_rlm/composition/live.py
+++ b/src/fleet_rlm/composition/live.py
@@ -463,7 +463,7 @@ async def build_daytona_composition(
     dispatcher: SyncBridgeDispatcher | None = None,
 ) -> RuntimeInventory:
     """Construct the Daytona runtime inventory; clean up partial init on failure."""
-    from fleet_rlm.rlm._dspy_compat import assert_dspy_version
+    from fleet_rlm.rlm.compat_3_3_1 import assert_dspy_version
 
     assert_dspy_version()
     require_daytona_settings(settings)

--- a/src/fleet_rlm/composition/live.py
+++ b/src/fleet_rlm/composition/live.py
@@ -463,7 +463,17 @@ async def build_daytona_composition(
     skill_catalog: SkillCatalog,
     dispatcher: SyncBridgeDispatcher | None = None,
 ) -> RuntimeInventory:
-    """Construct the Daytona runtime inventory; clean up partial init on failure."""
+    """
+    Construct the Daytona runtime inventory and recover cleanly from initialization failures.
+    
+    Parameters:
+        settings (Settings): Configuration used to create and validate the runtime.
+        skill_catalog (SkillCatalog): Catalog of skills available to the runtime.
+        dispatcher (SyncBridgeDispatcher | None): Optional dispatcher for synchronous bridge operations.
+    
+    Returns:
+        RuntimeInventory: The initialized Daytona runtime services and background tasks.
+    """
     from fleet_rlm.rlm.compat_3_3_1 import assert_dspy_version
 
     assert_dspy_version()
@@ -873,7 +883,20 @@ def build_run_preparation(
     models: RLMModelBundle,
     session_runtime_registry: SessionRLMRegistry | None = None,
 ) -> DefaultRunPreparer:
-    """Compose Daytona Run preparation without mutating resource ownership."""
+    """
+    Create a Daytona run preparer configured with models, runtime limits, attachments, environments, and live capabilities.
+    
+    Parameters:
+        resources (DaytonaRuntimeResources): Daytona resources used to provide run environments and volume paths.
+        attachment_lifecycle (Any): Attachment lifecycle used during run preparation.
+        skill_catalog (SkillCatalog): Skills available to live capabilities.
+        settings (Settings): Runtime and budget configuration.
+        models (RLMModelBundle): Models used for run execution.
+        session_runtime_registry (SessionRLMRegistry | None): Optional registry for session-scoped runtime state.
+    
+    Returns:
+        DefaultRunPreparer: The configured run preparer.
+    """
     from fleet_rlm.runtime.daytona.run_environment import (
         _DaytonaEnvironmentProvider,
         _LiveCapabilityPreparer,

--- a/src/fleet_rlm/composition/testing.py
+++ b/src/fleet_rlm/composition/testing.py
@@ -34,7 +34,7 @@ from fleet_rlm.composition.inventory import (
     install_runtime_inventory,
 )
 from fleet_rlm.config.settings import Settings
-from fleet_rlm.rlm._dspy_compat import assert_dspy_version
+from fleet_rlm.rlm.compat_3_3_1 import assert_dspy_version
 from fleet_rlm.rlm.program import FleetRLMSignature, RLMModelBundle, RLMOptions, rlm_options
 from fleet_rlm.rlm.recursion import RecursiveRLMOptions
 from fleet_rlm.rlm.runtime import RLMFactoryLike

--- a/src/fleet_rlm/config/loader.py
+++ b/src/fleet_rlm/config/loader.py
@@ -199,11 +199,9 @@ def _validate_policy_table(value: object, location: str, *, allow_partial_llm: b
                 )
             continue
         llm = _require_mapping(child, f"{location}.llm")
-        extras = set(llm).difference(_TABLE_KEYS["llm"])
-        if extras:
-            raise FleetConfigurationError(
-                f"unknown configuration key(s) at {location}.llm: {', '.join(sorted(extras))}"
-            )
+        unknown_roles = set(llm).difference(_TABLE_KEYS["llm"])
+        if unknown_roles:
+            raise FleetConfigurationError(f"unknown LLM role(s) at {location}.llm: {', '.join(sorted(unknown_roles))}")
         for role, role_value in llm.items():
             role_table = _require_mapping(role_value, f"{location}.llm.{role}")
             role_extras = set(role_table).difference(_ROLE_KEYS)

--- a/src/fleet_rlm/config/settings.py
+++ b/src/fleet_rlm/config/settings.py
@@ -157,6 +157,17 @@ class Settings(BaseModel):
         if unknown:
             raise FleetConfigurationError(f"unsupported Settings field(s): {', '.join(map(str, unknown))}")
 
+    runtime_variant: Annotated[
+        Literal["legacy"],
+        FleetFieldPolicy(
+            toml_path="runtime.variant",
+            group="Runtime",
+            label="Runtime variant",
+            editor="single_choice",
+            choices=("legacy",),
+            rank=72,
+        ),
+    ] = Field(default="legacy", description="Implemented execution architecture; independent of provider environment")
     app_name: Annotated[
         str,
         FleetFieldPolicy(

--- a/src/fleet_rlm/config/settings.py
+++ b/src/fleet_rlm/config/settings.py
@@ -152,7 +152,15 @@ class Settings(BaseModel):
 
     @classmethod
     def _reject_unknown_fields(cls, data: Mapping[Any, Any]) -> None:
-        """Fail on unsupported keys, naming keys only to protect secret values."""
+        """
+        Reject unsupported configuration field names.
+        
+        Parameters:
+            data (Mapping[Any, Any]): Configuration data whose keys are checked.
+        
+        Raises:
+            FleetConfigurationError: If the data contains fields not defined by the settings model.
+        """
         unknown = sorted(key for key in data if key not in cls.model_fields)
         if unknown:
             raise FleetConfigurationError(f"unsupported Settings field(s): {', '.join(map(str, unknown))}")

--- a/src/fleet_rlm/config/settings.py
+++ b/src/fleet_rlm/config/settings.py
@@ -394,6 +394,28 @@ class Settings(BaseModel):
             required_in_policy=True,
         ),
     ] = Field(default=50, gt=0)
+    rlm_max_provider_attempts: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_provider_attempts",
+            group="RLM",
+            label="Maximum provider attempts",
+            editor="number",
+            rank=73,
+            required_in_policy=True,
+        ),
+    ] = Field(default=2048, gt=0)
+    rlm_max_tool_calls: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_tool_calls",
+            group="RLM",
+            label="Maximum Tool calls",
+            editor="number",
+            rank=74,
+            required_in_policy=True,
+        ),
+    ] = Field(default=256, gt=0)
     rlm_max_output_chars: Annotated[
         int,
         FleetFieldPolicy(
@@ -416,6 +438,17 @@ class Settings(BaseModel):
             required_in_policy=True,
         ),
     ] = Field(default=4_000, gt=0)
+    rlm_max_execution_output_bytes: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.max_execution_output_bytes",
+            group="RLM",
+            label="Maximum execution output bytes",
+            editor="number",
+            rank=75,
+            required_in_policy=True,
+        ),
+    ] = Field(default=2_000_000, gt=0)
     rlm_execution_timeout_s: Annotated[
         int,
         FleetFieldPolicy(
@@ -437,6 +470,17 @@ class Settings(BaseModel):
             rank=69,
         ),
     ] = Field(default=300, gt=0)
+    rlm_finalization_attempts: Annotated[
+        int,
+        FleetFieldPolicy(
+            toml_path="rlm.finalization_attempts",
+            group="RLM",
+            label="Finalization attempts",
+            editor="number",
+            rank=76,
+            required_in_policy=True,
+        ),
+    ] = Field(default=2, ge=0)
     rlm_recursion_enabled: Annotated[
         bool,
         FleetFieldPolicy(

--- a/src/fleet_rlm/config/settings.py
+++ b/src/fleet_rlm/config/settings.py
@@ -154,10 +154,10 @@ class Settings(BaseModel):
     def _reject_unknown_fields(cls, data: Mapping[Any, Any]) -> None:
         """
         Reject unsupported configuration field names.
-        
+
         Parameters:
             data (Mapping[Any, Any]): Configuration data whose keys are checked.
-        
+
         Raises:
             FleetConfigurationError: If the data contains fields not defined by the settings model.
         """

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -135,6 +135,13 @@ def _typed_submit_source(output_fields: list[dict[str, Any]]) -> str:
                 raise ValueError(f"typed output default for {name} is not JSON-compatible")
             default_values[name] = default_json
         signature_parts.append(parameter)
+        if not required:
+            validation_parts.extend(
+                (
+                    f"if {name} is _FLEET_MISSING:",
+                    f"    {name} = _fleet_default({name!r})",
+                )
+            )
         if type_hint in {"str", "builtins.str"}:
             message = (
                 f"SUBMIT field {name} must be a string; serialize mappings/lists with "
@@ -144,13 +151,6 @@ def _typed_submit_source(output_fields: list[dict[str, Any]]) -> str:
                 (
                     f"if not isinstance({name}, str):",
                     f"    raise TypeError({message!r})",
-                )
-            )
-        if not required:
-            validation_parts.extend(
-                (
-                    f"if {name} is _FLEET_MISSING:",
-                    f"    {name} = _fleet_default({name!r})",
                 )
             )
         result_parts.append(f'"{name}": {name}')

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -1734,10 +1734,10 @@ class SyncBridgeDispatcher:
 
     def run(self, awaitable: Any) -> Any:
         """Run an awaitable on the composition-owned event loop.
-        
+
         Args:
             awaitable: The host operation to execute.
-        
+
         Returns:
             The awaitable's result.
         """
@@ -1792,12 +1792,12 @@ class _SyncBridgeLoop:
     def run(self, awaitable: Any) -> Any:
         """
         Execute an awaitable on the service event loop and wait for its result.
-        
+
         Parameters:
-        	awaitable (Any): The awaitable to execute.
-        
+                awaitable (Any): The awaitable to execute.
+
         Returns:
-        	Any: The awaitable's result.
+                Any: The awaitable's result.
         """
         if self._closed:
             if inspect.iscoroutine(awaitable):

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -1733,11 +1733,13 @@ class SyncBridgeDispatcher:
         return self._service_loop
 
     def run(self, awaitable: Any) -> Any:
-        """Await one host operation on this persistent composition loop.
-
-        DSPy invokes host Tools synchronously from a worker loop. This public
-        structural seam lets the provider-neutral RLM observer use the same
-        composition-owned loop without creating a loop or thread per call.
+        """Run an awaitable on the composition-owned event loop.
+        
+        Args:
+            awaitable: The host operation to execute.
+        
+        Returns:
+            The awaitable's result.
         """
         return _SyncBridgeLoop(caller_loop=None, dispatcher=self).run(awaitable)
 
@@ -1788,7 +1790,15 @@ class _SyncBridgeLoop:
         return self._caller_loop
 
     def run(self, awaitable: Any) -> Any:
-        """Post one awaitable on the service loop and block until it settles."""
+        """
+        Execute an awaitable on the service event loop and wait for its result.
+        
+        Parameters:
+        	awaitable (Any): The awaitable to execute.
+        
+        Returns:
+        	Any: The awaitable's result.
+        """
         if self._closed:
             if inspect.iscoroutine(awaitable):
                 awaitable.close()

--- a/src/fleet_rlm/daytona/broker.py
+++ b/src/fleet_rlm/daytona/broker.py
@@ -1732,6 +1732,15 @@ class SyncBridgeDispatcher:
         """Return the registered composition loop, if any."""
         return self._service_loop
 
+    def run(self, awaitable: Any) -> Any:
+        """Await one host operation on this persistent composition loop.
+
+        DSPy invokes host Tools synchronously from a worker loop. This public
+        structural seam lets the provider-neutral RLM observer use the same
+        composition-owned loop without creating a loop or thread per call.
+        """
+        return _SyncBridgeLoop(caller_loop=None, dispatcher=self).run(awaitable)
+
 
 class _SyncBridgeLoop:
     """Service-loop routing and close state for one synchronous Daytona bridge.
@@ -1789,6 +1798,14 @@ class _SyncBridgeLoop:
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise self._bridge_error("synchronous Daytona bridge service loop is unavailable")
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if current_loop is loop:
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise self._bridge_error("synchronous Daytona bridge called from its owning event loop")
         try:
             future = asyncio.run_coroutine_threadsafe(awaitable, loop)
         except RuntimeError as exc:

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -511,6 +511,17 @@ class DaytonaCodeInterpreter:
         execution_output_cap: int = DEFAULT_EXECUTION_OUTPUT_CHARS,
         max_code_chars: int = DEFAULT_INTERMEDIATE_CODE_CHARS,
     ) -> None:
+        """Initialize the interpreter with its backend, tools, output configuration, callbacks, and execution limits.
+        
+        Parameters:
+            backend (InterpreterBackend | None): Backend used to execute code.
+            tools (Mapping[str, Callable[..., Any]] | None): Host tools available to executed code.
+            output_fields (list[dict[str, Any]] | None): Metadata describing fields accepted in submitted final output.
+            callbacks (list[BaseCallback] | None): Optional callbacks for execution lifecycle events.
+            broker_port (int): Port used by the HTTP tool broker.
+            execution_output_cap (int): Maximum captured output size per execution.
+            max_code_chars (int): Maximum permitted size of submitted code.
+        """
         self._backend = backend
         # DSPy 3.3.1's callback contract is opt-in and engineering-only.
         # Fleet Runtime Events and manual spans remain the product/trace
@@ -572,12 +583,24 @@ class DaytonaCodeInterpreter:
         return copy_output_fields(self._output_fields)
 
     def bind_output_contract(self, contract: FleetOutputContract) -> None:
+        """
+        Bind an output contract and update the interpreter's output field metadata.
+        
+        Parameters:
+        	contract (FleetOutputContract): Contract defining the interpreter's output fields.
+        """
         self._ensure_binding_mutation_allowed()
         self._fleet_output_contract = contract
         self.output_fields = [{"name": field.name} for field in contract.fields]
 
     @output_fields.setter
     def output_fields(self, value: list[dict[str, Any]] | None) -> None:
+        """
+        Configure the output field metadata used for final-output submission.
+        
+        Parameters:
+        	value (list[dict[str, Any]] | None): Output field definitions, or `None` to clear them.
+        """
         self._ensure_binding_mutation_allowed()
         copied = copy_output_fields(value)
         if copied is not None and self._fleet_output_contract is not None:
@@ -690,7 +713,13 @@ class DaytonaCodeInterpreter:
         self._started = True
 
     def bind_observer(self, observer: ObservationObserver | None, *, max_chars: int = 10_000) -> None:
-        """Bind one run-local observer without changing interpreter execution semantics."""
+        """
+        Bind a run-local observer and configure the maximum size of observation details.
+        
+        Parameters:
+            observer: Observer that receives observation events, or ``None`` to disable observation.
+            max_chars: Maximum number of characters retained for each observation detail.
+        """
         self._ensure_binding_mutation_allowed()
         normalized_max_chars = max(1, int(max_chars))
         if self._observer is not observer or self._observation_max_chars != normalized_max_chars:
@@ -702,13 +731,26 @@ class DaytonaCodeInterpreter:
         self._no_progress_repair_used = False
 
     def bind_turn_budget(self, budget: TurnBudget | None) -> None:
-        """Bind the current Turn's shared admission ledger before execution."""
+        """
+        Bind or clear the shared budget ledger for the current turn.
+        
+        Parameters:
+        	budget (TurnBudget | None): The turn budget to use, or None to clear the binding.
+        """
         self._ensure_binding_mutation_allowed()
         self._turn_budget = budget
         self._output_budget_exhausted = False
 
     def bind_context_capsule(self, capsule: Any) -> None:
-        """Bind one host-created context capsule before DSPy starts the RLM."""
+        """
+        Bind and validate the host-created context capsule used for execution.
+        
+        Parameters:
+        	capsule (Any): Context capsule containing the sandbox manifest and trusted mount root.
+        
+        Raises:
+        	DaytonaAdapterError: If the capsule is invalid or conflicts with an existing context binding.
+        """
         from fleet_rlm.rlm.program import AttachmentContextCapsule
 
         if not isinstance(capsule, AttachmentContextCapsule):
@@ -737,6 +779,15 @@ class DaytonaCodeInterpreter:
         self._context_binding = binding
 
     def _observe(self, detail: StepStarted | RLMCode | RLMOutput | StepFinished) -> None:
+        """
+        Process an observation detail and forward it to the configured observer.
+        
+        Parameters:
+        	detail: Observation event to process.
+        
+        Raises:
+        	TurnBudgetExhausted: If the output detail exceeds the remaining execution-output budget.
+        """
         if isinstance(detail, RLMOutput) and detail.output and self._turn_budget is not None:
             if self._output_budget_exhausted:
                 return
@@ -826,20 +877,21 @@ class DaytonaCodeInterpreter:
 
     def _execute_once(self, code: str, variables: dict[str, Any] | None = None) -> Any:
         """
-        Execute one code step in the configured interpreter.
-
+        Execute one code step in the configured interpreter and process its result.
+        
         Parameters:
             code (str): Python code to execute.
             variables (dict[str, Any] | None): Variables to make available during execution.
-
+        
         Returns:
-            Any: The submitted final value or bounded ordinary execution output.
-
+            Any: The submitted final value or bounded execution output.
+        
         Raises:
             CodeExecutionError: If execution produces a recoverable error.
             CodeInterpreterError: If execution cannot safely continue.
             DaytonaAdapterError: If the interpreter is unavailable, misconfigured, shut down, or the provider fails.
             RunTerminalError: If repeated execution makes no progress.
+            TurnBudgetExhausted: If the turn budget cannot cover the execution output.
         """
         if self._shutdown:
             msg = "interpreter already shut down"

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -57,7 +57,7 @@ from fleet_rlm.daytona.interpreter_output import (
     _PublicStdoutProjector,
 )
 from fleet_rlm.observability.tracing import trace_preview_limit, turn_phase_span
-from fleet_rlm.rlm._dspy_compat import (
+from fleet_rlm.rlm.compat_3_3_1 import (
     PUBLIC_FINAL_OUTPUT_LABEL,
     CodeExecutionError,
     CodeInterpreterError,
@@ -76,6 +76,7 @@ from fleet_rlm.rlm.events import (
     ToolObserver,
     observe_tool,
 )
+from fleet_rlm.rlm.output_contract import FleetOutputContract
 from fleet_rlm.rlm.result import (
     RunNoProgressError,
     RunTerminalError,
@@ -524,6 +525,7 @@ class DaytonaCodeInterpreter:
         self._execution_started = False
         self._tools: _BindingTools = _BindingTools(self, tools)
         self._bound_tools: dict[str, Callable[..., Any]] = {}
+        self._fleet_output_contract: FleetOutputContract | None = None
         self._output_fields: list[dict[str, Any]] | None = None
         self._output_fields_digest: str | None = None
         self.output_fields = output_fields
@@ -566,10 +568,17 @@ class DaytonaCodeInterpreter:
         """Return the current typed-output metadata copy."""
         return copy_output_fields(self._output_fields)
 
+    def bind_output_contract(self, contract: FleetOutputContract) -> None:
+        self._ensure_binding_mutation_allowed()
+        self._fleet_output_contract = contract
+        self.output_fields = [{"name": field.name} for field in contract.fields]
+
     @output_fields.setter
     def output_fields(self, value: list[dict[str, Any]] | None) -> None:
         self._ensure_binding_mutation_allowed()
         copied = copy_output_fields(value)
+        if copied is not None and self._fleet_output_contract is not None:
+            copied = self._fleet_output_contract.merge(copied)
         digest = _output_fields_digest(copied)
         self._output_fields = copied
         if digest != getattr(self, "_output_fields_digest", None):

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -512,7 +512,7 @@ class DaytonaCodeInterpreter:
         max_code_chars: int = DEFAULT_INTERMEDIATE_CODE_CHARS,
     ) -> None:
         """Initialize the interpreter with its backend, tools, output configuration, callbacks, and execution limits.
-        
+
         Parameters:
             backend (InterpreterBackend | None): Backend used to execute code.
             tools (Mapping[str, Callable[..., Any]] | None): Host tools available to executed code.
@@ -585,9 +585,9 @@ class DaytonaCodeInterpreter:
     def bind_output_contract(self, contract: FleetOutputContract) -> None:
         """
         Bind an output contract and update the interpreter's output field metadata.
-        
+
         Parameters:
-        	contract (FleetOutputContract): Contract defining the interpreter's output fields.
+                contract (FleetOutputContract): Contract defining the interpreter's output fields.
         """
         self._ensure_binding_mutation_allowed()
         self._fleet_output_contract = contract
@@ -597,9 +597,9 @@ class DaytonaCodeInterpreter:
     def output_fields(self, value: list[dict[str, Any]] | None) -> None:
         """
         Configure the output field metadata used for final-output submission.
-        
+
         Parameters:
-        	value (list[dict[str, Any]] | None): Output field definitions, or `None` to clear them.
+                value (list[dict[str, Any]] | None): Output field definitions, or `None` to clear them.
         """
         self._ensure_binding_mutation_allowed()
         copied = copy_output_fields(value)
@@ -715,7 +715,7 @@ class DaytonaCodeInterpreter:
     def bind_observer(self, observer: ObservationObserver | None, *, max_chars: int = 10_000) -> None:
         """
         Bind a run-local observer and configure the maximum size of observation details.
-        
+
         Parameters:
             observer: Observer that receives observation events, or ``None`` to disable observation.
             max_chars: Maximum number of characters retained for each observation detail.
@@ -733,9 +733,9 @@ class DaytonaCodeInterpreter:
     def bind_turn_budget(self, budget: TurnBudget | None) -> None:
         """
         Bind or clear the shared budget ledger for the current turn.
-        
+
         Parameters:
-        	budget (TurnBudget | None): The turn budget to use, or None to clear the binding.
+                budget (TurnBudget | None): The turn budget to use, or None to clear the binding.
         """
         self._ensure_binding_mutation_allowed()
         self._turn_budget = budget
@@ -744,12 +744,12 @@ class DaytonaCodeInterpreter:
     def bind_context_capsule(self, capsule: Any) -> None:
         """
         Bind and validate the host-created context capsule used for execution.
-        
+
         Parameters:
-        	capsule (Any): Context capsule containing the sandbox manifest and trusted mount root.
-        
+                capsule (Any): Context capsule containing the sandbox manifest and trusted mount root.
+
         Raises:
-        	DaytonaAdapterError: If the capsule is invalid or conflicts with an existing context binding.
+                DaytonaAdapterError: If the capsule is invalid or conflicts with an existing context binding.
         """
         from fleet_rlm.rlm.program import AttachmentContextCapsule
 
@@ -781,12 +781,12 @@ class DaytonaCodeInterpreter:
     def _observe(self, detail: StepStarted | RLMCode | RLMOutput | StepFinished) -> None:
         """
         Process an observation detail and forward it to the configured observer.
-        
+
         Parameters:
-        	detail: Observation event to process.
-        
+                detail: Observation event to process.
+
         Raises:
-        	TurnBudgetExhausted: If the output detail exceeds the remaining execution-output budget.
+                TurnBudgetExhausted: If the output detail exceeds the remaining execution-output budget.
         """
         if isinstance(detail, RLMOutput) and detail.output and self._turn_budget is not None:
             if self._output_budget_exhausted:
@@ -878,14 +878,14 @@ class DaytonaCodeInterpreter:
     def _execute_once(self, code: str, variables: dict[str, Any] | None = None) -> Any:
         """
         Execute one code step in the configured interpreter and process its result.
-        
+
         Parameters:
             code (str): Python code to execute.
             variables (dict[str, Any] | None): Variables to make available during execution.
-        
+
         Returns:
             Any: The submitted final value or bounded execution output.
-        
+
         Raises:
             CodeExecutionError: If execution produces a recoverable error.
             CodeInterpreterError: If execution cannot safely continue.

--- a/src/fleet_rlm/daytona/interpreter.py
+++ b/src/fleet_rlm/daytona/interpreter.py
@@ -57,6 +57,7 @@ from fleet_rlm.daytona.interpreter_output import (
     _PublicStdoutProjector,
 )
 from fleet_rlm.observability.tracing import trace_preview_limit, turn_phase_span
+from fleet_rlm.rlm.budget import BudgetDimension, TurnBudget, TurnBudgetExhausted
 from fleet_rlm.rlm.compat_3_3_1 import (
     PUBLIC_FINAL_OUTPUT_LABEL,
     CodeExecutionError,
@@ -535,6 +536,8 @@ class DaytonaCodeInterpreter:
         self._http_broker: DaytonaHttpToolBroker | None = None
         self._observer: ObservationObserver | None = None
         self._observation_max_chars = 10_000
+        self._turn_budget: TurnBudget | None = None
+        self._output_budget_exhausted = False
         self._execution_output_cap = max(1, int(execution_output_cap))
         self._max_code_chars = max(1, int(max_code_chars))
         self._observation_step = 0
@@ -698,6 +701,12 @@ class DaytonaCodeInterpreter:
         self._last_execution = None
         self._no_progress_repair_used = False
 
+    def bind_turn_budget(self, budget: TurnBudget | None) -> None:
+        """Bind the current Turn's shared admission ledger before execution."""
+        self._ensure_binding_mutation_allowed()
+        self._turn_budget = budget
+        self._output_budget_exhausted = False
+
     def bind_context_capsule(self, capsule: Any) -> None:
         """Bind one host-created context capsule before DSPy starts the RLM."""
         from fleet_rlm.rlm.program import AttachmentContextCapsule
@@ -728,6 +737,17 @@ class DaytonaCodeInterpreter:
         self._context_binding = binding
 
     def _observe(self, detail: StepStarted | RLMCode | RLMOutput | StepFinished) -> None:
+        if isinstance(detail, RLMOutput) and detail.output and self._turn_budget is not None:
+            if self._output_budget_exhausted:
+                return
+            try:
+                self._turn_budget.reserve(
+                    BudgetDimension.EXECUTION_OUTPUT_BYTES,
+                    len(detail.output.encode("utf-8")),
+                )
+            except TurnBudgetExhausted:
+                self._output_budget_exhausted = True
+                raise
         if self._observer is None:
             return
         try:
@@ -928,6 +948,16 @@ class DaytonaCodeInterpreter:
                     outputs.update(broker_metrics)
                 phase.set_outputs(outputs)
                 return result
+            except TurnBudgetExhausted:
+                # The output reservation is the terminal boundary for this
+                # execution. The first failed reservation suppresses any
+                # additional error-frame bytes, then the domain exhaustion is
+                # propagated unchanged to the Turn runner.
+                stdout_projector.finish()
+                _close_output_stream(
+                    "Execution failed", step=step, stream_id=output_stream_id, state=output_state, observe=self._observe
+                )
+                raise
             except RunTerminalError:
                 stdout_projector.finish()
                 _close_output_stream(

--- a/src/fleet_rlm/daytona/interpreter_output.py
+++ b/src/fleet_rlm/daytona/interpreter_output.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from fleet_rlm.daytona.broker import FINAL_OUTPUT_MARKER, final_output_frame
-from fleet_rlm.rlm._dspy_compat import is_final_output
+from fleet_rlm.rlm.compat_3_3_1 import is_final_output
 from fleet_rlm.rlm.events import RLMOutput
 
 OutputCallback = Callable[[str], None]

--- a/src/fleet_rlm/optimization/routing.py
+++ b/src/fleet_rlm/optimization/routing.py
@@ -16,7 +16,7 @@ from typing import Any, Literal, cast
 
 import dspy
 
-from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
 from fleet_rlm.rlm.events import ObservationDetail, ToolCompleted, ToolFailed, ToolStarted
 from fleet_rlm.rlm.program import RLMModelBundle, RLMOptions, build_native_rlm, root_signature_for_recursion
 from fleet_rlm.rlm.recursion import (

--- a/src/fleet_rlm/persistence/database.py
+++ b/src/fleet_rlm/persistence/database.py
@@ -116,11 +116,11 @@ def _pool_kwargs_for_url(normalized_url: str) -> dict[str, object]:
 
 def create_async_engine_from_url(url: str, *, echo: bool = False) -> AsyncEngine:
     """Create a lazy asynchronous database engine from a database URL.
-    
+
     Parameters:
         url (str): Database URL to normalize and use for engine creation.
         echo (bool): Whether to enable SQL statement logging.
-    
+
     Returns:
         AsyncEngine: An asynchronous engine that enables foreign-key enforcement for SQLite connections.
     """
@@ -140,12 +140,12 @@ def create_async_engine_from_url(url: str, *, echo: bool = False) -> AsyncEngine
 
 def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     """Create an asynchronous session factory with non-expiring sessions.
-    
+
     Parameters:
-    	engine (AsyncEngine): The engine used to create database sessions.
-    
+        engine (AsyncEngine): The engine used to create database sessions.
+
     Returns:
-    	async_sessionmaker[AsyncSession]: A configured asynchronous session factory.
+        async_sessionmaker[AsyncSession]: A configured asynchronous session factory.
     """
     return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/src/fleet_rlm/persistence/database.py
+++ b/src/fleet_rlm/persistence/database.py
@@ -115,13 +115,22 @@ def _pool_kwargs_for_url(normalized_url: str) -> dict[str, object]:
 
 
 def create_async_engine_from_url(url: str, *, echo: bool = False) -> AsyncEngine:
-    """Build an async engine. Does not open connections until first use."""
+    """Create a lazy asynchronous database engine from a database URL.
+    
+    Parameters:
+        url (str): Database URL to normalize and use for engine creation.
+        echo (bool): Whether to enable SQL statement logging.
+    
+    Returns:
+        AsyncEngine: An asynchronous engine that enables foreign-key enforcement for SQLite connections.
+    """
     normalized = normalize_database_url(url)
     engine = create_async_engine(normalized, echo=echo, **_pool_kwargs_for_url(normalized))
     if engine.dialect.name == "sqlite":
 
         @event.listens_for(engine.sync_engine, "connect")
         def _enable_foreign_keys(connection, _record) -> None:
+            """Enable foreign-key enforcement for a SQLite connection."""
             cursor = connection.cursor()
             cursor.execute("PRAGMA foreign_keys=ON")
             cursor.close()
@@ -130,6 +139,14 @@ def create_async_engine_from_url(url: str, *, echo: bool = False) -> AsyncEngine
 
 
 def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """Create an asynchronous session factory with non-expiring sessions.
+    
+    Parameters:
+    	engine (AsyncEngine): The engine used to create database sessions.
+    
+    Returns:
+    	async_sessionmaker[AsyncSession]: A configured asynchronous session factory.
+    """
     return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 

--- a/src/fleet_rlm/persistence/database.py
+++ b/src/fleet_rlm/persistence/database.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import inspect, text
+from sqlalchemy import event, inspect, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import (
@@ -117,7 +117,16 @@ def _pool_kwargs_for_url(normalized_url: str) -> dict[str, object]:
 def create_async_engine_from_url(url: str, *, echo: bool = False) -> AsyncEngine:
     """Build an async engine. Does not open connections until first use."""
     normalized = normalize_database_url(url)
-    return create_async_engine(normalized, echo=echo, **_pool_kwargs_for_url(normalized))
+    engine = create_async_engine(normalized, echo=echo, **_pool_kwargs_for_url(normalized))
+    if engine.dialect.name == "sqlite":
+
+        @event.listens_for(engine.sync_engine, "connect")
+        def _enable_foreign_keys(connection, _record) -> None:
+            cursor = connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+    return engine
 
 
 def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:

--- a/src/fleet_rlm/persistence/models.py
+++ b/src/fleet_rlm/persistence/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     String,
@@ -71,6 +72,12 @@ class SessionRow(Base):
 class TurnRow(Base):
     __tablename__ = "fleet_turns"
     __table_args__ = (
+        ForeignKeyConstraint(
+            ["run_id", "session_id"],
+            ["fleet_runs.id", "fleet_runs.session_id"],
+            name="fk_fleet_turns_run_session",
+            ondelete="CASCADE",
+        ),
         UniqueConstraint("session_id", "sequence", name="uq_fleet_turns_session_sequence"),
         UniqueConstraint("run_id", "role", name="uq_fleet_turns_run_role"),
         CheckConstraint(
@@ -96,6 +103,7 @@ class TurnRow(Base):
 class RunRow(Base):
     __tablename__ = "fleet_runs"
     __table_args__ = (
+        Index("uq_fleet_runs_id_session", "id", "session_id", unique=True),
         CheckConstraint(
             "status IN ('running', 'settling', 'completed', 'failed', 'cancelled', 'timeout')",
             name="ck_fleet_runs_status",

--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -10,7 +10,7 @@ from typing import Literal
 from uuid import UUID, uuid4
 
 from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from fleet_rlm.artifacts.models import ArtifactRef
@@ -421,6 +421,23 @@ class InMemoryRunStateStore:
         )
 
 
+def _expected_claim_conflict(error: IntegrityError) -> bool:
+    """Recognize only claim uniqueness conflicts, never FK/check failures."""
+    original = error.orig
+    if getattr(original, "sqlite_errorname", None) == "SQLITE_CONSTRAINT_UNIQUE":
+        return str(original) in {
+            "UNIQUE constraint failed: fleet_runs.session_id",
+            "UNIQUE constraint failed: fleet_runs.session_id, fleet_runs.idempotency_key",
+        }
+    if getattr(original, "sqlstate", getattr(original, "pgcode", None)) != "23505":
+        return False
+    diagnostic = getattr(original, "diag", None)
+    constraint = getattr(diagnostic, "constraint_name", None)
+    if constraint is None:
+        constraint = getattr(getattr(original, "__cause__", None), "constraint_name", None)
+    return constraint in {"uq_fleet_runs_one_running", "uq_fleet_runs_live_idempotency"}
+
+
 class SqlAlchemyRunStateStore:
     """Transaction-backed authoritative Turn lifecycle state."""
 
@@ -486,6 +503,10 @@ class SqlAlchemyRunStateStore:
                     )
                 )
                 history = await self._history(db, request.session_id)
+        except IntegrityError as exc:
+            if not _expected_claim_conflict(exc):
+                raise RunLifecycleUnavailableError("Turn lifecycle is unavailable") from exc
+            return await self._reconcile_claim_conflict(request)
         except (OSError, SQLAlchemyError) as exc:
             raise RunLifecycleUnavailableError("Turn lifecycle is unavailable") from exc
 
@@ -512,6 +533,44 @@ class SqlAlchemyRunStateStore:
             cancelled,
             claim,
         )
+
+    async def _reconcile_claim_conflict(self, request: RunClaim) -> RunStart:
+        """Read the winning claim once after rollback, retaining Session authority."""
+        try:
+            async with self._sessions() as db, db.begin():
+                session = await db.scalar(
+                    select(SessionRow).where(
+                        SessionRow.id == request.session_id,
+                        SessionRow.user_id == request.access.user_id,
+                        SessionRow.workspace_id == request.access.workspace_id,
+                        SessionRow.status == "active",
+                    )
+                )
+                if session is None:
+                    raise RunNotFoundError("Turn not found")
+                prior = await db.scalar(
+                    select(RunRow)
+                    .where(
+                        RunRow.session_id == request.session_id,
+                        RunRow.idempotency_key == request.idempotency_key,
+                        RunRow.status.in_(("running", "settling", "completed")),
+                    )
+                    .order_by(RunRow.created_at.desc())
+                    .limit(1)
+                )
+                if _prior_run_needs_replay(prior, request):
+                    assert prior is not None
+                    return await self._replay(db, prior)
+                active = await db.scalar(
+                    select(RunRow.id).where(
+                        RunRow.session_id == request.session_id,
+                        RunRow.status.in_(("running", "settling")),
+                    )
+                )
+                _reject_active_run(active is not None)
+        except (OSError, SQLAlchemyError) as exc:
+            raise RunLifecycleUnavailableError("Turn lifecycle is unavailable") from exc
+        raise RunLifecycleUnavailableError("Turn lifecycle is unavailable")
 
     async def commit(
         self,

--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -339,13 +339,15 @@ class InMemoryRunStateStore:
     ) -> ReconciliationSummary:
         """
         Recover running or settling claims from a prior process.
-        
+
         Parameters:
-        	fence (Callable[[UUID], Awaitable[None]] | None): Optional callback used to verify provider state before recovery.
-        	deadline (float | None): Optional monotonic-time deadline for bounded recovery.
-        
+                fence (Callable[[UUID], Awaitable[None]] | None): Optional callback used to
+                    verify provider state before recovery.
+                deadline (float | None): Optional monotonic-time deadline for bounded recovery.
+
         Returns:
-        	ReconciliationSummary: Counts recovery candidates, successful recoveries, fence failures, skipped runs, and deadline exhaustion.
+                ReconciliationSummary: Counts recovery candidates, successful recoveries,
+                    fence failures, skipped runs, and deadline exhaustion.
         """
         async with self._lock:
             pending = [
@@ -433,12 +435,12 @@ class InMemoryRunStateStore:
 def _expected_claim_conflict(error: IntegrityError) -> bool:
     """
     Determines whether a database integrity error represents a supported claim uniqueness conflict.
-    
+
     Parameters:
-    	error (IntegrityError): The database integrity error to classify.
-    
+        error (IntegrityError): The database integrity error to classify.
+
     Returns:
-    	bool: `true` if the error represents a supported claim uniqueness conflict, `false` otherwise.
+        bool: `true` if the error represents a supported claim uniqueness conflict, `false` otherwise.
     """
     original = error.orig
     if getattr(original, "sqlite_errorname", None) == "SQLITE_CONSTRAINT_UNIQUE":
@@ -479,17 +481,18 @@ class SqlAlchemyRunStateStore:
     async def begin(self, request: RunClaim) -> RunStart:
         """
         Start a run for an active session, reusing an eligible prior run when applicable.
-        
+
         Parameters:
-        	request (RunClaim): Claim request containing the session, access credentials, proposed run identity, idempotency key, and input.
-        
+                request (RunClaim): Claim request containing the session, access
+                    credentials, proposed run identity, idempotency key, and input.
+
         Returns:
-        	RunStart: A claimed run with session history and a cancellation-status callback.
-        
+                RunStart: A claimed run with session history and a cancellation-status callback.
+
         Raises:
-        	RunNotFoundError: If the session is missing or inactive.
-        	RunLifecycleUnavailableError: If the lifecycle store is unavailable or claim reconciliation fails.
-        	DatabaseConnectionError: If cancellation status cannot be probed after the configured retries.
+                RunNotFoundError: If the session is missing or inactive.
+                RunLifecycleUnavailableError: If the lifecycle store is unavailable or claim reconciliation fails.
+                DatabaseConnectionError: If cancellation status cannot be probed after the configured retries.
         """
         try:
             async with self._sessions() as db, db.begin():
@@ -573,16 +576,16 @@ class SqlAlchemyRunStateStore:
     async def _reconcile_claim_conflict(self, request: RunClaim) -> RunStart:
         """
         Reconciles a claim conflict by reloading the authoritative session and winning run.
-        
+
         Parameters:
-        	request (RunClaim): Claim request used to identify the session and idempotent run.
-        
+                request (RunClaim): Claim request used to identify the session and idempotent run.
+
         Returns:
-        	RunStart: Replay of the previously completed run.
-        
+                RunStart: Replay of the previously completed run.
+
         Raises:
-        	RunNotFoundError: If the session is missing, inactive, or inaccessible.
-        	RunLifecycleUnavailableError: If the winning claim cannot be found or the database is unavailable.
+                RunNotFoundError: If the session is missing, inactive, or inaccessible.
+                RunLifecycleUnavailableError: If the winning claim cannot be found or the database is unavailable.
         """
         try:
             async with self._sessions() as db, db.begin():
@@ -628,18 +631,18 @@ class SqlAlchemyRunStateStore:
         memory_intents: tuple[MemoryPromotionIntent, ...] = (),
     ) -> CommittedTurnReceipt:
         """Persist the committed result and artifacts for a claimed turn.
-        
+
         Parameters:
-        	run (ClaimedRun): The active turn claim authorizing the commit.
-        	committed (CommittedTurn): The completed turn data.
-        	artifacts (tuple[PromotedArtifact, ...]): Artifacts to associate with the turn.
-        	memory_intents (tuple[MemoryPromotionIntent, ...]): Memory promotion intents associated with the turn.
-        
+                run (ClaimedRun): The active turn claim authorizing the commit.
+                committed (CommittedTurn): The completed turn data.
+                artifacts (tuple[PromotedArtifact, ...]): Artifacts to associate with the turn.
+                memory_intents (tuple[MemoryPromotionIntent, ...]): Memory promotion intents associated with the turn.
+
         Returns:
-        	CommittedTurnReceipt: The receipt for the committed turn.
-        
+                CommittedTurnReceipt: The receipt for the committed turn.
+
         Raises:
-        	RunStateError: If the claim authority has been revoked.
+                RunStateError: If the claim authority has been revoked.
         """
         if run.authority.revoked:
             raise RunStateError("Turn claim is invalid")

--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -337,7 +337,16 @@ class InMemoryRunStateStore:
         *,
         deadline: float | None = None,
     ) -> ReconciliationSummary:
-        """Recover prior-process claims with the same bounded policy as SQL."""
+        """
+        Recover running or settling claims from a prior process.
+        
+        Parameters:
+        	fence (Callable[[UUID], Awaitable[None]] | None): Optional callback used to verify provider state before recovery.
+        	deadline (float | None): Optional monotonic-time deadline for bounded recovery.
+        
+        Returns:
+        	ReconciliationSummary: Counts recovery candidates, successful recoveries, fence failures, skipped runs, and deadline exhaustion.
+        """
         async with self._lock:
             pending = [
                 (run.run_id, run.session_id, run.status, run.claim)
@@ -422,7 +431,15 @@ class InMemoryRunStateStore:
 
 
 def _expected_claim_conflict(error: IntegrityError) -> bool:
-    """Recognize only claim uniqueness conflicts, never FK/check failures."""
+    """
+    Determines whether a database integrity error represents a supported claim uniqueness conflict.
+    
+    Parameters:
+    	error (IntegrityError): The database integrity error to classify.
+    
+    Returns:
+    	bool: `true` if the error represents a supported claim uniqueness conflict, `false` otherwise.
+    """
     original = error.orig
     if getattr(original, "sqlite_errorname", None) == "SQLITE_CONSTRAINT_UNIQUE":
         return str(original) in {
@@ -460,6 +477,20 @@ class SqlAlchemyRunStateStore:
         self._stale_after = stale_after_seconds
 
     async def begin(self, request: RunClaim) -> RunStart:
+        """
+        Start a run for an active session, reusing an eligible prior run when applicable.
+        
+        Parameters:
+        	request (RunClaim): Claim request containing the session, access credentials, proposed run identity, idempotency key, and input.
+        
+        Returns:
+        	RunStart: A claimed run with session history and a cancellation-status callback.
+        
+        Raises:
+        	RunNotFoundError: If the session is missing or inactive.
+        	RunLifecycleUnavailableError: If the lifecycle store is unavailable or claim reconciliation fails.
+        	DatabaseConnectionError: If cancellation status cannot be probed after the configured retries.
+        """
         try:
             async with self._sessions() as db, db.begin():
                 session = await db.scalar(
@@ -540,7 +571,19 @@ class SqlAlchemyRunStateStore:
         )
 
     async def _reconcile_claim_conflict(self, request: RunClaim) -> RunStart:
-        """Read the winning claim once after rollback, retaining Session authority."""
+        """
+        Reconciles a claim conflict by reloading the authoritative session and winning run.
+        
+        Parameters:
+        	request (RunClaim): Claim request used to identify the session and idempotent run.
+        
+        Returns:
+        	RunStart: Replay of the previously completed run.
+        
+        Raises:
+        	RunNotFoundError: If the session is missing, inactive, or inaccessible.
+        	RunLifecycleUnavailableError: If the winning claim cannot be found or the database is unavailable.
+        """
         try:
             async with self._sessions() as db, db.begin():
                 session = await db.scalar(
@@ -584,6 +627,20 @@ class SqlAlchemyRunStateStore:
         artifacts: tuple[PromotedArtifact, ...],
         memory_intents: tuple[MemoryPromotionIntent, ...] = (),
     ) -> CommittedTurnReceipt:
+        """Persist the committed result and artifacts for a claimed turn.
+        
+        Parameters:
+        	run (ClaimedRun): The active turn claim authorizing the commit.
+        	committed (CommittedTurn): The completed turn data.
+        	artifacts (tuple[PromotedArtifact, ...]): Artifacts to associate with the turn.
+        	memory_intents (tuple[MemoryPromotionIntent, ...]): Memory promotion intents associated with the turn.
+        
+        Returns:
+        	CommittedTurnReceipt: The receipt for the committed turn.
+        
+        Raises:
+        	RunStateError: If the claim authority has been revoked.
+        """
         if run.authority.revoked:
             raise RunStateError("Turn claim is invalid")
         async with self._sessions() as db, db.begin():

--- a/src/fleet_rlm/persistence/repositories/turns.py
+++ b/src/fleet_rlm/persistence/repositories/turns.py
@@ -431,8 +431,13 @@ def _expected_claim_conflict(error: IntegrityError) -> bool:
         }
     if getattr(original, "sqlstate", getattr(original, "pgcode", None)) != "23505":
         return False
-    diagnostic = getattr(original, "diag", None)
-    constraint = getattr(diagnostic, "constraint_name", None)
+    # asyncpg exposes the constraint name directly on the driver exception;
+    # SQLAlchemy/other adapters may retain it under ``diag`` or ``__cause__``.
+    # Check the real asyncpg shape first, then keep the compatibility fallbacks.
+    constraint = getattr(original, "constraint_name", None)
+    if constraint is None:
+        diagnostic = getattr(original, "diag", None)
+        constraint = getattr(diagnostic, "constraint_name", None)
     if constraint is None:
         constraint = getattr(getattr(original, "__cause__", None), "constraint_name", None)
     return constraint in {"uq_fleet_runs_one_running", "uq_fleet_runs_live_idempotency"}

--- a/src/fleet_rlm/rlm/_dspy_compat.py
+++ b/src/fleet_rlm/rlm/_dspy_compat.py
@@ -11,7 +11,7 @@ import contextlib
 import json
 import logging
 import time
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Generator, Mapping, Sequence
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
@@ -391,18 +391,71 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        """
-        Execute the stock JSONAdapter pipeline with a bounded corrective re-ask.
+        """Drive the shared repair policy through the stock DSPy adapter."""
+        machine = self._repair_steps(lm, lm_kwargs, signature, inputs)
+        try:
+            request = next(machine)
+            while True:
+                call_kwargs, request_signature, request_inputs = request
+                try:
+                    response = super().__call__(lm, call_kwargs, request_signature, demos, request_inputs)
+                except (AdapterParseError, LMTimeoutError, TimeoutError) as exc:
+                    try:
+                        request = machine.throw(exc)
+                    except StopIteration as done:
+                        return done.value
+                else:
+                    try:
+                        request = machine.send(response)
+                    except StopIteration as done:
+                        return done.value
+        finally:
+            machine.close()
 
-        Parameters:
-            lm (BaseLM): The language model instance to use for generation.
-            lm_kwargs (dict[str, Any]): Additional keyword arguments for the LM call.
-            signature (type[Signature]): The DSPy signature for this call.
-            demos (list[dict[str, Any]]): Few-shot examples included in the prompt.
-            inputs (dict[str, Any]): The current input values for this call.
+    async def acall(
+        self,
+        lm: BaseLM,
+        lm_kwargs: dict[str, Any],
+        signature: type[Signature],
+        demos: list[dict[str, Any]],
+        inputs: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Drive the shared repair policy through the stock DSPy adapter."""
+        machine = self._repair_steps(lm, lm_kwargs, signature, inputs)
+        try:
+            request = next(machine)
+            while True:
+                call_kwargs, request_signature, request_inputs = request
+                try:
+                    response = await super().acall(lm, call_kwargs, request_signature, demos, request_inputs)
+                except (AdapterParseError, LMTimeoutError, TimeoutError) as exc:
+                    try:
+                        request = machine.throw(exc)
+                    except StopIteration as done:
+                        return done.value
+                else:
+                    try:
+                        request = machine.send(response)
+                    except StopIteration as done:
+                        return done.value
+        finally:
+            machine.close()
 
-        Returns:
-            list[dict[str, Any]]: Parsed responses keyed by the signature output fields.
+    def _repair_steps(
+        self,
+        lm: BaseLM,
+        lm_kwargs: dict[str, Any],
+        signature: type[Signature],
+        inputs: dict[str, Any],
+    ) -> Generator[
+        tuple[dict[str, Any], type[Signature], dict[str, Any]],
+        list[dict[str, Any]],
+        list[dict[str, Any]],
+    ]:
+        """Yield requests and consume responses/errors without owning provider I/O.
+
+        Both drivers close the machine on failure or cancellation. All repair,
+        reserve-transition, and finalization grammar decisions live here.
         """
         attempt = 0
         base_signature = signature
@@ -434,7 +487,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                 action=action,
             )
             try:
-                response = super().__call__(lm, call_kwargs, request_signature, demos, request_inputs)
+                response = yield call_kwargs, request_signature, request_inputs
             except (LMTimeoutError, TimeoutError):
                 if not wrap_up and action and self._wrap_up_seconds > 0:
                     boundary_remaining = self._remaining()
@@ -504,141 +557,6 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                         # wrap-up grammar. Execute it as the initial
                         # final-answer attempt instead of spending reserve
                         # time on an unnecessary re-ask.
-                        return response
-                    request_signature, request_inputs, directive_field = self._with_wrap_up_directive(
-                        request_signature,
-                        request_inputs,
-                        after_response,
-                        field_name=directive_field,
-                    )
-                if wrap_up and action and not is_submit_only_code(_action_code(response)):
-                    self._wrap_up_rejection_reason = "exploration_or_additional_code"
-                    if self._wrap_up_attempts >= 2:
-                        raise TimeoutError("wrap-up action did not submit before the Turn deadline")
-                    request_signature, request_inputs = self._with_wrap_up_correction(
-                        request_signature,
-                        request_inputs,
-                        reason="exploration or additional code",
-                    )
-                    continue
-                return response
-            return response
-
-    async def acall(
-        self,
-        lm: BaseLM,
-        lm_kwargs: dict[str, Any],
-        signature: type[Signature],
-        demos: list[dict[str, Any]],
-        inputs: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        """
-        Execute the stock JSONAdapter pipeline with a bounded corrective re-ask.
-
-        Parameters:
-            lm (BaseLM): The language model instance to use for generation.
-            lm_kwargs (dict[str, Any]): Additional keyword arguments for the LM call.
-            signature (type[Signature]): The DSPy signature for this call.
-            demos (list[dict[str, Any]]): Few-shot examples included in the prompt.
-            inputs (dict[str, Any]): The current input values for this call.
-
-        Returns:
-            list[dict[str, Any]]: Parsed responses keyed by the signature output fields.
-        """
-        attempt = 0
-        base_signature = signature
-        base_inputs = dict(inputs)
-        wrap_up = False
-        request_signature = signature
-        request_inputs = dict(inputs)
-        directive_field: str | None = None
-        while True:
-            remaining = self._remaining()
-            action = _iteration_is_action(base_inputs)
-            if action and self._wrap_up_required(base_inputs, remaining):
-                wrap_up = True
-                assert remaining is not None
-                self._enter_wrap_up(remaining)
-            if wrap_up and remaining is not None:
-                request_signature, request_inputs, directive_field = self._with_wrap_up_directive(
-                    request_signature,
-                    request_inputs,
-                    remaining,
-                    field_name=directive_field,
-                )
-                self._next_wrap_up_attempt()
-            call_kwargs = self._call_kwargs(
-                lm,
-                lm_kwargs,
-                remaining=remaining,
-                wrap_up=wrap_up,
-                action=action,
-            )
-            try:
-                response = await super().acall(lm, call_kwargs, request_signature, demos, request_inputs)
-            except (LMTimeoutError, TimeoutError):
-                if not wrap_up and action and self._wrap_up_seconds > 0:
-                    boundary_remaining = self._remaining()
-                    if boundary_remaining is not None and boundary_remaining <= self._wrap_up_seconds:
-                        wrap_up = True
-                        self._enter_wrap_up(boundary_remaining)
-                        request_signature, request_inputs, directive_field = self._with_wrap_up_directive(
-                            request_signature,
-                            request_inputs,
-                            boundary_remaining,
-                            field_name=directive_field,
-                        )
-                        continue
-                raise
-            except AdapterParseError as exc:
-                if wrap_up:
-                    if self._wrap_up_attempts >= 2:
-                        raise TimeoutError("wrap-up action was not parseable before the Turn deadline") from exc
-                    self._wrap_up_rejection_reason = "unparseable_json"
-                    request_signature, request_inputs = self._with_wrap_up_correction(
-                        request_signature,
-                        request_inputs,
-                        reason="unparseable JSON",
-                    )
-                    continue
-                if action and self._wrap_up_seconds > 0:
-                    # Keep parse corrections that cross the reserve boundary
-                    # inside the same two-attempt wrap-up budget as action
-                    # corrections.
-                    boundary_remaining = self._remaining()
-                    if boundary_remaining is not None and boundary_remaining <= self._wrap_up_seconds:
-                        wrap_up = True
-                        self._enter_wrap_up(boundary_remaining, rejection_reason="unparseable_json")
-                        self._next_wrap_up_attempt()
-                        request_signature, request_inputs, directive_field = self._with_wrap_up_directive(
-                            request_signature,
-                            request_inputs,
-                            boundary_remaining,
-                            field_name=directive_field,
-                        )
-                        request_signature, request_inputs = self._with_wrap_up_correction(
-                            request_signature,
-                            request_inputs,
-                            reason="unparseable JSON",
-                        )
-                        continue
-                if attempt >= self._max_parse_retries:
-                    raise
-                attempt += 1
-                request_signature, request_inputs = _retry_call_arguments(
-                    base_signature,
-                    base_inputs,
-                    attempt,
-                    exc,
-                )
-                continue
-            if remaining is not None:
-                after_response = self._remaining()
-                if not wrap_up and action and after_response is not None and after_response <= self._wrap_up_seconds:
-                    wrap_up = True
-                    self._enter_wrap_up(after_response)
-                    self._next_wrap_up_attempt()
-                    if is_submit_only_code(_action_code(response)):
                         return response
                     request_signature, request_inputs, directive_field = self._with_wrap_up_directive(
                         request_signature,

--- a/src/fleet_rlm/rlm/_dspy_compat.py
+++ b/src/fleet_rlm/rlm/_dspy_compat.py
@@ -7,7 +7,6 @@ than importing private or version-sensitive DSPy mechanics directly.
 
 from __future__ import annotations
 
-import ast
 import contextlib
 import json
 import logging
@@ -28,6 +27,7 @@ from dspy.utils.exceptions import AdapterParseError, LMTimeoutError
 
 from fleet_rlm.json_types import JsonValue
 from fleet_rlm.rlm.result import _safe_usage_entry, sanitize_public_text, truncate_public_text
+from fleet_rlm.rlm.submit_validation import is_submit_only_code
 
 logger = logging.getLogger(__name__)
 
@@ -173,136 +173,6 @@ def _retry_call_arguments(
     retry_inputs = dict(inputs)
     retry_inputs[correction_field] = _retry_correction_feedback(attempt, exc)
     return retry_signature, retry_inputs
-
-
-_SAFE_SUBMIT_CALLS = frozenset(
-    {
-        "str",
-        "repr",
-        "int",
-        "float",
-        "bool",
-        "len",
-        "min",
-        "max",
-        "sum",
-        "round",
-        "sorted",
-        "json.dumps",
-    }
-)
-
-_PYTHON_FENCE_LANGS = frozenset({"", "python", "py"})
-
-
-def _qualified_ast_name(node: ast.AST) -> str | None:
-    """Return a dotted name for a simple AST name/attribute expression."""
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        parent = _qualified_ast_name(node.value)
-        return f"{parent}.{node.attr}" if parent else None
-    return None
-
-
-def _strip_action_code_fences(code: str) -> str:
-    """Mirror DSPy's public action fence handling for wrap-up validation.
-
-    Native RLM actions are commonly emitted in a Python markdown fence and
-    DSPy strips that fence before execution. Validation must inspect the same
-    executable text, while still rejecting an explicit non-Python fence.
-    """
-    text = code.strip()
-    if "```" not in text:
-        return text
-    lines = text.splitlines()
-    while len(lines) >= 2 and lines[0].strip() == "```" and lines[-1].strip() == "```":
-        lines.pop(0)
-        lines.pop()
-    text = "\n".join(lines).strip()
-    if "```" not in text:
-        return text
-    fence_start = text.find("```")
-    lang_line, separator, remainder = text[fence_start + 3 :].partition("\n")
-    if not separator:
-        return text
-    lang = (lang_line.strip().split(maxsplit=1)[0] if lang_line.strip() else "").lower()
-    if lang not in _PYTHON_FENCE_LANGS:
-        return text
-    block_end = remainder.find("```")
-    if block_end == -1:
-        return remainder.strip()
-    return remainder[:block_end].strip()
-
-
-def _is_safe_submit_value(node: ast.AST) -> bool:
-    """Allow only data expressions that cannot launch another action."""
-    if isinstance(node, (ast.Constant, ast.Name)):
-        return True
-    if isinstance(node, ast.JoinedStr):
-        return all(_is_safe_submit_value(value) for value in node.values)
-    if isinstance(node, ast.FormattedValue):
-        return _is_safe_submit_value(node.value) and (
-            node.format_spec is None or _is_safe_submit_value(node.format_spec)
-        )
-    if isinstance(node, ast.Attribute):
-        return not node.attr.startswith("_") and _is_safe_submit_value(node.value)
-    if isinstance(node, ast.Subscript):
-        return _is_safe_submit_value(node.value) and _is_safe_submit_value(node.slice)
-    if isinstance(node, ast.Slice):
-        return all(part is None or _is_safe_submit_value(part) for part in (node.lower, node.upper, node.step))
-    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
-        return all(_is_safe_submit_value(item) for item in node.elts)
-    if isinstance(node, ast.Dict):
-        return all(
-            key is not None and _is_safe_submit_value(key) and _is_safe_submit_value(value)
-            for key, value in zip(node.keys, node.values, strict=True)
-        )
-    if isinstance(node, ast.Call):
-        if _qualified_ast_name(node.func) not in _SAFE_SUBMIT_CALLS:
-            return False
-        if any(isinstance(argument, ast.Starred) for argument in node.args):
-            return False
-        if any(keyword.arg is None for keyword in node.keywords):
-            return False
-        return all(_is_safe_submit_value(argument) for argument in node.args) and all(
-            _is_safe_submit_value(keyword.value) for keyword in node.keywords
-        )
-    if isinstance(node, ast.UnaryOp):
-        return _is_safe_submit_value(node.operand)
-    if isinstance(node, ast.BinOp):
-        return _is_safe_submit_value(node.left) and _is_safe_submit_value(node.right)
-    if isinstance(node, ast.BoolOp):
-        return all(_is_safe_submit_value(value) for value in node.values)
-    if isinstance(node, ast.Compare):
-        return _is_safe_submit_value(node.left) and all(_is_safe_submit_value(item) for item in node.comparators)
-    if isinstance(node, ast.IfExp):
-        return (
-            _is_safe_submit_value(node.test) and _is_safe_submit_value(node.body) and _is_safe_submit_value(node.orelse)
-        )
-    return False
-
-
-def _is_submit_only_code(code: object) -> bool:
-    """Validate the bounded, side-effect-free action allowed in wrap-up mode."""
-    if not isinstance(code, str):
-        return False
-    try:
-        module = ast.parse(_strip_action_code_fences(code), mode="exec")
-    except SyntaxError:
-        return False
-    if len(module.body) != 1 or not isinstance(module.body[0], ast.Expr):
-        return False
-    expression = module.body[0].value
-    if (
-        not isinstance(expression, ast.Call)
-        or not isinstance(expression.func, ast.Name)
-        or expression.func.id != "SUBMIT"
-    ):
-        return False
-    if expression.args or any(keyword.arg is None for keyword in expression.keywords):
-        return False
-    return all(_is_safe_submit_value(keyword.value) for keyword in expression.keywords)
 
 
 def _iteration_is_action(inputs: Mapping[str, Any]) -> bool:
@@ -629,7 +499,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                     wrap_up = True
                     self._enter_wrap_up(after_response)
                     self._next_wrap_up_attempt()
-                    if _is_submit_only_code(_action_code(response)):
+                    if is_submit_only_code(_action_code(response)):
                         # The late normal response already satisfies the
                         # wrap-up grammar. Execute it as the initial
                         # final-answer attempt instead of spending reserve
@@ -641,7 +511,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                         after_response,
                         field_name=directive_field,
                     )
-                if wrap_up and action and not _is_submit_only_code(_action_code(response)):
+                if wrap_up and action and not is_submit_only_code(_action_code(response)):
                     self._wrap_up_rejection_reason = "exploration_or_additional_code"
                     if self._wrap_up_attempts >= 2:
                         raise TimeoutError("wrap-up action did not submit before the Turn deadline")
@@ -768,7 +638,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                     wrap_up = True
                     self._enter_wrap_up(after_response)
                     self._next_wrap_up_attempt()
-                    if _is_submit_only_code(_action_code(response)):
+                    if is_submit_only_code(_action_code(response)):
                         return response
                     request_signature, request_inputs, directive_field = self._with_wrap_up_directive(
                         request_signature,
@@ -776,7 +646,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                         after_response,
                         field_name=directive_field,
                     )
-                if wrap_up and action and not _is_submit_only_code(_action_code(response)):
+                if wrap_up and action and not is_submit_only_code(_action_code(response)):
                     self._wrap_up_rejection_reason = "exploration_or_additional_code"
                     if self._wrap_up_attempts >= 2:
                         raise TimeoutError("wrap-up action did not submit before the Turn deadline")

--- a/src/fleet_rlm/rlm/budget.py
+++ b/src/fleet_rlm/rlm/budget.py
@@ -23,6 +23,12 @@ class BudgetDimension(StrEnum):
 
 class TurnBudgetExhausted(RuntimeError):  # noqa: N818 - domain exhaustion category
     def __init__(self, dimension: BudgetDimension) -> None:
+        """
+        Initialize an exception identifying the exhausted turn-budget dimension.
+        
+        Parameters:
+        	dimension (BudgetDimension): The budget dimension that has been exhausted.
+        """
         self.dimension = dimension
         super().__init__(f"Turn budget exhausted: {dimension.value}")
 
@@ -41,6 +47,14 @@ class BudgetLimits:
     finalization_seconds: float = 0.0
 
     def __post_init__(self) -> None:
+        """
+        Validate budget limits and finalization configuration.
+        
+        Raises:
+            ValueError: If a count limit is not a nonnegative integer, finalization
+                seconds is not finite and nonnegative, or finalization attempts exceed
+                the provider-attempt limit.
+        """
         for value in (
             self.provider_attempts,
             self.tool_calls,
@@ -75,6 +89,16 @@ class TurnBudget:
     """
 
     def __init__(self, *, deadline: float | None, limits: BudgetLimits | None = None) -> None:
+        """
+        Initialize a turn budget with an optional deadline and resource limits.
+        
+        Parameters:
+            deadline (float | None): Finite absolute deadline, or None for no deadline.
+            limits (BudgetLimits | None): Resource and finalization limits for the turn.
+        
+        Raises:
+            ValueError: If deadline is not a finite number or None.
+        """
         if deadline is not None and (
             not isinstance(deadline, (int, float)) or isinstance(deadline, bool) or not math.isfinite(deadline)
         ):
@@ -99,7 +123,21 @@ class TurnBudget:
         *,
         finalization: bool = False,
     ) -> float:
-        """Debit atomically and return remaining time for the admitted operation."""
+        """
+        Atomically admit an operation against a budget dimension and report its remaining time.
+        
+        Parameters:
+            dimension (BudgetDimension): Resource dimension to charge.
+            count (int): Amount to charge.
+            finalization (bool): Whether the provider-attempt reservation uses finalization capacity.
+        
+        Returns:
+            float: Time remaining for the admitted operation.
+        
+        Raises:
+            ValueError: If the dimension is not reservable or count is not a nonnegative integer.
+            TurnBudgetExhausted: If the reservation exceeds a budget limit or available deadline.
+        """
         if dimension not in self._used:
             raise ValueError("dimension is not a reservable counter")
         if type(count) is not int or count < 0:
@@ -123,6 +161,18 @@ class TurnBudget:
             return remaining
 
     def _remaining(self, *, finalization: bool) -> float:
+        """
+        Calculate the time available for an operation.
+        
+        Parameters:
+            finalization (bool): Whether the operation is a finalization attempt.
+        
+        Returns:
+            float: Available time in seconds.
+        
+        Raises:
+            TurnBudgetExhausted: If the budget is settled or the available time is exhausted.
+        """
         if self._settled:
             raise TurnBudgetExhausted(BudgetDimension.SETTLED)
         remaining = math.inf if self.deadline is None else self.deadline - time.monotonic()
@@ -133,11 +183,29 @@ class TurnBudget:
         return remaining
 
     def remaining(self, *, finalization: bool = False) -> float:
+        """
+        Determine the time available for an operation.
+        
+        Parameters:
+            finalization (bool): Whether the operation is a finalization attempt.
+        
+        Returns:
+            float: Available seconds for the operation.
+        """
         with self._lock:
             return self._remaining(finalization=finalization)
 
     def reclassify_finalization(self, count: int = 1) -> None:
-        """Consume finalization capacity for an already-admitted response."""
+        """
+        Consume finalization capacity for an already-admitted response.
+        
+        Parameters:
+        	count (int): Number of finalization attempts to consume.
+        
+        Raises:
+        	ValueError: If count is not a nonnegative integer.
+        	TurnBudgetExhausted: If the deadline or finalization-attempt limit is exhausted.
+        """
         if type(count) is not int or count < 0:
             raise ValueError("reclassification count must be a nonnegative integer")
         with self._lock:
@@ -148,7 +216,13 @@ class TurnBudget:
             self._finalization_attempts += count
 
     def exploration_exhausted(self) -> bool:
-        """Whether an explicit provider reserve has fenced further exploration."""
+        """
+        Determine whether provider exploration has exhausted its available capacity.
+        
+        Returns:
+            bool: `True` if the provider-attempt limit or exploration capacity before the
+                finalization reserve has been reached, `False` otherwise.
+        """
         with self._lock:
             limit = self.limits.provider_attempts
             finalization_reserve = self.limits.finalization_attempts or 0
@@ -158,6 +232,12 @@ class TurnBudget:
             )
 
     def snapshot(self) -> dict[str, int]:
+        """
+        Return the current usage counts for each tracked budget dimension.
+        
+        Returns:
+        	dict[str, int]: A mapping from budget dimension names to their consumed counts.
+        """
         with self._lock:
             return {dimension.value: count for dimension, count in self._used.items()}
 
@@ -185,6 +265,19 @@ class AdapterBudget:
         turn: TurnBudget | None = None,
     ) -> None:
         # Existing preparation-only seams use +inf for an unbounded invocation.
+        """
+        Initialize invocation-local budget and finalization policies.
+        
+        Parameters:
+            deadline (float | None): Absolute deadline for the invocation; positive infinity means unbounded.
+            reserve_seconds (float): Time reserved for finalization.
+            max_parse_retries (int): Maximum number of parse-repair retries.
+            max_finalization_attempts (int): Maximum number of finalization attempts.
+            turn (TurnBudget | None): Shared turn budget, or a new budget when omitted.
+        
+        Raises:
+            ValueError: If a numeric limit is invalid, negative, non-finite where prohibited, or not an integer where required.
+        """
         if deadline == math.inf:
             deadline = None
         if deadline is not None and (
@@ -213,6 +306,15 @@ class AdapterBudget:
         self._lock = Lock()
 
     def remaining(self) -> float | None:
+        """
+        Determine the time remaining for the current invocation.
+        
+        Returns:
+            float | None: Available time in seconds, or `None` when the deadline is unbounded.
+        
+        Raises:
+            TimeoutError: If the turn or invocation deadline has expired.
+        """
         try:
             remaining = self.turn.remaining(finalization=True)
         except TurnBudgetExhausted as exc:
@@ -226,28 +328,61 @@ class AdapterBudget:
         return remaining if math.isfinite(remaining) else None
 
     def can_repair(self, retries: int) -> bool:
+        """Determine whether another parse-repair attempt is allowed.
+        
+        Parameters:
+        	retries (int): Number of parse-repair attempts already used.
+        
+        Returns:
+        	bool: `true` if another repair attempt is allowed, `false` otherwise.
+        """
         return retries < self.max_parse_retries
 
     @property
     def finalization_used(self) -> int:
+        """Report the number of finalization attempts used by this invocation.
+        
+        Returns:
+        	int: The number of finalization attempts consumed.
+        """
         with self._lock:
             return self._finalization_used
 
     def can_finalize(self) -> bool:
+        """Determine whether another finalization attempt is available.
+        
+        Returns:
+        	bool: `true` if the finalization limit has not been reached, `false` otherwise.
+        """
         return self.finalization_used < self.max_finalization_attempts
 
     def _check_finalization(self) -> None:
+        """Raise ``TimeoutError`` when the local finalization-attempt limit is exhausted."""
         if self._finalization_used >= self.max_finalization_attempts:
             raise TimeoutError("wrap-up action did not submit before the Turn deadline")
 
     def reclassify_late_response(self) -> None:
-        """Count a late admitted response as finalization, without double debit."""
+        """Reclassify a previously admitted response as a finalization attempt without charging another provider attempt."""
         with self._lock:
             self._check_finalization()
             self.turn.reclassify_finalization()
             self._finalization_used += 1
 
     def reserve_provider(self, *, action: bool, wrap_up: bool, can_finalize: bool) -> float:
+        """
+        Reserve a provider attempt for an action or finalization call.
+        
+        Parameters:
+            action (bool): Whether the call performs an action.
+            wrap_up (bool): Whether the call is a wrap-up finalization call.
+            can_finalize (bool): Whether the call may use finalization capacity.
+        
+        Returns:
+            float: The time available for the admitted provider call.
+        
+        Raises:
+            TimeoutError: If the available time is exhausted.
+        """
         with self._lock:
             if wrap_up:
                 self._check_finalization()
@@ -276,4 +411,9 @@ class ProviderAdmission:
     can_finalize: bool
 
     def reserve(self) -> float:
+        """Reserve admission for the provider call.
+        
+        Returns:
+        	float: The remaining time available for the call.
+        """
         return self.budget.reserve_provider(action=self.action, wrap_up=self.wrap_up, can_finalize=self.can_finalize)

--- a/src/fleet_rlm/rlm/budget.py
+++ b/src/fleet_rlm/rlm/budget.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 from enum import StrEnum
 from threading import Lock
 
+DEFAULT_PARSE_RETRIES = 2
+DEFAULT_FINALIZATION_ATTEMPTS = 2
+
 
 class BudgetDimension(StrEnum):
     DEADLINE = "deadline"
@@ -60,8 +63,8 @@ class TurnBudget:
     attempt does not reach the network; token counts are deliberately absent.
     """
 
-    def __init__(self, *, deadline: float, limits: BudgetLimits | None = None) -> None:
-        if not math.isfinite(deadline):
+    def __init__(self, *, deadline: float | None, limits: BudgetLimits | None = None) -> None:
+        if deadline is not None and not math.isfinite(deadline):
             raise ValueError("deadline must be finite")
         self.deadline = deadline
         self.limits = limits or BudgetLimits()
@@ -104,7 +107,7 @@ class TurnBudget:
     def _remaining(self, *, finalization: bool) -> float:
         if self._settled:
             raise TurnBudgetExhausted(BudgetDimension.SETTLED)
-        remaining = self.deadline - time.monotonic()
+        remaining = math.inf if self.deadline is None else self.deadline - time.monotonic()
         if not finalization:
             remaining -= self.limits.finalization_seconds
         if remaining <= 0:
@@ -115,6 +118,15 @@ class TurnBudget:
         with self._lock:
             return self._remaining(finalization=finalization)
 
+    def exploration_exhausted(self) -> bool:
+        """Whether an explicit provider reserve has fenced further exploration."""
+        with self._lock:
+            limit = self.limits.provider_attempts
+            return limit is not None and (
+                self._used[BudgetDimension.PROVIDER_ATTEMPTS] >= limit
+                or self._exploration_attempts >= limit - self.limits.finalization_attempts
+            )
+
     def snapshot(self) -> dict[str, int]:
         with self._lock:
             return {dimension.value: count for dimension, count in self._used.items()}
@@ -123,3 +135,111 @@ class TurnBudget:
         """Close admission. Owning lifecycle must separately cancel in-flight work."""
         with self._lock:
             self._settled = True
+
+
+class AdapterBudget:
+    """Invocation-local repair policy over one shared Turn admission ledger.
+
+    Finalization slots count physical provider admissions, including transport
+    retries and DSPy schema fallback. A late exploration response can consume a
+    finalization slot without charging its provider attempt a second time.
+    """
+
+    def __init__(
+        self,
+        *,
+        deadline: float | None = None,
+        reserve_seconds: float = 0.0,
+        max_parse_retries: int = DEFAULT_PARSE_RETRIES,
+        max_finalization_attempts: int = DEFAULT_FINALIZATION_ATTEMPTS,
+        turn: TurnBudget | None = None,
+    ) -> None:
+        # Existing preparation-only seams use +inf for an unbounded invocation.
+        if deadline == math.inf:
+            deadline = None
+        if deadline is not None and (
+            not isinstance(deadline, (int, float)) or isinstance(deadline, bool) or not math.isfinite(deadline)
+        ):
+            raise ValueError("deadline must be finite or None")
+        if (
+            not isinstance(reserve_seconds, (int, float))
+            or isinstance(reserve_seconds, bool)
+            or not math.isfinite(reserve_seconds)
+            or reserve_seconds < 0
+        ):
+            raise ValueError("reserve_seconds must be finite and nonnegative")
+        for value in (max_parse_retries, max_finalization_attempts):
+            if type(value) is not int or value < 0:
+                raise ValueError("repair attempt limits must be nonnegative integers")
+        self.turn = turn or TurnBudget(deadline=deadline)
+        self.deadline = deadline
+        self.reserve_seconds = reserve_seconds
+        self.max_parse_retries = max_parse_retries
+        self.max_finalization_attempts = max_finalization_attempts
+        self._finalization_used = 0
+        self._lock = Lock()
+
+    def remaining(self) -> float | None:
+        try:
+            remaining = self.turn.remaining(finalization=True)
+        except TurnBudgetExhausted as exc:
+            if exc.dimension != BudgetDimension.DEADLINE:
+                raise
+            raise TimeoutError("Turn deadline exceeded") from exc
+        if self.deadline is not None:
+            remaining = min(remaining, self.deadline - time.monotonic())
+        if remaining <= 0:
+            raise TimeoutError("Turn deadline exceeded")
+        return remaining if math.isfinite(remaining) else None
+
+    def can_repair(self, retries: int) -> bool:
+        return retries < self.max_parse_retries
+
+    @property
+    def finalization_used(self) -> int:
+        with self._lock:
+            return self._finalization_used
+
+    def can_finalize(self) -> bool:
+        return self.finalization_used < self.max_finalization_attempts
+
+    def _check_finalization(self) -> None:
+        if self._finalization_used >= self.max_finalization_attempts:
+            raise TimeoutError("wrap-up action did not submit before the Turn deadline")
+
+    def reclassify_late_response(self) -> None:
+        """Count a late admitted response as finalization, without double debit."""
+        with self._lock:
+            self._check_finalization()
+            self._finalization_used += 1
+
+    def reserve_provider(self, *, action: bool, wrap_up: bool, can_finalize: bool) -> float:
+        with self._lock:
+            if wrap_up:
+                self._check_finalization()
+            remaining = self.remaining()
+            available = math.inf if remaining is None else remaining
+            if action and not wrap_up:
+                available -= self.reserve_seconds
+            if available <= 0:
+                raise TimeoutError("Turn final-answer reserve exhausted")
+            remaining_turn = self.turn.reserve(
+                BudgetDimension.PROVIDER_ATTEMPTS,
+                finalization=can_finalize and (wrap_up or not action),
+            )
+            if wrap_up:
+                self._finalization_used += 1
+            return min(available, remaining_turn)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAdmission:
+    """An explicit call-local capability, never provider kwargs or global mode."""
+
+    budget: AdapterBudget
+    action: bool
+    wrap_up: bool
+    can_finalize: bool
+
+    def reserve(self) -> float:
+        return self.budget.reserve_provider(action=self.action, wrap_up=self.wrap_up, can_finalize=self.can_finalize)

--- a/src/fleet_rlm/rlm/budget.py
+++ b/src/fleet_rlm/rlm/budget.py
@@ -35,7 +35,9 @@ class BudgetLimits:
     tool_calls: int | None = None
     recursive_children: int | None = None
     execution_output_bytes: int | None = None
-    finalization_attempts: int = 0
+    # ``None`` leaves finalization admission to the invocation-local
+    # ``AdapterBudget``. A value, including zero, is an explicit global ceiling.
+    finalization_attempts: int | None = None
     finalization_seconds: float = 0.0
 
     def __post_init__(self) -> None:
@@ -48,9 +50,18 @@ class BudgetLimits:
         ):
             if value is not None and (type(value) is not int or value < 0):
                 raise ValueError("budget counts must be nonnegative integers")
-        if not math.isfinite(self.finalization_seconds) or self.finalization_seconds < 0:
+        if (
+            not isinstance(self.finalization_seconds, (int, float))
+            or isinstance(self.finalization_seconds, bool)
+            or not math.isfinite(self.finalization_seconds)
+            or self.finalization_seconds < 0
+        ):
             raise ValueError("finalization_seconds must be finite and nonnegative")
-        if self.provider_attempts is not None and self.finalization_attempts > self.provider_attempts:
+        if (
+            self.provider_attempts is not None
+            and self.finalization_attempts is not None
+            and self.finalization_attempts > self.provider_attempts
+        ):
             raise ValueError("finalization reserve exceeds provider attempt limit")
 
 
@@ -64,8 +75,10 @@ class TurnBudget:
     """
 
     def __init__(self, *, deadline: float | None, limits: BudgetLimits | None = None) -> None:
-        if deadline is not None and not math.isfinite(deadline):
-            raise ValueError("deadline must be finite")
+        if deadline is not None and (
+            not isinstance(deadline, (int, float)) or isinstance(deadline, bool) or not math.isfinite(deadline)
+        ):
+            raise ValueError("deadline must be a finite number or None")
         self.deadline = deadline
         self.limits = limits or BudgetLimits()
         self._lock = Lock()
@@ -77,6 +90,7 @@ class TurnBudget:
             BudgetDimension.EXECUTION_OUTPUT_BYTES: 0,
         }
         self._exploration_attempts = 0
+        self._finalization_attempts = 0
 
     def reserve(
         self,
@@ -95,10 +109,14 @@ class TurnBudget:
             limit = getattr(self.limits, dimension.value)
             if limit is not None and self._used[dimension] + count > limit:
                 raise TurnBudgetExhausted(dimension)
-            if dimension == BudgetDimension.PROVIDER_ATTEMPTS and not finalization:
-                if limit is not None and (
-                    self._exploration_attempts + count > limit - self.limits.finalization_attempts
-                ):
+            if dimension == BudgetDimension.PROVIDER_ATTEMPTS and finalization:
+                finalization_limit = self.limits.finalization_attempts
+                if finalization_limit is not None and self._finalization_attempts + count > finalization_limit:
+                    raise TurnBudgetExhausted(dimension)
+                self._finalization_attempts += count
+            elif dimension == BudgetDimension.PROVIDER_ATTEMPTS:
+                finalization_reserve = self.limits.finalization_attempts or 0
+                if limit is not None and (self._exploration_attempts + count > limit - finalization_reserve):
                     raise TurnBudgetExhausted(dimension)
                 self._exploration_attempts += count
             self._used[dimension] += count
@@ -118,13 +136,25 @@ class TurnBudget:
         with self._lock:
             return self._remaining(finalization=finalization)
 
+    def reclassify_finalization(self, count: int = 1) -> None:
+        """Consume finalization capacity for an already-admitted response."""
+        if type(count) is not int or count < 0:
+            raise ValueError("reclassification count must be a nonnegative integer")
+        with self._lock:
+            self._remaining(finalization=True)
+            limit = self.limits.finalization_attempts
+            if limit is not None and self._finalization_attempts + count > limit:
+                raise TurnBudgetExhausted(BudgetDimension.PROVIDER_ATTEMPTS)
+            self._finalization_attempts += count
+
     def exploration_exhausted(self) -> bool:
         """Whether an explicit provider reserve has fenced further exploration."""
         with self._lock:
             limit = self.limits.provider_attempts
+            finalization_reserve = self.limits.finalization_attempts or 0
             return limit is not None and (
                 self._used[BudgetDimension.PROVIDER_ATTEMPTS] >= limit
-                or self._exploration_attempts >= limit - self.limits.finalization_attempts
+                or self._exploration_attempts >= limit - finalization_reserve
             )
 
     def snapshot(self) -> dict[str, int]:
@@ -171,6 +201,9 @@ class AdapterBudget:
         for value in (max_parse_retries, max_finalization_attempts):
             if type(value) is not int or value < 0:
                 raise ValueError("repair attempt limits must be nonnegative integers")
+        # Without an explicitly supplied Turn ledger, finalization remains
+        # governed by this invocation-local adapter cap. A shared production
+        # ledger may opt into a global finalization ceiling via its limits.
         self.turn = turn or TurnBudget(deadline=deadline)
         self.deadline = deadline
         self.reserve_seconds = reserve_seconds
@@ -211,6 +244,7 @@ class AdapterBudget:
         """Count a late admitted response as finalization, without double debit."""
         with self._lock:
             self._check_finalization()
+            self.turn.reclassify_finalization()
             self._finalization_used += 1
 
     def reserve_provider(self, *, action: bool, wrap_up: bool, can_finalize: bool) -> float:

--- a/src/fleet_rlm/rlm/budget.py
+++ b/src/fleet_rlm/rlm/budget.py
@@ -25,9 +25,9 @@ class TurnBudgetExhausted(RuntimeError):  # noqa: N818 - domain exhaustion categ
     def __init__(self, dimension: BudgetDimension) -> None:
         """
         Initialize an exception identifying the exhausted turn-budget dimension.
-        
+
         Parameters:
-        	dimension (BudgetDimension): The budget dimension that has been exhausted.
+                dimension (BudgetDimension): The budget dimension that has been exhausted.
         """
         self.dimension = dimension
         super().__init__(f"Turn budget exhausted: {dimension.value}")
@@ -49,7 +49,7 @@ class BudgetLimits:
     def __post_init__(self) -> None:
         """
         Validate budget limits and finalization configuration.
-        
+
         Raises:
             ValueError: If a count limit is not a nonnegative integer, finalization
                 seconds is not finite and nonnegative, or finalization attempts exceed
@@ -91,11 +91,11 @@ class TurnBudget:
     def __init__(self, *, deadline: float | None, limits: BudgetLimits | None = None) -> None:
         """
         Initialize a turn budget with an optional deadline and resource limits.
-        
+
         Parameters:
             deadline (float | None): Finite absolute deadline, or None for no deadline.
             limits (BudgetLimits | None): Resource and finalization limits for the turn.
-        
+
         Raises:
             ValueError: If deadline is not a finite number or None.
         """
@@ -125,15 +125,15 @@ class TurnBudget:
     ) -> float:
         """
         Atomically admit an operation against a budget dimension and report its remaining time.
-        
+
         Parameters:
             dimension (BudgetDimension): Resource dimension to charge.
             count (int): Amount to charge.
             finalization (bool): Whether the provider-attempt reservation uses finalization capacity.
-        
+
         Returns:
             float: Time remaining for the admitted operation.
-        
+
         Raises:
             ValueError: If the dimension is not reservable or count is not a nonnegative integer.
             TurnBudgetExhausted: If the reservation exceeds a budget limit or available deadline.
@@ -163,13 +163,13 @@ class TurnBudget:
     def _remaining(self, *, finalization: bool) -> float:
         """
         Calculate the time available for an operation.
-        
+
         Parameters:
             finalization (bool): Whether the operation is a finalization attempt.
-        
+
         Returns:
             float: Available time in seconds.
-        
+
         Raises:
             TurnBudgetExhausted: If the budget is settled or the available time is exhausted.
         """
@@ -185,10 +185,10 @@ class TurnBudget:
     def remaining(self, *, finalization: bool = False) -> float:
         """
         Determine the time available for an operation.
-        
+
         Parameters:
             finalization (bool): Whether the operation is a finalization attempt.
-        
+
         Returns:
             float: Available seconds for the operation.
         """
@@ -198,13 +198,13 @@ class TurnBudget:
     def reclassify_finalization(self, count: int = 1) -> None:
         """
         Consume finalization capacity for an already-admitted response.
-        
+
         Parameters:
-        	count (int): Number of finalization attempts to consume.
-        
+                count (int): Number of finalization attempts to consume.
+
         Raises:
-        	ValueError: If count is not a nonnegative integer.
-        	TurnBudgetExhausted: If the deadline or finalization-attempt limit is exhausted.
+                ValueError: If count is not a nonnegative integer.
+                TurnBudgetExhausted: If the deadline or finalization-attempt limit is exhausted.
         """
         if type(count) is not int or count < 0:
             raise ValueError("reclassification count must be a nonnegative integer")
@@ -218,7 +218,7 @@ class TurnBudget:
     def exploration_exhausted(self) -> bool:
         """
         Determine whether provider exploration has exhausted its available capacity.
-        
+
         Returns:
             bool: `True` if the provider-attempt limit or exploration capacity before the
                 finalization reserve has been reached, `False` otherwise.
@@ -234,9 +234,9 @@ class TurnBudget:
     def snapshot(self) -> dict[str, int]:
         """
         Return the current usage counts for each tracked budget dimension.
-        
+
         Returns:
-        	dict[str, int]: A mapping from budget dimension names to their consumed counts.
+                dict[str, int]: A mapping from budget dimension names to their consumed counts.
         """
         with self._lock:
             return {dimension.value: count for dimension, count in self._used.items()}
@@ -267,16 +267,17 @@ class AdapterBudget:
         # Existing preparation-only seams use +inf for an unbounded invocation.
         """
         Initialize invocation-local budget and finalization policies.
-        
+
         Parameters:
             deadline (float | None): Absolute deadline for the invocation; positive infinity means unbounded.
             reserve_seconds (float): Time reserved for finalization.
             max_parse_retries (int): Maximum number of parse-repair retries.
             max_finalization_attempts (int): Maximum number of finalization attempts.
             turn (TurnBudget | None): Shared turn budget, or a new budget when omitted.
-        
+
         Raises:
-            ValueError: If a numeric limit is invalid, negative, non-finite where prohibited, or not an integer where required.
+            ValueError: If a numeric limit is invalid, negative, non-finite where
+                prohibited, or not an integer where required.
         """
         if deadline == math.inf:
             deadline = None
@@ -308,10 +309,10 @@ class AdapterBudget:
     def remaining(self) -> float | None:
         """
         Determine the time remaining for the current invocation.
-        
+
         Returns:
             float | None: Available time in seconds, or `None` when the deadline is unbounded.
-        
+
         Raises:
             TimeoutError: If the turn or invocation deadline has expired.
         """
@@ -329,30 +330,30 @@ class AdapterBudget:
 
     def can_repair(self, retries: int) -> bool:
         """Determine whether another parse-repair attempt is allowed.
-        
+
         Parameters:
-        	retries (int): Number of parse-repair attempts already used.
-        
+                retries (int): Number of parse-repair attempts already used.
+
         Returns:
-        	bool: `true` if another repair attempt is allowed, `false` otherwise.
+                bool: `true` if another repair attempt is allowed, `false` otherwise.
         """
         return retries < self.max_parse_retries
 
     @property
     def finalization_used(self) -> int:
         """Report the number of finalization attempts used by this invocation.
-        
+
         Returns:
-        	int: The number of finalization attempts consumed.
+                int: The number of finalization attempts consumed.
         """
         with self._lock:
             return self._finalization_used
 
     def can_finalize(self) -> bool:
         """Determine whether another finalization attempt is available.
-        
+
         Returns:
-        	bool: `true` if the finalization limit has not been reached, `false` otherwise.
+                bool: `true` if the finalization limit has not been reached, `false` otherwise.
         """
         return self.finalization_used < self.max_finalization_attempts
 
@@ -362,7 +363,9 @@ class AdapterBudget:
             raise TimeoutError("wrap-up action did not submit before the Turn deadline")
 
     def reclassify_late_response(self) -> None:
-        """Reclassify a previously admitted response as a finalization attempt without charging another provider attempt."""
+        """Reclassify a previously admitted response as a finalization attempt
+        without charging another provider attempt.
+        """
         with self._lock:
             self._check_finalization()
             self.turn.reclassify_finalization()
@@ -371,15 +374,15 @@ class AdapterBudget:
     def reserve_provider(self, *, action: bool, wrap_up: bool, can_finalize: bool) -> float:
         """
         Reserve a provider attempt for an action or finalization call.
-        
+
         Parameters:
             action (bool): Whether the call performs an action.
             wrap_up (bool): Whether the call is a wrap-up finalization call.
             can_finalize (bool): Whether the call may use finalization capacity.
-        
+
         Returns:
             float: The time available for the admitted provider call.
-        
+
         Raises:
             TimeoutError: If the available time is exhausted.
         """
@@ -412,8 +415,8 @@ class ProviderAdmission:
 
     def reserve(self) -> float:
         """Reserve admission for the provider call.
-        
+
         Returns:
-        	float: The remaining time available for the call.
+                float: The remaining time available for the call.
         """
         return self.budget.reserve_provider(action=self.action, wrap_up=self.wrap_up, can_finalize=self.can_finalize)

--- a/src/fleet_rlm/rlm/budget.py
+++ b/src/fleet_rlm/rlm/budget.py
@@ -1,0 +1,125 @@
+"""Thread-safe, Turn-owned admission accounting, shared with recursive children."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from threading import Lock
+
+
+class BudgetDimension(StrEnum):
+    DEADLINE = "deadline"
+    PROVIDER_ATTEMPTS = "provider_attempts"
+    TOOL_CALLS = "tool_calls"
+    RECURSIVE_CHILDREN = "recursive_children"
+    EXECUTION_OUTPUT_BYTES = "execution_output_bytes"
+    SETTLED = "settled"
+
+
+class TurnBudgetExhausted(RuntimeError):  # noqa: N818 - domain exhaustion category
+    def __init__(self, dimension: BudgetDimension) -> None:
+        self.dimension = dimension
+        super().__init__(f"Turn budget exhausted: {dimension.value}")
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetLimits:
+    """None means observed accounting, not a claimed hard admission limit."""
+
+    provider_attempts: int | None = None
+    tool_calls: int | None = None
+    recursive_children: int | None = None
+    execution_output_bytes: int | None = None
+    finalization_attempts: int = 0
+    finalization_seconds: float = 0.0
+
+    def __post_init__(self) -> None:
+        for value in (
+            self.provider_attempts,
+            self.tool_calls,
+            self.recursive_children,
+            self.execution_output_bytes,
+            self.finalization_attempts,
+        ):
+            if value is not None and (type(value) is not int or value < 0):
+                raise ValueError("budget counts must be nonnegative integers")
+        if not math.isfinite(self.finalization_seconds) or self.finalization_seconds < 0:
+            raise ValueError("finalization_seconds must be finite and nonnegative")
+        if self.provider_attempts is not None and self.finalization_attempts > self.provider_attempts:
+            raise ValueError("finalization reserve exceeds provider attempt limit")
+
+
+class TurnBudget:
+    """Atomic monotonic reservations; failed work is charged, never refunded.
+
+    Finalization is an explicit caller capability, not a global mutable mode:
+    concurrent child exploration cannot borrow the root's reserved capacity.
+    Counts describe admitted operations. Provider caching may mean an admitted
+    attempt does not reach the network; token counts are deliberately absent.
+    """
+
+    def __init__(self, *, deadline: float, limits: BudgetLimits | None = None) -> None:
+        if not math.isfinite(deadline):
+            raise ValueError("deadline must be finite")
+        self.deadline = deadline
+        self.limits = limits or BudgetLimits()
+        self._lock = Lock()
+        self._settled = False
+        self._used = {
+            BudgetDimension.PROVIDER_ATTEMPTS: 0,
+            BudgetDimension.TOOL_CALLS: 0,
+            BudgetDimension.RECURSIVE_CHILDREN: 0,
+            BudgetDimension.EXECUTION_OUTPUT_BYTES: 0,
+        }
+        self._exploration_attempts = 0
+
+    def reserve(
+        self,
+        dimension: BudgetDimension,
+        count: int = 1,
+        *,
+        finalization: bool = False,
+    ) -> float:
+        """Debit atomically and return remaining time for the admitted operation."""
+        if dimension not in self._used:
+            raise ValueError("dimension is not a reservable counter")
+        if type(count) is not int or count < 0:
+            raise ValueError("reservation count must be a nonnegative integer")
+        with self._lock:
+            remaining = self._remaining(finalization=finalization)
+            limit = getattr(self.limits, dimension.value)
+            if limit is not None and self._used[dimension] + count > limit:
+                raise TurnBudgetExhausted(dimension)
+            if dimension == BudgetDimension.PROVIDER_ATTEMPTS and not finalization:
+                if limit is not None and (
+                    self._exploration_attempts + count > limit - self.limits.finalization_attempts
+                ):
+                    raise TurnBudgetExhausted(dimension)
+                self._exploration_attempts += count
+            self._used[dimension] += count
+            return remaining
+
+    def _remaining(self, *, finalization: bool) -> float:
+        if self._settled:
+            raise TurnBudgetExhausted(BudgetDimension.SETTLED)
+        remaining = self.deadline - time.monotonic()
+        if not finalization:
+            remaining -= self.limits.finalization_seconds
+        if remaining <= 0:
+            raise TurnBudgetExhausted(BudgetDimension.DEADLINE)
+        return remaining
+
+    def remaining(self, *, finalization: bool = False) -> float:
+        with self._lock:
+            return self._remaining(finalization=finalization)
+
+    def snapshot(self) -> dict[str, int]:
+        with self._lock:
+            return {dimension.value: count for dimension, count in self._used.items()}
+
+    def settle(self) -> None:
+        """Close admission. Owning lifecycle must separately cancel in-flight work."""
+        with self._lock:
+            self._settled = True

--- a/src/fleet_rlm/rlm/compat_3_3_1.py
+++ b/src/fleet_rlm/rlm/compat_3_3_1.py
@@ -207,6 +207,15 @@ def _append_input_field(
 
 
 def _budget_directive(remaining: float, *, attempts_exhausted: bool = False) -> str:
+    """Create a directive requiring immediate submission when exploration must end.
+    
+    Parameters:
+        remaining (float): Estimated seconds remaining in the time budget.
+        attempts_exhausted (bool): Whether the exploration attempt limit has been reached.
+    
+    Returns:
+        str: A directive containing the budget reason, remaining time, and required SUBMIT action.
+    """
     seconds = max(0, int(remaining))
     reason = "Exploration attempt budget exhausted" if attempts_exhausted else "Time budget nearly exhausted"
     return (
@@ -260,14 +269,19 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         wrap_up_seconds: float = 0.0,
         budget: TurnBudget | None = None,
     ) -> None:
-        """Initialize the adapter with a bounded retry budget.
-
+        """
+        Initialize the adapter with deadline, wrap-up, and parse-retry budgets.
+        
         Parameters:
-            max_parse_retries (int): Additional attempts after the first failed
-                action response; must be a non-negative integer.
-
+            max_parse_retries (int): Number of additional attempts allowed after the
+                initial parse failure.
+            deadline (float | None): Absolute deadline for adapter processing.
+            wrap_up_seconds (float): Time reserved for final-answer submission.
+            budget (TurnBudget | None): Optional turn budget used to control adapter
+                limits.
+        
         Raises:
-            ValueError: If ``max_parse_retries`` is not a non-negative integer.
+            ValueError: If a budget value is invalid.
         """
         super().__init__()
         self._budget = AdapterBudget(
@@ -283,18 +297,35 @@ class FleetJSONAdapter(dspy.JSONAdapter):
 
     @property
     def _wrap_up_seconds(self) -> float:
+        """Return the time reserved for the final wrap-up phase."""
         return self._budget.reserve_seconds
 
     @property
     def _wrap_up_attempts(self) -> int:
+        """Return the number of finalization attempts used by the adapter."""
         return self._budget.finalization_used
 
     def _remaining(self) -> float | None:
+        """Return the remaining budget time in seconds, or `None` when no deadline is set."""
         return self._budget.remaining()
 
     def _lm_for_request(self, lm: BaseLM, *, action: bool, wrap_up: bool) -> BaseLM:
         # Local import avoids coupling the DSPy compatibility module's import
         # initialization to program construction, which consumes this module.
+        """
+        Prepare the language model for an adapter request with deadline and budget tracking.
+        
+        Parameters:
+            lm (BaseLM): Language model to wrap.
+            action (bool): Whether the request is for a native action.
+            wrap_up (bool): Whether the request is part of the wrap-up phase.
+        
+        Returns:
+            BaseLM: A deadline-aware language model proxy.
+        
+        Raises:
+            ValueError: If the request attempts to switch turn budgets after budget state has been established.
+        """
         from fleet_rlm.rlm.program import DeadlineLMProxy
 
         if isinstance(lm, DeadlineLMProxy) and lm.budget is not None and lm.budget is not self._budget.turn:
@@ -325,6 +356,14 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         self._budget.reclassify_late_response()
 
     def _wrap_up_required(self, inputs: Mapping[str, Any], remaining: float | None) -> bool:
+        """Determine whether the current action iteration must enter wrap-up mode.
+        
+        Parameters:
+        	remaining (float | None): The time remaining for the current turn, in seconds.
+        
+        Returns:
+        	`True` if wrap-up is enabled and the action iteration is at or below its time reserve or has exhausted exploration, `False` otherwise.
+        """
         return bool(
             remaining is not None
             and self._wrap_up_seconds > 0
@@ -340,6 +379,18 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         *,
         field_name: str | None = None,
     ) -> tuple[type[Signature], dict[str, Any], str]:
+        """
+        Prepare inputs with a mandatory final-answer budget directive.
+        
+        Parameters:
+        	signature (type[Signature]): The input signature to update.
+        	inputs (Mapping[str, Any]): Current input values.
+        	remaining (float): Time remaining for finalization.
+        	field_name (str | None): Existing input field to receive the directive, if available.
+        
+        Returns:
+        	tuple[type[Signature], dict[str, Any], str]: The updated signature, input values, and field name containing the directive.
+        """
         directive = _budget_directive(remaining, attempts_exhausted=self._budget.turn.exploration_exhausted())
         if field_name is not None and field_name in signature.fields:
             updated = dict(inputs)
@@ -378,7 +429,19 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        """Drive the shared repair policy through the stock DSPy adapter."""
+        """
+        Drive the DSPy adapter through the bounded repair and finalization policy.
+        
+        Parameters:
+            lm (BaseLM): Language model used to generate the response.
+            lm_kwargs (dict[str, Any]): Keyword arguments for the language model.
+            signature (type[Signature]): DSPy signature describing the request.
+            demos (list[dict[str, Any]]): Demonstration examples passed to the adapter.
+            inputs (dict[str, Any]): Input values for the request.
+        
+        Returns:
+            list[dict[str, Any]]: Parsed adapter output records.
+        """
         machine = self._repair_steps(lm, lm_kwargs, signature, inputs)
         try:
             request = next(machine)
@@ -439,10 +502,15 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         list[dict[str, Any]],
         list[dict[str, Any]],
     ]:
-        """Yield requests and consume responses/errors without owning provider I/O.
-
-        Both drivers close the machine on failure or cancellation. All repair,
-        reserve-transition, and finalization grammar decisions live here.
+        """Drive request repair and wrap-up processing for an LM interaction.
+        
+        Yields:
+            tuple[BaseLM, dict[str, Any], type[Signature], dict[str, Any]]:
+                The LM, call arguments, signature, and inputs for the next request.
+        
+        Returns:
+            list[dict[str, Any]]:
+                The parsed response accepted as the final result.
         """
         lm = self._lm_for_request(lm, action=False, wrap_up=False)
         attempt = 0
@@ -687,6 +755,13 @@ class _RLMTraceCallback(BaseCallback):
         self._last_call: dict[str, JsonValue] | None = None
 
     def on_lm_start(self, call_id: str, instance: Any, inputs: dict[str, Any]) -> None:
+        """Record the start of an LM call for tracing and usage correlation.
+        
+        Parameters:
+        	call_id (str): Identifier for the LM call.
+        	instance (Any): LM instance associated with the call.
+        	inputs (dict[str, Any]): Input fields supplied to the LM.
+        """
         if self._deadline is not None and time.monotonic() >= self._deadline:
             return
         role = self._roles.get(id(getattr(instance, "_fleet_trace_identity", instance)))
@@ -730,6 +805,14 @@ class _RLMTraceCallback(BaseCallback):
         outputs: dict[str, Any] | None,
         exception: BaseException | None = None,
     ) -> None:
+        """
+        Finalize tracking for a language-model call, recording its outcome, timing, usage, and response details.
+        
+        Parameters:
+        	call_id (str): Identifier of the tracked call.
+        	outputs (dict[str, Any] | None): Model outputs, if the call produced any.
+        	exception (BaseException | None): Exception that caused the call to fail, if applicable.
+        """
         state = self._spans.pop(call_id, None)
         if state is None:
             return

--- a/src/fleet_rlm/rlm/compat_3_3_1.py
+++ b/src/fleet_rlm/rlm/compat_3_3_1.py
@@ -26,6 +26,7 @@ from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import AdapterParseError, LMTimeoutError
 
 from fleet_rlm.json_types import JsonValue
+from fleet_rlm.rlm.budget import DEFAULT_PARSE_RETRIES, AdapterBudget, TurnBudget
 from fleet_rlm.rlm.result import _safe_usage_entry, sanitize_public_text, truncate_public_text
 from fleet_rlm.rlm.submit_validation import is_submit_only_code
 
@@ -90,8 +91,6 @@ BUDGET_DIRECTIVE_FIELD = "fleet_budget_directive"
 WRAP_UP_CORRECTION_FIELD = "fleet_wrap_up_correction"
 
 _EMPTY_RESPONSE_MARKER = "The LM returned an empty or null response"
-
-DEFAULT_PARSE_RETRIES = 2
 
 
 def _retry_correction_feedback(attempt: int, exc: AdapterParseError) -> str:
@@ -207,10 +206,11 @@ def _append_input_field(
     return extended, extended_inputs, field
 
 
-def _budget_directive(remaining: float) -> str:
+def _budget_directive(remaining: float, *, attempts_exhausted: bool = False) -> str:
     seconds = max(0, int(remaining))
+    reason = "Exploration attempt budget exhausted" if attempts_exhausted else "Time budget nearly exhausted"
     return (
-        f"Time budget nearly exhausted ({seconds}s remaining). Submit your best-supported answer now "
+        f"{reason} ({seconds}s remaining). Submit your best-supported answer now "
         "using evidence already gathered. Do not explore, call tools, or execute additional code. "
         "Return exactly one SUBMIT(...) action."
     )
@@ -258,6 +258,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         max_parse_retries: int = DEFAULT_PARSE_RETRIES,
         deadline: float | None = None,
         wrap_up_seconds: float = 0.0,
+        budget: TurnBudget | None = None,
     ) -> None:
         """Initialize the adapter with a bounded retry budget.
 
@@ -268,28 +269,39 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         Raises:
             ValueError: If ``max_parse_retries`` is not a non-negative integer.
         """
-        if not isinstance(max_parse_retries, int) or isinstance(max_parse_retries, bool) or max_parse_retries < 0:
-            raise ValueError(f"max_parse_retries must be a non-negative integer, got {max_parse_retries!r}")
-        if deadline is not None and not isinstance(deadline, (int, float)):
-            raise ValueError(f"deadline must be numeric or None, got {deadline!r}")
-        if not isinstance(wrap_up_seconds, (int, float)) or isinstance(wrap_up_seconds, bool) or wrap_up_seconds < 0:
-            raise ValueError(f"wrap_up_seconds must be a non-negative number, got {wrap_up_seconds!r}")
         super().__init__()
-        self._max_parse_retries = max_parse_retries
-        self._deadline = float(deadline) if deadline is not None else None
-        self._wrap_up_seconds = float(wrap_up_seconds)
+        self._budget = AdapterBudget(
+            deadline=deadline,
+            reserve_seconds=wrap_up_seconds,
+            max_parse_retries=max_parse_retries,
+            turn=budget,
+        )
+        self._explicit_budget = budget is not None
         self._wrap_up_entered = False
-        self._wrap_up_attempts = 0
         self._wrap_up_rejection_reason: str | None = None
         self._wrap_up_remaining_ms: int | None = None
 
+    @property
+    def _wrap_up_seconds(self) -> float:
+        return self._budget.reserve_seconds
+
+    @property
+    def _wrap_up_attempts(self) -> int:
+        return self._budget.finalization_used
+
     def _remaining(self) -> float | None:
-        if self._deadline is None:
-            return None
-        remaining = self._deadline - time.monotonic()
-        if remaining <= 0:
-            raise TimeoutError("Turn deadline exceeded")
-        return remaining
+        return self._budget.remaining()
+
+    def _lm_for_request(self, lm: BaseLM, *, action: bool, wrap_up: bool) -> BaseLM:
+        # Local import avoids coupling the DSPy compatibility module's import
+        # initialization to program construction, which consumes this module.
+        from fleet_rlm.rlm.program import DeadlineLMProxy
+
+        if isinstance(lm, DeadlineLMProxy) and lm.budget is not None and lm.budget is not self._budget.turn:
+            if self._explicit_budget or any(self._budget.turn.snapshot().values()):
+                raise ValueError("adapter cannot switch Turn budgets")
+            self._budget.turn = lm.budget
+        return DeadlineLMProxy.for_adapter(lm, self._budget, action=action, wrap_up=wrap_up)
 
     def _enter_wrap_up(self, remaining: float, *, rejection_reason: str | None = None) -> None:
         """Record the first reserve transition and any bounded rejection reason."""
@@ -309,41 +321,16 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         }
 
     def _next_wrap_up_attempt(self) -> None:
-        """Consume one of the two total final-answer provider attempts."""
-        if self._wrap_up_attempts >= 2:
-            raise TimeoutError("wrap-up action did not submit before the Turn deadline")
-        self._wrap_up_attempts += 1
+        """Reclassify an already-charged late response as finalization."""
+        self._budget.reclassify_late_response()
 
     def _wrap_up_required(self, inputs: Mapping[str, Any], remaining: float | None) -> bool:
         return bool(
             remaining is not None
             and self._wrap_up_seconds > 0
             and _iteration_is_action(inputs)
-            and remaining <= self._wrap_up_seconds
+            and (remaining <= self._wrap_up_seconds or self._budget.turn.exploration_exhausted())
         )
-
-    def _call_kwargs(
-        self,
-        lm: BaseLM,
-        lm_kwargs: Mapping[str, Any],
-        *,
-        remaining: float | None,
-        wrap_up: bool,
-        action: bool,
-    ) -> dict[str, Any]:
-        values = dict(lm_kwargs)
-        if remaining is None:
-            return values
-        available = remaining if wrap_up or not action else remaining - self._wrap_up_seconds
-        if available <= 0:
-            raise TimeoutError("Turn final-answer reserve exhausted")
-        configured = values.get("timeout")
-        if configured is None:
-            configured = getattr(lm, "kwargs", {}).get("timeout")
-        if isinstance(configured, (int, float)) and not isinstance(configured, bool) and configured > 0:
-            available = min(float(configured), available)
-        values["timeout"] = available
-        return values
 
     def _with_wrap_up_directive(
         self,
@@ -353,7 +340,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         *,
         field_name: str | None = None,
     ) -> tuple[type[Signature], dict[str, Any], str]:
-        directive = _budget_directive(remaining)
+        directive = _budget_directive(remaining, attempts_exhausted=self._budget.turn.exploration_exhausted())
         if field_name is not None and field_name in signature.fields:
             updated = dict(inputs)
             updated[field_name] = directive
@@ -396,9 +383,9 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         try:
             request = next(machine)
             while True:
-                call_kwargs, request_signature, request_inputs = request
+                call_lm, call_kwargs, request_signature, request_inputs = request
                 try:
-                    response = super().__call__(lm, call_kwargs, request_signature, demos, request_inputs)
+                    response = super().__call__(call_lm, call_kwargs, request_signature, demos, request_inputs)
                 except (AdapterParseError, LMTimeoutError, TimeoutError) as exc:
                     try:
                         request = machine.throw(exc)
@@ -425,9 +412,9 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         try:
             request = next(machine)
             while True:
-                call_kwargs, request_signature, request_inputs = request
+                call_lm, call_kwargs, request_signature, request_inputs = request
                 try:
-                    response = await super().acall(lm, call_kwargs, request_signature, demos, request_inputs)
+                    response = await super().acall(call_lm, call_kwargs, request_signature, demos, request_inputs)
                 except (AdapterParseError, LMTimeoutError, TimeoutError) as exc:
                     try:
                         request = machine.throw(exc)
@@ -448,7 +435,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         signature: type[Signature],
         inputs: dict[str, Any],
     ) -> Generator[
-        tuple[dict[str, Any], type[Signature], dict[str, Any]],
+        tuple[BaseLM, dict[str, Any], type[Signature], dict[str, Any]],
         list[dict[str, Any]],
         list[dict[str, Any]],
     ]:
@@ -457,6 +444,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         Both drivers close the machine on failure or cancellation. All repair,
         reserve-transition, and finalization grammar decisions live here.
         """
+        lm = self._lm_for_request(lm, action=False, wrap_up=False)
         attempt = 0
         base_signature = signature
         base_inputs = dict(inputs)
@@ -478,16 +466,9 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                     remaining,
                     field_name=directive_field,
                 )
-                self._next_wrap_up_attempt()
-            call_kwargs = self._call_kwargs(
-                lm,
-                lm_kwargs,
-                remaining=remaining,
-                wrap_up=wrap_up,
-                action=action,
-            )
+            call_lm = self._lm_for_request(lm, action=action, wrap_up=wrap_up)
             try:
-                response = yield call_kwargs, request_signature, request_inputs
+                response = yield call_lm, dict(lm_kwargs), request_signature, request_inputs
             except (LMTimeoutError, TimeoutError):
                 if not wrap_up and action and self._wrap_up_seconds > 0:
                     boundary_remaining = self._remaining()
@@ -504,7 +485,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                 raise
             except AdapterParseError as exc:
                 if wrap_up:
-                    if self._wrap_up_attempts >= 2:
+                    if not self._budget.can_finalize():
                         raise TimeoutError("wrap-up action was not parseable before the Turn deadline") from exc
                     self._wrap_up_rejection_reason = "unparseable_json"
                     request_signature, request_inputs = self._with_wrap_up_correction(
@@ -536,7 +517,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                             reason="unparseable JSON",
                         )
                         continue
-                if attempt >= self._max_parse_retries:
+                if not self._budget.can_repair(attempt):
                     raise
                 attempt += 1
                 request_signature, request_inputs = _retry_call_arguments(
@@ -566,7 +547,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
                     )
                 if wrap_up and action and not is_submit_only_code(_action_code(response)):
                     self._wrap_up_rejection_reason = "exploration_or_additional_code"
-                    if self._wrap_up_attempts >= 2:
+                    if not self._budget.can_finalize():
                         raise TimeoutError("wrap-up action did not submit before the Turn deadline")
                     request_signature, request_inputs = self._with_wrap_up_correction(
                         request_signature,
@@ -708,7 +689,7 @@ class _RLMTraceCallback(BaseCallback):
     def on_lm_start(self, call_id: str, instance: Any, inputs: dict[str, Any]) -> None:
         if self._deadline is not None and time.monotonic() >= self._deadline:
             return
-        role = self._roles.get(id(instance))
+        role = self._roles.get(id(getattr(instance, "_fleet_trace_identity", instance)))
         if role is None:
             return
         model = "unknown"
@@ -753,7 +734,7 @@ class _RLMTraceCallback(BaseCallback):
         if state is None:
             return
         instance, span, history_length, call_index, started_at = state
-        role = self._roles.get(id(instance), "unknown")
+        role = self._roles.get(id(getattr(instance, "_fleet_trace_identity", instance)), "unknown")
         try:
             usage = _latest_lm_telemetry(instance, history_length, outputs)
         except Exception:

--- a/src/fleet_rlm/rlm/compat_3_3_1.py
+++ b/src/fleet_rlm/rlm/compat_3_3_1.py
@@ -1,4 +1,4 @@
-"""DSPy 3.3.x compatibility, version guard, callbacks, and interpreter contracts.
+"""DSPy 3.3.1 compatibility, version guard, callbacks, and interpreter contracts.
 
 This module isolates version-specific and private/public DSPy 3.3.1 contracts.
 Other modules in ``fleet_rlm.rlm`` depend on this compatibility layer rather

--- a/src/fleet_rlm/rlm/compat_3_3_1.py
+++ b/src/fleet_rlm/rlm/compat_3_3_1.py
@@ -208,11 +208,11 @@ def _append_input_field(
 
 def _budget_directive(remaining: float, *, attempts_exhausted: bool = False) -> str:
     """Create a directive requiring immediate submission when exploration must end.
-    
+
     Parameters:
         remaining (float): Estimated seconds remaining in the time budget.
         attempts_exhausted (bool): Whether the exploration attempt limit has been reached.
-    
+
     Returns:
         str: A directive containing the budget reason, remaining time, and required SUBMIT action.
     """
@@ -271,7 +271,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
     ) -> None:
         """
         Initialize the adapter with deadline, wrap-up, and parse-retry budgets.
-        
+
         Parameters:
             max_parse_retries (int): Number of additional attempts allowed after the
                 initial parse failure.
@@ -279,7 +279,7 @@ class FleetJSONAdapter(dspy.JSONAdapter):
             wrap_up_seconds (float): Time reserved for final-answer submission.
             budget (TurnBudget | None): Optional turn budget used to control adapter
                 limits.
-        
+
         Raises:
             ValueError: If a budget value is invalid.
         """
@@ -314,15 +314,15 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         # initialization to program construction, which consumes this module.
         """
         Prepare the language model for an adapter request with deadline and budget tracking.
-        
+
         Parameters:
             lm (BaseLM): Language model to wrap.
             action (bool): Whether the request is for a native action.
             wrap_up (bool): Whether the request is part of the wrap-up phase.
-        
+
         Returns:
             BaseLM: A deadline-aware language model proxy.
-        
+
         Raises:
             ValueError: If the request attempts to switch turn budgets after budget state has been established.
         """
@@ -357,12 +357,13 @@ class FleetJSONAdapter(dspy.JSONAdapter):
 
     def _wrap_up_required(self, inputs: Mapping[str, Any], remaining: float | None) -> bool:
         """Determine whether the current action iteration must enter wrap-up mode.
-        
+
         Parameters:
-        	remaining (float | None): The time remaining for the current turn, in seconds.
-        
+                remaining (float | None): The time remaining for the current turn, in seconds.
+
         Returns:
-        	`True` if wrap-up is enabled and the action iteration is at or below its time reserve or has exhausted exploration, `False` otherwise.
+                `True` if wrap-up is enabled and the action iteration is at or below its
+                time reserve or has exhausted exploration, `False` otherwise.
         """
         return bool(
             remaining is not None
@@ -381,15 +382,16 @@ class FleetJSONAdapter(dspy.JSONAdapter):
     ) -> tuple[type[Signature], dict[str, Any], str]:
         """
         Prepare inputs with a mandatory final-answer budget directive.
-        
+
         Parameters:
-        	signature (type[Signature]): The input signature to update.
-        	inputs (Mapping[str, Any]): Current input values.
-        	remaining (float): Time remaining for finalization.
-        	field_name (str | None): Existing input field to receive the directive, if available.
-        
+                signature (type[Signature]): The input signature to update.
+                inputs (Mapping[str, Any]): Current input values.
+                remaining (float): Time remaining for finalization.
+                field_name (str | None): Existing input field to receive the directive, if available.
+
         Returns:
-        	tuple[type[Signature], dict[str, Any], str]: The updated signature, input values, and field name containing the directive.
+                tuple[type[Signature], dict[str, Any], str]: The updated signature, input
+                values, and field name containing the directive.
         """
         directive = _budget_directive(remaining, attempts_exhausted=self._budget.turn.exploration_exhausted())
         if field_name is not None and field_name in signature.fields:
@@ -431,14 +433,14 @@ class FleetJSONAdapter(dspy.JSONAdapter):
     ) -> list[dict[str, Any]]:
         """
         Drive the DSPy adapter through the bounded repair and finalization policy.
-        
+
         Parameters:
             lm (BaseLM): Language model used to generate the response.
             lm_kwargs (dict[str, Any]): Keyword arguments for the language model.
             signature (type[Signature]): DSPy signature describing the request.
             demos (list[dict[str, Any]]): Demonstration examples passed to the adapter.
             inputs (dict[str, Any]): Input values for the request.
-        
+
         Returns:
             list[dict[str, Any]]: Parsed adapter output records.
         """
@@ -503,11 +505,11 @@ class FleetJSONAdapter(dspy.JSONAdapter):
         list[dict[str, Any]],
     ]:
         """Drive request repair and wrap-up processing for an LM interaction.
-        
+
         Yields:
             tuple[BaseLM, dict[str, Any], type[Signature], dict[str, Any]]:
                 The LM, call arguments, signature, and inputs for the next request.
-        
+
         Returns:
             list[dict[str, Any]]:
                 The parsed response accepted as the final result.
@@ -756,11 +758,11 @@ class _RLMTraceCallback(BaseCallback):
 
     def on_lm_start(self, call_id: str, instance: Any, inputs: dict[str, Any]) -> None:
         """Record the start of an LM call for tracing and usage correlation.
-        
+
         Parameters:
-        	call_id (str): Identifier for the LM call.
-        	instance (Any): LM instance associated with the call.
-        	inputs (dict[str, Any]): Input fields supplied to the LM.
+                call_id (str): Identifier for the LM call.
+                instance (Any): LM instance associated with the call.
+                inputs (dict[str, Any]): Input fields supplied to the LM.
         """
         if self._deadline is not None and time.monotonic() >= self._deadline:
             return
@@ -807,11 +809,11 @@ class _RLMTraceCallback(BaseCallback):
     ) -> None:
         """
         Finalize tracking for a language-model call, recording its outcome, timing, usage, and response details.
-        
+
         Parameters:
-        	call_id (str): Identifier of the tracked call.
-        	outputs (dict[str, Any] | None): Model outputs, if the call produced any.
-        	exception (BaseException | None): Exception that caused the call to fail, if applicable.
+                call_id (str): Identifier of the tracked call.
+                outputs (dict[str, Any] | None): Model outputs, if the call produced any.
+                exception (BaseException | None): Exception that caused the call to fail, if applicable.
         """
         state = self._spans.pop(call_id, None)
         if state is None:

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -408,7 +408,7 @@ class AsyncToolBridge(Protocol):
 
     def run(self, awaitable: Any) -> Any:
         """Await one host operation on the bridge's persistent event loop."""
-        ...
+        pass
 
 
 class ToolResultSerializationError(TypeError):

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -407,7 +407,15 @@ class AsyncToolBridge(Protocol):
     """Composition-owned bridge for awaiting async host Tools from DSPy sync code."""
 
     def run(self, awaitable: Any) -> Any:
-        """Await one host operation on the bridge's persistent event loop."""
+        """
+        Run a host operation through the asynchronous bridge.
+        
+        Parameters:
+            awaitable (Any): The awaitable host operation to execute.
+        
+        Returns:
+            Any: The operation's result.
+        """
         pass
 
 
@@ -510,6 +518,23 @@ def _validate_tool_arguments(
     event_view: ToolEventView,
     trace: _ToolTrace,
 ) -> dict[str, Any]:
+    """
+    Validate tool arguments and report validation failures.
+    
+    Parameters:
+        validator (dspy.Tool): Tool used to validate the arguments.
+        arguments (Mapping[str, Any]): Arguments supplied to the tool.
+        source (dspy.Tool): Original tool being invoked.
+        observer (ToolObserver): Callback for tool lifecycle events.
+        event_view (ToolEventView): View used to create failure details.
+        trace (_ToolTrace): Trace for the current tool call.
+    
+    Returns:
+        dict[str, Any]: Validated tool arguments.
+    
+    Raises:
+        Exception: Re-raises the validation exception.
+    """
     try:
         return validator(**arguments)
     except Exception:
@@ -519,13 +544,18 @@ def _validate_tool_arguments(
 
 
 def _resolve_awaitable_result(result: Any, *, async_bridge: AsyncToolBridge | None = None) -> Any:
-    """Resolve an async host Tool through the composition-owned async bridge.
-
-    Native DSPy invokes interpreter Tools synchronously.  Outside an event loop
-    the credential-free direct path can own a short-lived loop; while DSPy is
-    running on a loop, the host operation must be submitted to the persistent
-    composition loop.  Creating a private loop/thread per Tool would break
-    loop-affine host resources and leak work past the Turn ownership boundary.
+    """
+    Resolve an awaitable tool result using the available asynchronous execution context.
+    
+    Parameters:
+        result (Any): The synchronous value or awaitable result to resolve.
+        async_bridge (AsyncToolBridge | None): Bridge used when resolution occurs inside a running event loop.
+    
+    Returns:
+        Any: The resolved value, or the original value when it is not awaitable.
+    
+    Raises:
+        RuntimeError: If an awaitable is resolved inside a running event loop without an async bridge.
     """
     if not inspect.isawaitable(result):
         return result
@@ -557,6 +587,27 @@ def _execute_observed_tool(
     guards: RunToolGuards | None,
     async_bridge: AsyncToolBridge | None,
 ) -> Any:
+    """
+    Execute a validated tool call and report its result or failure.
+    
+    Parameters:
+    	source (dspy.Tool): Tool to execute.
+    	validated (Mapping[str, Any]): Arguments validated for invocation.
+    	arguments (Mapping[str, Any]): Original tool arguments used for failure reporting.
+    	observer (ToolObserver): Callback for reporting tool failures.
+    	event_view (ToolEventView): View used to create failure event details.
+    	trace (_ToolTrace): Trace for the tool invocation.
+    	after_result (ToolAfterResult | None): Optional callback invoked with a successful result.
+    	guards (RunToolGuards | None): Optional guards governing tool execution.
+    	async_bridge (AsyncToolBridge | None): Optional bridge for resolving asynchronous results.
+    
+    Returns:
+    	Any: The tool's JSON-serializable result.
+    
+    Raises:
+    	ToolResultSerializationError: If the result cannot be serialized as JSON.
+    	Exception: Propagates exceptions raised during execution or result handling.
+    """
     try:
         if guards is not None:
             guards.reserve_tool()
@@ -615,6 +666,15 @@ def _run_observed_tool(
     args: tuple[Any, ...],
     kwargs: Mapping[str, Any],
 ) -> Any:
+    """
+    Execute an observed tool call and report its lifecycle events.
+    
+    Parameters:
+        async_bridge: Optional bridge used to resolve asynchronous tool results.
+    
+    Returns:
+        The tool's result.
+    """
     trace = _ToolTrace(source, str(uuid4()))
     _reject_unauthorized(source, observer, event_view, trace, is_authorized)
     arguments = _bind_tool_arguments(signature, args, kwargs, source, observer, event_view, trace)
@@ -667,7 +727,18 @@ def observe_tool(
     guards: RunToolGuards | None = None,
     async_bridge: AsyncToolBridge | None = None,
 ) -> dspy.Tool:
-    """Return a fresh Tool whose extracted ``func`` preserves DSPy validation."""
+    """Create a DSPy tool that observes calls to the source tool.
+    
+    Parameters:
+        tool (dspy.Tool): Source tool whose calls are observed.
+        async_bridge (AsyncToolBridge | None): Bridge used to resolve awaitable results when an event loop is already running.
+    
+    Returns:
+        dspy.Tool: A wrapped tool that preserves the source tool's metadata and validation contract.
+    
+    Raises:
+        TypeError: If `tool` is not a `dspy.Tool`.
+    """
     if not isinstance(tool, dspy.Tool):
         raise TypeError("observe_tool requires a dspy.Tool")
     source = tool
@@ -676,6 +747,9 @@ def observe_tool(
 
     @wraps(source.func)
     def wrapped(*args: Any, **kwargs: Any) -> Any:
+        """
+        Execute the wrapped tool with lifecycle observation and return its result.
+        """
         return _run_observed_tool(
             source,
             signature,

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -25,7 +25,7 @@ import dspy
 from fleet_rlm.json_types import JsonValue, validate_json_value
 from fleet_rlm.observability.diagnostics import trace_failure_category
 from fleet_rlm.observability.tracing import turn_phase_span
-from fleet_rlm.rlm._dspy_compat import FleetJSONAdapter, _RLMTraceCallback
+from fleet_rlm.rlm.compat_3_3_1 import FleetJSONAdapter, _RLMTraceCallback
 from fleet_rlm.rlm.result import (
     ExecutionDetail,
     RLMConfigError,

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -409,10 +409,10 @@ class AsyncToolBridge(Protocol):
     def run(self, awaitable: Any) -> Any:
         """
         Run a host operation through the asynchronous bridge.
-        
+
         Parameters:
             awaitable (Any): The awaitable host operation to execute.
-        
+
         Returns:
             Any: The operation's result.
         """
@@ -520,7 +520,7 @@ def _validate_tool_arguments(
 ) -> dict[str, Any]:
     """
     Validate tool arguments and report validation failures.
-    
+
     Parameters:
         validator (dspy.Tool): Tool used to validate the arguments.
         arguments (Mapping[str, Any]): Arguments supplied to the tool.
@@ -528,10 +528,10 @@ def _validate_tool_arguments(
         observer (ToolObserver): Callback for tool lifecycle events.
         event_view (ToolEventView): View used to create failure details.
         trace (_ToolTrace): Trace for the current tool call.
-    
+
     Returns:
         dict[str, Any]: Validated tool arguments.
-    
+
     Raises:
         Exception: Re-raises the validation exception.
     """
@@ -546,14 +546,14 @@ def _validate_tool_arguments(
 def _resolve_awaitable_result(result: Any, *, async_bridge: AsyncToolBridge | None = None) -> Any:
     """
     Resolve an awaitable tool result using the available asynchronous execution context.
-    
+
     Parameters:
         result (Any): The synchronous value or awaitable result to resolve.
         async_bridge (AsyncToolBridge | None): Bridge used when resolution occurs inside a running event loop.
-    
+
     Returns:
         Any: The resolved value, or the original value when it is not awaitable.
-    
+
     Raises:
         RuntimeError: If an awaitable is resolved inside a running event loop without an async bridge.
     """
@@ -590,24 +590,24 @@ def _execute_observed_tool(
 ) -> Any:
     """
     Execute a validated tool call and report its result or failure.
-    
+
     Parameters:
-    	source (dspy.Tool): Tool to execute.
-    	validated (Mapping[str, Any]): Arguments validated for invocation.
-    	arguments (Mapping[str, Any]): Original tool arguments used for failure reporting.
-    	observer (ToolObserver): Callback for reporting tool failures.
-    	event_view (ToolEventView): View used to create failure event details.
-    	trace (_ToolTrace): Trace for the tool invocation.
-    	after_result (ToolAfterResult | None): Optional callback invoked with a successful result.
-    	guards (RunToolGuards | None): Optional guards governing tool execution.
-    	async_bridge (AsyncToolBridge | None): Optional bridge for resolving asynchronous results.
-    
+        source (dspy.Tool): Tool to execute.
+        validated (Mapping[str, Any]): Arguments validated for invocation.
+        arguments (Mapping[str, Any]): Original tool arguments used for failure reporting.
+        observer (ToolObserver): Callback for reporting tool failures.
+        event_view (ToolEventView): View used to create failure event details.
+        trace (_ToolTrace): Trace for the tool invocation.
+        after_result (ToolAfterResult | None): Optional callback invoked with a successful result.
+        guards (RunToolGuards | None): Optional guards governing tool execution.
+        async_bridge (AsyncToolBridge | None): Optional bridge for resolving asynchronous results.
+
     Returns:
-    	Any: The tool's JSON-serializable result.
-    
+        Any: The tool's JSON-serializable result.
+
     Raises:
-    	ToolResultSerializationError: If the result cannot be serialized as JSON.
-    	Exception: Propagates exceptions raised during execution or result handling.
+        ToolResultSerializationError: If the result cannot be serialized as JSON.
+        Exception: Propagates exceptions raised during execution or result handling.
     """
     try:
         if guards is not None:
@@ -669,10 +669,10 @@ def _run_observed_tool(
 ) -> Any:
     """
     Execute an observed tool call and report its lifecycle events.
-    
+
     Parameters:
         async_bridge: Optional bridge used to resolve asynchronous tool results.
-    
+
     Returns:
         The tool's result.
     """
@@ -729,14 +729,15 @@ def observe_tool(
     async_bridge: AsyncToolBridge | None = None,
 ) -> dspy.Tool:
     """Create a DSPy tool that observes calls to the source tool.
-    
+
     Parameters:
         tool (dspy.Tool): Source tool whose calls are observed.
-        async_bridge (AsyncToolBridge | None): Bridge used to resolve awaitable results when an event loop is already running.
-    
+        async_bridge (AsyncToolBridge | None): Bridge used to resolve awaitable results
+            when an event loop is already running.
+
     Returns:
         dspy.Tool: A wrapped tool that preserves the source tool's metadata and validation contract.
-    
+
     Raises:
         TypeError: If `tool` is not a `dspy.Tool`.
     """

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -1175,6 +1175,7 @@ class ExecutionTraceAssembler:
         adapter = FleetJSONAdapter(
             deadline=context.execution.deadline,
             wrap_up_seconds=context.execution.wrap_up_seconds,
+            budget=getattr(context.execution.models, "budget", None),
         )
         with (
             turn_phase_span(

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -574,6 +574,7 @@ def _resolve_awaitable_result(result: Any, *, async_bridge: AsyncToolBridge | No
         if callable(cancel):
             cancel()
         raise RuntimeError("async Tool requires a persistent async bridge")
+    return result
 
 
 def _execute_observed_tool(

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -538,11 +538,12 @@ def _resolve_awaitable_result(result: Any, *, async_bridge: AsyncToolBridge | No
     except RuntimeError:
         return asyncio.run(await_result())
     if async_bridge is None:
-        close = getattr(result, "close", None)
-        if callable(close):
-            close()
+        if inspect.iscoroutine(result):
+            result.close()
+        cancel = getattr(result, "cancel", None)
+        if callable(cancel):
+            cancel()
         raise RuntimeError("async Tool requires a persistent async bridge")
-    return async_bridge.run(await_result())
 
 
 def _execute_observed_tool(

--- a/src/fleet_rlm/rlm/events.py
+++ b/src/fleet_rlm/rlm/events.py
@@ -8,16 +8,14 @@ and execution trace assembly for one native DSPy RLM execution.
 from __future__ import annotations
 
 import asyncio
-import contextvars
 import inspect
 import time
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from functools import wraps
-from threading import Thread
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast
 from uuid import UUID, uuid4
 
 import dspy
@@ -405,6 +403,14 @@ class EventRecorder:
 ToolObserver: TypeAlias = Callable[[ObservationDetail | Status | WarningEvent], None]
 
 
+class AsyncToolBridge(Protocol):
+    """Composition-owned bridge for awaiting async host Tools from DSPy sync code."""
+
+    def run(self, awaitable: Any) -> Any:
+        """Await one host operation on the bridge's persistent event loop."""
+        ...
+
+
 class ToolResultSerializationError(TypeError):
     """Closed failure for a host Tool result outside Fleet's JSON contract."""
 
@@ -512,13 +518,14 @@ def _validate_tool_arguments(
         raise
 
 
-def _resolve_awaitable_result(result: Any) -> Any:
-    """Resolve sync and async host Tools through the synchronous DSPy seam.
+def _resolve_awaitable_result(result: Any, *, async_bridge: AsyncToolBridge | None = None) -> Any:
+    """Resolve an async host Tool through the composition-owned async bridge.
 
-    Native DSPy invokes interpreter Tools synchronously, while Fleet's
-    composition also exposes async host implementations.  If the caller is
-    already on an event loop, a private thread avoids nesting or blocking that
-    loop; otherwise ``asyncio.run`` keeps the deterministic path small.
+    Native DSPy invokes interpreter Tools synchronously.  Outside an event loop
+    the credential-free direct path can own a short-lived loop; while DSPy is
+    running on a loop, the host operation must be submitted to the persistent
+    composition loop.  Creating a private loop/thread per Tool would break
+    loop-affine host resources and leak work past the Turn ownership boundary.
     """
     if not inspect.isawaitable(result):
         return result
@@ -530,27 +537,12 @@ def _resolve_awaitable_result(result: Any) -> Any:
         asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(await_result())
-
-    context = contextvars.copy_context()
-    values: list[Any] = []
-    errors: list[BaseException] = []
-
-    def run() -> None:
-        # Ferry every worker-thread failure back to the caller, including
-        # asyncio.CancelledError (a BaseException), rather than losing it.
-        try:
-            values.append(context.run(asyncio.run, await_result()))
-        except BaseException as exc:
-            errors.append(exc)
-
-    worker = Thread(target=run, name="fleet-rlm-async-tool", daemon=True)
-    worker.start()
-    worker.join()
-    if errors:
-        raise errors[0]
-    if not values:
-        raise RuntimeError("async Tool produced no result")
-    return values[0]
+    if async_bridge is None:
+        close = getattr(result, "close", None)
+        if callable(close):
+            close()
+        raise RuntimeError("async Tool requires a persistent async bridge")
+    return async_bridge.run(await_result())
 
 
 def _execute_observed_tool(
@@ -562,9 +554,12 @@ def _execute_observed_tool(
     trace: _ToolTrace,
     after_result: ToolAfterResult | None,
     guards: RunToolGuards | None,
+    async_bridge: AsyncToolBridge | None,
 ) -> Any:
     try:
-        result = _resolve_awaitable_result(source.func(**validated))
+        if guards is not None:
+            guards.reserve_tool()
+        result = _resolve_awaitable_result(source.func(**validated), async_bridge=async_bridge)
         try:
             validate_json_value(result, path=f"Tool {source.name} result")
         except (TypeError, ValueError):
@@ -615,6 +610,7 @@ def _run_observed_tool(
     after_result: ToolAfterResult | None,
     is_authorized: Callable[[], bool] | None,
     guards: RunToolGuards | None,
+    async_bridge: AsyncToolBridge | None,
     args: tuple[Any, ...],
     kwargs: Mapping[str, Any],
 ) -> Any:
@@ -634,6 +630,7 @@ def _run_observed_tool(
         trace,
         after_result,
         guards,
+        async_bridge,
     )
     _check_tool_progress(source, result, arguments, observer, event_view, trace, guards)
     projected_output = event_view.output(result)
@@ -667,6 +664,7 @@ def observe_tool(
     after_result: ToolAfterResult | None = None,
     is_authorized: Callable[[], bool] | None = None,
     guards: RunToolGuards | None = None,
+    async_bridge: AsyncToolBridge | None = None,
 ) -> dspy.Tool:
     """Return a fresh Tool whose extracted ``func`` preserves DSPy validation."""
     if not isinstance(tool, dspy.Tool):
@@ -686,6 +684,7 @@ def observe_tool(
             after_result,
             is_authorized,
             guards,
+            async_bridge,
             args,
             kwargs,
         )
@@ -1536,6 +1535,7 @@ class ObservationSession:
 __all__ = [
     "PROVIDER_ENDPOINT_NOT_FOUND_MESSAGE",
     "ArtifactCreated",
+    "AsyncToolBridge",
     "AttachmentRead",
     "DetailRelay",
     "EventRecorder",

--- a/src/fleet_rlm/rlm/output_contract.py
+++ b/src/fleet_rlm/rlm/output_contract.py
@@ -22,6 +22,15 @@ class FleetOutputContract:
 
     @classmethod
     def from_signature(cls, signature: Any) -> FleetOutputContract:
+        """
+        Build an output contract from a signature's output fields.
+        
+        Parameters:
+            signature (Any): Signature containing output field definitions.
+        
+        Returns:
+            FleetOutputContract: Contract containing field requirements and JSON-encoded defaults.
+        """
         fields = []
         for name, field in signature.output_fields.items():
             default_json = None
@@ -34,7 +43,17 @@ class FleetOutputContract:
         return cls(tuple(fields))
 
     def merge(self, native_fields: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Keep native types while supplying Fleet's required/default metadata."""
+        """Merge Fleet-required and default metadata into native output fields while preserving their other metadata.
+        
+        Parameters:
+        	native_fields (list[dict[str, Any]]): Native interpreter output field metadata whose names and order must match the Fleet contract.
+        
+        Returns:
+        	list[dict[str, Any]]: Output field metadata with Fleet-required and default values applied.
+        
+        Raises:
+        	ValueError: If the native fields do not match the Fleet contract in name or order.
+        """
         if [field.get("name") for field in native_fields] != [field.name for field in self.fields]:
             raise ValueError("interpreter output fields do not match the bound Fleet output contract")
         result = []
@@ -48,7 +67,7 @@ class FleetOutputContract:
 
 
 def bind_output_contract(interpreter: Any, signature: Any) -> None:
-    """Bind through the caller-owned adapter; lightweight non-Fleet doubles opt out."""
+    """Bind the signature's output contract through a compatible interpreter adapter."""
     if signature is None or not hasattr(signature, "output_fields"):
         return
     bind = getattr(interpreter, "bind_output_contract", None)

--- a/src/fleet_rlm/rlm/output_contract.py
+++ b/src/fleet_rlm/rlm/output_contract.py
@@ -24,10 +24,10 @@ class FleetOutputContract:
     def from_signature(cls, signature: Any) -> FleetOutputContract:
         """
         Build an output contract from a signature's output fields.
-        
+
         Parameters:
             signature (Any): Signature containing output field definitions.
-        
+
         Returns:
             FleetOutputContract: Contract containing field requirements and JSON-encoded defaults.
         """
@@ -44,15 +44,16 @@ class FleetOutputContract:
 
     def merge(self, native_fields: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Merge Fleet-required and default metadata into native output fields while preserving their other metadata.
-        
+
         Parameters:
-        	native_fields (list[dict[str, Any]]): Native interpreter output field metadata whose names and order must match the Fleet contract.
-        
+                native_fields (list[dict[str, Any]]): Native interpreter output field
+                    metadata whose names and order must match the Fleet contract.
+
         Returns:
-        	list[dict[str, Any]]: Output field metadata with Fleet-required and default values applied.
-        
+                list[dict[str, Any]]: Output field metadata with Fleet-required and default values applied.
+
         Raises:
-        	ValueError: If the native fields do not match the Fleet contract in name or order.
+                ValueError: If the native fields do not match the Fleet contract in name or order.
         """
         if [field.get("name") for field in native_fields] != [field.name for field in self.fields]:
             raise ValueError("interpreter output fields do not match the bound Fleet output contract")

--- a/src/fleet_rlm/rlm/output_contract.py
+++ b/src/fleet_rlm/rlm/output_contract.py
@@ -1,0 +1,56 @@
+"""Fleet-owned output defaults, independent of native DSPy execution internals."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, cast
+
+from fleet_rlm.json_types import strict_json_dumps
+
+
+@dataclass(frozen=True, slots=True)
+class OutputField:
+    name: str
+    required: bool
+    default_json: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FleetOutputContract:
+    fields: tuple[OutputField, ...]
+
+    @classmethod
+    def from_signature(cls, signature: Any) -> FleetOutputContract:
+        fields = []
+        for name, field in signature.output_fields.items():
+            default_json = None
+            if not field.is_required():
+                default = field.default
+                if field.default_factory is not None:
+                    default = cast(Callable[[], Any], field.default_factory)()
+                default_json = strict_json_dumps(default)
+            fields.append(OutputField(name, field.is_required(), default_json))
+        return cls(tuple(fields))
+
+    def merge(self, native_fields: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Keep native types while supplying Fleet's required/default metadata."""
+        if [field.get("name") for field in native_fields] != [field.name for field in self.fields]:
+            raise ValueError("interpreter output fields do not match the bound Fleet output contract")
+        result = []
+        for native, field in zip(native_fields, self.fields, strict=True):
+            merged = {**native, "required": field.required}
+            merged.pop("default_json", None)
+            if field.default_json is not None:
+                merged["default_json"] = field.default_json
+            result.append(merged)
+        return result
+
+
+def bind_output_contract(interpreter: Any, signature: Any) -> None:
+    """Bind through the caller-owned adapter; lightweight non-Fleet doubles opt out."""
+    if signature is None or not hasattr(signature, "output_fields"):
+        return
+    bind = getattr(interpreter, "bind_output_contract", None)
+    if callable(bind):
+        bind(FleetOutputContract.from_signature(signature))

--- a/src/fleet_rlm/rlm/program.py
+++ b/src/fleet_rlm/rlm/program.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from fleet_rlm.config.settings import LLMRoleSettings, Settings
 from fleet_rlm.paths import DEFAULT_VOLUME_MOUNT_PATH, validate_mount_path
-from fleet_rlm.rlm.budget import BudgetDimension, TurnBudget
+from fleet_rlm.rlm.budget import AdapterBudget, BudgetDimension, ProviderAdmission, TurnBudget
 from fleet_rlm.rlm.compat_3_3_1 import (
     daytona_provider_contract,
 )
@@ -681,6 +681,7 @@ class RLMModelBundle:
                 deadline=deadline,
                 reserve_seconds=normalized_reserve,
                 budget=turn_budget,
+                can_finalize=False,
             )
             if _supports_turn_lm_copy(self.sub_lm)
             else self.sub_lm
@@ -703,6 +704,7 @@ class RLMModelBundle:
                 deadline=deadline,
                 error_message="recursive child LM deadline exceeded",
                 budget=self.budget,
+                can_finalize=False,
             ),
             sub_lm=_copy_lm_for_deadline(
                 self.sub_lm,
@@ -710,6 +712,7 @@ class RLMModelBundle:
                 reserve_seconds=reserve_seconds,
                 error_message="recursive child LM deadline exceeded",
                 budget=self.budget,
+                can_finalize=False,
             ),
             utility_lm=self.utility_lm,
             deadline=deadline,
@@ -742,15 +745,19 @@ def _supports_turn_lm_copy(lm: Any) -> bool:
 class DeadlineLMProxy(dspy.BaseLM):
     """Turn-owned DSPy LM proxy with one retry owner and no instance method edits."""
 
+    _fleet_trace_identity: Any
+
     def __init__(
         self,
         wrapped: Any,
         *,
-        deadline: float,
+        deadline: float | None,
         reserve_seconds: float,
         retries: int,
         error_message: str,
         budget: TurnBudget | None = None,
+        admission: ProviderAdmission | None = None,
+        can_finalize: bool = True,
     ) -> None:
         super().__init__(
             model=getattr(wrapped, "model", "test/deadline"),
@@ -767,6 +774,8 @@ class DeadlineLMProxy(dspy.BaseLM):
         self._fleet_retry_budget = retries
         self._deadline_error_message = error_message
         self.budget = budget
+        self.admission = admission
+        self.can_finalize = can_finalize
 
     def __getattr__(self, name: str) -> Any:
         wrapped = self.__dict__.get("wrapped")
@@ -792,14 +801,53 @@ class DeadlineLMProxy(dspy.BaseLM):
 
     def copy(self, **kwargs: Any) -> Any:
         kwargs["num_retries"] = 0
-        return type(self)(
+        copied = type(self)(
             self.wrapped.copy(**kwargs),
             deadline=self._fleet_deadline,
             reserve_seconds=self._fleet_reserve_seconds,
             retries=self._fleet_retry_budget,
             error_message=self._deadline_error_message,
             budget=self.budget,
+            admission=self.admission,
+            can_finalize=self.can_finalize,
         )
+        if "_fleet_trace_identity" in vars(self):
+            copied._fleet_trace_identity = self._fleet_trace_identity
+        return copied
+
+    @classmethod
+    def for_adapter(cls, lm: Any, budget: AdapterBudget, *, action: bool, wrap_up: bool) -> DeadlineLMProxy:
+        """Make a call-local view while preserving the immutable provider template."""
+        if isinstance(lm, cls):
+            if lm.budget is not None and lm.budget is not budget.turn:
+                raise RLMModelBundleError("adapter and LM must share the Turn budget")
+            wrapped = lm.wrapped
+            deadline = lm._fleet_deadline
+            reserve = lm._fleet_reserve_seconds
+            retries = lm._fleet_retry_budget
+            can_finalize = lm.can_finalize
+        else:
+            # Real provider LMs must disable their internal retry owner on a copy.
+            # Non-provider BaseLM scripts have no transport retry implementation.
+            wrapped = lm.copy(num_retries=0) if isinstance(lm, dspy.LM) else lm
+            deadline = budget.deadline
+            reserve = 0.0
+            retries = getattr(lm, "num_retries", 0)
+            can_finalize = True
+        if type(retries) is not int or retries < 0:
+            retries = 0
+        view = cls(
+            wrapped,
+            deadline=deadline,
+            reserve_seconds=reserve,
+            retries=retries,
+            error_message="Turn LM deadline exceeded",
+            budget=budget.turn,
+            admission=ProviderAdmission(budget, action, wrap_up, can_finalize),
+            can_finalize=can_finalize,
+        )
+        view._fleet_trace_identity = getattr(lm, "_fleet_trace_identity", lm)
+        return view
 
     def dump_state(self) -> dict[str, Any]:
         """Persist the provider template, never a transient Turn deadline."""
@@ -807,15 +855,19 @@ class DeadlineLMProxy(dspy.BaseLM):
 
     def _attempt_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         bounded = dict(kwargs)
-        bounded["timeout"] = _remaining_lm_timeout(
+        available = _remaining_lm_timeout(
             self._fleet_deadline,
             self,
             bounded,
             reserve_seconds=self._fleet_reserve_seconds,
             error_message=self._deadline_error_message,
         )
-        if self.budget is not None:
-            bounded["timeout"] = min(bounded["timeout"], self.budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS))
+        if self.admission is not None:
+            available = min(available, self.admission.reserve())
+        elif self.budget is not None:
+            available = min(available, self.budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS))
+        if math.isfinite(available):
+            bounded["timeout"] = available
         return bounded
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
@@ -846,6 +898,7 @@ def _copy_lm_for_deadline(
     reserve_seconds: float = 0.0,
     error_message: str = "Turn LM deadline exceeded",
     budget: TurnBudget | None = None,
+    can_finalize: bool = True,
 ) -> Any:
     """Copy one LM and enforce an absolute deadline on every provider attempt."""
     copy_lm = getattr(lm, "copy", None)
@@ -865,6 +918,7 @@ def _copy_lm_for_deadline(
         retries=retry_budget,
         error_message=error_message,
         budget=budget if budget is not None else getattr(lm, "budget", None),
+        can_finalize=can_finalize,
     )
 
 
@@ -878,14 +932,14 @@ def _copy_lm_for_child(lm: Any, *, deadline: float) -> Any:
 
 
 def _remaining_lm_timeout(
-    deadline: float,
+    deadline: float | None,
     lm: Any,
     call_kwargs: dict[str, Any],
     *,
     reserve_seconds: float = 0.0,
     error_message: str = "Turn LM deadline exceeded",
 ) -> float:
-    remaining = deadline - time.monotonic()
+    remaining = math.inf if deadline is None else deadline - time.monotonic()
     available = remaining - max(0.0, reserve_seconds)
     if available <= 0:
         raise TimeoutError(error_message)

--- a/src/fleet_rlm/rlm/program.py
+++ b/src/fleet_rlm/rlm/program.py
@@ -644,6 +644,7 @@ class RLMModelBundle:
     budget: TurnBudget | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
+        """Validate that the model bundle includes both root and sub-models."""
         if self.root_lm is None:
             raise RLMModelBundleError("root_lm is required")
         if self.sub_lm is None:
@@ -652,17 +653,18 @@ class RLMModelBundle:
     def bind_turn_deadline(
         self, *, deadline: float, reserve_seconds: float = 0.0, budget: TurnBudget | None = None
     ) -> RLMModelBundle:
-        """Return isolated Root/Sub runtimes bound to one Turn deadline.
-
-        Production ``dspy.LM`` instances are copied per Turn so a deadline
-        wrapper can never accumulate on a process- or Session-scoped model.
-        Lightweight injected test doubles that do not expose ``copy`` remain
-        untouched; they cannot issue provider calls and preserve the existing
-        preparation-only test seam. A DSPy ``BaseLM`` subclass that overrides
-        ``copy`` is also left in place here: Fleet's live test doubles use that
-        hook to switch the Root response script to a child-specific script,
-        rather than to clone a provider runtime. Child forks still invoke that
-        hook explicitly through :meth:`fork_for_child`.
+        """Bind the root and submodel runtimes to a turn deadline.
+        
+        Parameters:
+            deadline (float): Absolute deadline in seconds, or positive infinity for no deadline.
+            reserve_seconds (float): Time reserved for finalization by the submodel.
+            budget (TurnBudget | None): Optional shared turn budget.
+        
+        Returns:
+            RLMModelBundle: A model bundle with deadline-bound runtimes and budget settings.
+        
+        Raises:
+            ValueError: If the deadline or reserve duration is invalid.
         """
         if (
             not isinstance(deadline, (int, float))
@@ -709,7 +711,14 @@ class RLMModelBundle:
         )
 
     def fork_for_child(self, *, deadline: float) -> RLMModelBundle:
-        """Copy Root/Sub DSPy runtimes and bind every child LM call to one deadline."""
+        """Create isolated root and submodel runtimes for a recursive child bound to a shared deadline.
+        
+        Parameters:
+        	deadline (float): The absolute deadline for all child model calls.
+        
+        Returns:
+        	RLMModelBundle: A model bundle whose root and submodel calls enforce the specified deadline.
+        """
         reserve_seconds = max(0.0, self.reserve_seconds)
         return RLMModelBundle(
             root_lm=_copy_lm_for_deadline(
@@ -772,6 +781,19 @@ class DeadlineLMProxy(dspy.BaseLM):
         admission: ProviderAdmission | None = None,
         can_finalize: bool = True,
     ) -> None:
+        """
+        Initialize a deadline-enforcing language-model proxy.
+        
+        Parameters:
+        	wrapped (Any): Language-model instance to wrap.
+        	deadline (float | None): Absolute deadline for provider calls.
+        	reserve_seconds (float): Time reserved from the deadline for finalization.
+        	retries (int): Number of retry attempts for retryable provider errors.
+        	error_message (str): Message used when the deadline cannot be met.
+        	budget (TurnBudget | None): Optional turn budget shared by provider calls.
+        	admission (ProviderAdmission | None): Optional provider admission controller.
+        	can_finalize (bool): Whether the proxy may reserve time for finalization.
+        """
         super().__init__(
             model=getattr(wrapped, "model", "test/deadline"),
             model_type=getattr(wrapped, "model_type", "chat"),
@@ -791,6 +813,7 @@ class DeadlineLMProxy(dspy.BaseLM):
         self.can_finalize = can_finalize
 
     def __getattr__(self, name: str) -> Any:
+        """Delegate attribute lookup to the wrapped language model."""
         wrapped = self.__dict__.get("wrapped")
         if wrapped is None:
             raise AttributeError(name)
@@ -798,21 +821,47 @@ class DeadlineLMProxy(dspy.BaseLM):
 
     @property
     def supports_function_calling(self) -> bool:
+        """Determine whether the wrapped language model supports function calling.
+        
+        Returns:
+        	bool: `True` if the wrapped model supports function calling, `False` otherwise.
+        """
         return bool(getattr(self.wrapped, "supports_function_calling", False))
 
     @property
     def supports_response_schema(self) -> bool:
+        """
+        Determine whether the wrapped language model supports response schemas.
+        
+        Returns:
+        	bool: `True` if response schemas are supported, `False` otherwise.
+        """
         return bool(getattr(self.wrapped, "supports_response_schema", False))
 
     @property
     def supports_reasoning(self) -> bool:
+        """Indicate whether the wrapped language model supports reasoning.
+        
+        Returns:
+        	bool: `True` if the wrapped model supports reasoning, `False` otherwise.
+        """
         return bool(getattr(self.wrapped, "supports_reasoning", False))
 
     @property
     def supported_params(self) -> set[str]:
+        """Return the parameter names supported by the wrapped language model."""
         return set(getattr(self.wrapped, "supported_params", ()))
 
     def copy(self, **kwargs: Any) -> Any:
+        """
+        Create a copy of the wrapped language model with the current deadline configuration.
+        
+        Parameters:
+            **kwargs: Options forwarded to the wrapped language model copy.
+        
+        Returns:
+            A copied deadline-enforcing language model proxy.
+        """
         kwargs["num_retries"] = 0
         copied = type(self)(
             self.wrapped.copy(**kwargs),
@@ -830,7 +879,7 @@ class DeadlineLMProxy(dspy.BaseLM):
 
     @classmethod
     def for_adapter(cls, lm: Any, budget: AdapterBudget, *, action: bool, wrap_up: bool) -> DeadlineLMProxy:
-        """Make a call-local view while preserving the immutable provider template."""
+        """Create a call-local deadline-enforcing view of an LM using the adapter's budget and provider settings."""
         if isinstance(lm, cls):
             if lm.budget is not None and lm.budget is not budget.turn:
                 raise RLMModelBundleError("adapter and LM must share the Turn budget")
@@ -867,6 +916,15 @@ class DeadlineLMProxy(dspy.BaseLM):
         return self.wrapped.dump_state()
 
     def _attempt_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        """
+        Add a bounded timeout to language-model call parameters based on the remaining turn budget.
+        
+        Parameters:
+            kwargs (dict[str, Any]): Call parameters to copy and constrain.
+        
+        Returns:
+            dict[str, Any]: A copy of the call parameters with a calculated timeout when finite.
+        """
         bounded = dict(kwargs)
         available = _remaining_lm_timeout(
             self._fleet_deadline,
@@ -884,6 +942,15 @@ class DeadlineLMProxy(dspy.BaseLM):
         return bounded
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Forward a language-model request through the wrapped model with bounded retries.
+        
+        Returns:
+            Any: The wrapped model's response.
+        
+        Raises:
+            Exception: The final retryable provider error when all retry attempts fail.
+        """
         for attempt in range(self._fleet_retry_budget + 1):
             bounded = self._attempt_kwargs(kwargs)
             try:
@@ -894,6 +961,14 @@ class DeadlineLMProxy(dspy.BaseLM):
         raise AssertionError("provider retry loop exhausted")
 
     async def aforward(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        Forward a language-model request through the wrapped model with bounded retry handling.
+        
+        Retries failures classified as retryable and propagates the final failure when the retry budget is exhausted.
+        
+        Returns:
+        	Any: The wrapped model's response.
+        """
         for attempt in range(self._fleet_retry_budget + 1):
             bounded = self._attempt_kwargs(kwargs)
             try:
@@ -913,7 +988,23 @@ def _copy_lm_for_deadline(
     budget: TurnBudget | None = None,
     can_finalize: bool = True,
 ) -> Any:
-    """Copy one LM and enforce an absolute deadline on every provider attempt."""
+    """
+    Create an isolated language-model runtime that enforces an absolute deadline for provider attempts.
+    
+    Parameters:
+        lm (Any): Language-model runtime to copy.
+        deadline (float): Absolute deadline for provider attempts.
+        reserve_seconds (float): Time to reserve before the deadline.
+        error_message (str): Message used when the deadline is exceeded.
+        budget (TurnBudget | None): Optional turn budget for provider admission and accounting.
+        can_finalize (bool): Whether the runtime may finalize its turn budget.
+    
+    Returns:
+        Any: A deadline-enforcing language-model proxy.
+    
+    Raises:
+        RLMModelBundleError: If the model cannot be copied or its copy is not isolated.
+    """
     copy_lm = getattr(lm, "copy", None)
     if not callable(copy_lm):
         raise RLMModelBundleError("deadline-bound LM must support DSPy runtime copy()")
@@ -952,6 +1043,23 @@ def _remaining_lm_timeout(
     reserve_seconds: float = 0.0,
     error_message: str = "Turn LM deadline exceeded",
 ) -> float:
+    """
+    Calculate the timeout available for an LM call.
+    
+    Parameters:
+    	deadline (float | None): Absolute monotonic deadline, or `None` for no deadline.
+    	lm (Any): LM whose configured timeout may provide a fallback.
+    	call_kwargs (dict[str, Any]): Call arguments that may contain a timeout.
+    	reserve_seconds (float): Time to preserve after the call.
+    	error_message (str): Message for the timeout error.
+    
+    Returns:
+    	float: The smaller of the configured timeout and remaining available time.
+    
+    Raises:
+    	ValueError: If the deadline or reserve is invalid.
+    	TimeoutError: If the available time is exhausted.
+    """
     if deadline is not None and (
         not isinstance(deadline, (int, float))
         or isinstance(deadline, bool)
@@ -1081,6 +1189,13 @@ class FleetToolCatalog:
     entries: tuple[FleetToolEntry, ...] = ()
 
     def __post_init__(self) -> None:
+        """
+        Validate and normalize the catalog's tool entries.
+        
+        Raises:
+            RLMConfigError: If an entry has an invalid authority kind, an invalid or
+                conflicting name, or a duplicate name.
+        """
         object.__setattr__(self, "entries", tuple(self.entries))
         names: set[str] = set()
         for entry in self.entries:
@@ -1100,6 +1215,15 @@ class FleetToolCatalog:
 
     @classmethod
     def from_tools(cls, tools: Sequence[dspy.Tool] | None) -> FleetToolCatalog:
+        """
+        Create a tool catalog from DSPy tools.
+        
+        Parameters:
+            tools: The tools to include in the catalog. Values are converted to DSPy tools when necessary.
+        
+        Returns:
+            A catalog containing the supplied tools, classified by execution authority.
+        """
         entries = []
         for value in tools or ():
             tool = value if isinstance(value, dspy.Tool) else dspy.Tool(value)
@@ -1113,10 +1237,12 @@ class FleetToolCatalog:
 
     def model_tools(self) -> tuple[dspy.Tool, ...]:
         # Revalidate mutable DSPy tool objects immediately before construction.
+        """Return tools authorized for model execution, excluding settlement-only tools."""
         self.__post_init__()
         return tuple(entry.tool for entry in self.entries if entry.kind != FleetToolKind.SETTLEMENT_ONLY)
 
     def validate_constructed(self, rlm: Any) -> None:
+        """Validate that a constructed RLM exposes exactly the catalog's model tools."""
         expected = {tool.name for tool in self.model_tools()}
         actual = set(rlm.tools)
         if actual != expected or actual & _DSPY_BUILTIN_TOOLS:
@@ -1137,6 +1263,7 @@ class FleetProgramSpec:
     tool_catalog: FleetToolCatalog | None = None
 
     def __post_init__(self) -> None:
+        """Normalize tool configuration and skill instructions after initialization."""
         if self.tools is not None and self.tool_catalog is not None:
             raise RLMConfigError("provide one tool catalog, not both tools and a catalog")
         catalog = self.tool_catalog or FleetToolCatalog.from_tools(self.tools)
@@ -1157,7 +1284,19 @@ def build_native_rlm(
     sub_lm: dspy.LM | None = None,
     verbose: bool = True,
 ) -> Any:
-    """Build one fresh RLM through the DSPy 3.3.x constructor seam."""
+    """
+    Build a configured RLM with the supplied signature, execution limits, tools, and language model.
+    
+    Parameters:
+    	signature: The RLM signature to execute.
+    	options: Execution limits for iterations, language-model calls, and output size.
+    	tools: Tools available to the RLM.
+    	sub_lm: Optional language model for delegated calls.
+    	verbose: Whether to enable verbose execution output.
+    
+    Returns:
+    	A configured RLM instance.
+    """
     catalog = FleetToolCatalog.from_tools(tools)
     rlm = dspy.RLM(
         signature,
@@ -1175,7 +1314,15 @@ def build_native_rlm(
 
 
 def build_program(spec: RLMProgramSpec) -> Any:
-    """Build a native dspy.RLM instance from an RLMProgramSpec."""
+    """
+    Build a native DSPy RLM from the supplied program specification.
+    
+    Parameters:
+        spec (RLMProgramSpec): Program signature, execution options, tools, submodel, and related configuration.
+    
+    Returns:
+        Any: The configured native DSPy RLM instance.
+    """
     sig = spec.signature
     if (
         isinstance(sig, type)
@@ -1211,6 +1358,19 @@ class RLMFactory:
         signature: type[dspy.Signature] | str | None = None,
         verbose: bool | None = None,
     ) -> Any:
+        """
+        Create a configured native RLM program.
+        
+        Parameters:
+        	models (Any): Model bundle providing the optional submodel.
+        	options (RLMOptions): Execution limits and configuration for the program.
+        	tools (Sequence[dspy.Tool] | None): Tools available to the program.
+        	signature (type[dspy.Signature] | str | None): Signature defining the program interface.
+        	verbose (bool | None): Whether to enable verbose execution output.
+        
+        Returns:
+        	Any: The constructed RLM program.
+        """
         return build_program(
             FleetProgramSpec(
                 signature=signature or FleetRLMSignature,

--- a/src/fleet_rlm/rlm/program.py
+++ b/src/fleet_rlm/rlm/program.py
@@ -9,13 +9,14 @@ context capsule staging, and native `dspy.RLM` construction.
 
 from __future__ import annotations
 
-import contextlib
 import hashlib
 import json
+import keyword
+import math
 import os
 import re
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import PurePosixPath
@@ -27,9 +28,9 @@ from dspy.utils.exceptions import LMRateLimitError, LMServerError, LMTimeoutErro
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from fleet_rlm.config.settings import LLMRoleSettings, Settings
-from fleet_rlm.json_types import strict_json_dumps
 from fleet_rlm.paths import DEFAULT_VOLUME_MOUNT_PATH, validate_mount_path
-from fleet_rlm.rlm._dspy_compat import (
+from fleet_rlm.rlm.budget import BudgetDimension, TurnBudget
+from fleet_rlm.rlm.compat_3_3_1 import (
     daytona_provider_contract,
 )
 from fleet_rlm.rlm.result import RLMConfigError, RLMModelBundleError
@@ -640,6 +641,7 @@ class RLMModelBundle:
     utility_lm: Any | None = None
     deadline: float | None = field(default=None, repr=False, compare=False)
     reserve_seconds: float = field(default=0.0, repr=False, compare=False)
+    budget: TurnBudget | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if self.root_lm is None:
@@ -647,7 +649,9 @@ class RLMModelBundle:
         if self.sub_lm is None:
             raise RLMModelBundleError("sub_lm is required")
 
-    def bind_turn_deadline(self, *, deadline: float, reserve_seconds: float = 0.0) -> RLMModelBundle:
+    def bind_turn_deadline(
+        self, *, deadline: float, reserve_seconds: float = 0.0, budget: TurnBudget | None = None
+    ) -> RLMModelBundle:
         """Return isolated Root/Sub runtimes bound to one Turn deadline.
 
         Production ``dspy.LM`` instances are copied per Turn so a deadline
@@ -661,8 +665,13 @@ class RLMModelBundle:
         hook explicitly through :meth:`fork_for_child`.
         """
         normalized_reserve = max(0.0, float(reserve_seconds))
+        # Preparation-only test seams intentionally use an unbounded deadline.
+        # Production Turns supply a finite absolute deadline.
+        turn_budget = budget
+        if turn_budget is None and math.isfinite(deadline):
+            turn_budget = TurnBudget(deadline=deadline)
         root_lm = (
-            _copy_lm_for_deadline(self.root_lm, deadline=deadline)
+            _copy_lm_for_deadline(self.root_lm, deadline=deadline, budget=turn_budget)
             if _supports_turn_lm_copy(self.root_lm)
             else self.root_lm
         )
@@ -671,6 +680,7 @@ class RLMModelBundle:
                 self.sub_lm,
                 deadline=deadline,
                 reserve_seconds=normalized_reserve,
+                budget=turn_budget,
             )
             if _supports_turn_lm_copy(self.sub_lm)
             else self.sub_lm
@@ -681,6 +691,7 @@ class RLMModelBundle:
             utility_lm=self.utility_lm,
             deadline=deadline,
             reserve_seconds=normalized_reserve,
+            budget=turn_budget,
         )
 
     def fork_for_child(self, *, deadline: float) -> RLMModelBundle:
@@ -691,16 +702,19 @@ class RLMModelBundle:
                 self.root_lm,
                 deadline=deadline,
                 error_message="recursive child LM deadline exceeded",
+                budget=self.budget,
             ),
             sub_lm=_copy_lm_for_deadline(
                 self.sub_lm,
                 deadline=deadline,
                 reserve_seconds=reserve_seconds,
                 error_message="recursive child LM deadline exceeded",
+                budget=self.budget,
             ),
             utility_lm=self.utility_lm,
             deadline=deadline,
             reserve_seconds=reserve_seconds,
+            budget=self.budget,
         )
 
 
@@ -725,12 +739,113 @@ def _supports_turn_lm_copy(lm: Any) -> bool:
     )
 
 
+class DeadlineLMProxy(dspy.BaseLM):
+    """Turn-owned DSPy LM proxy with one retry owner and no instance method edits."""
+
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        deadline: float,
+        reserve_seconds: float,
+        retries: int,
+        error_message: str,
+        budget: TurnBudget | None = None,
+    ) -> None:
+        super().__init__(
+            model=getattr(wrapped, "model", "test/deadline"),
+            model_type=getattr(wrapped, "model_type", "chat"),
+            cache=getattr(wrapped, "cache", False),
+            callbacks=getattr(wrapped, "callbacks", None),
+            num_retries=0,
+        )
+        self.wrapped = wrapped
+        self.kwargs = dict(getattr(wrapped, "kwargs", {}))
+        self.history = getattr(wrapped, "history", [])
+        self._fleet_deadline = deadline
+        self._fleet_reserve_seconds = reserve_seconds
+        self._fleet_retry_budget = retries
+        self._deadline_error_message = error_message
+        self.budget = budget
+
+    def __getattr__(self, name: str) -> Any:
+        wrapped = self.__dict__.get("wrapped")
+        if wrapped is None:
+            raise AttributeError(name)
+        return getattr(wrapped, name)
+
+    @property
+    def supports_function_calling(self) -> bool:
+        return bool(getattr(self.wrapped, "supports_function_calling", False))
+
+    @property
+    def supports_response_schema(self) -> bool:
+        return bool(getattr(self.wrapped, "supports_response_schema", False))
+
+    @property
+    def supports_reasoning(self) -> bool:
+        return bool(getattr(self.wrapped, "supports_reasoning", False))
+
+    @property
+    def supported_params(self) -> set[str]:
+        return set(getattr(self.wrapped, "supported_params", ()))
+
+    def copy(self, **kwargs: Any) -> Any:
+        kwargs["num_retries"] = 0
+        return type(self)(
+            self.wrapped.copy(**kwargs),
+            deadline=self._fleet_deadline,
+            reserve_seconds=self._fleet_reserve_seconds,
+            retries=self._fleet_retry_budget,
+            error_message=self._deadline_error_message,
+            budget=self.budget,
+        )
+
+    def dump_state(self) -> dict[str, Any]:
+        """Persist the provider template, never a transient Turn deadline."""
+        return self.wrapped.dump_state()
+
+    def _attempt_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        bounded = dict(kwargs)
+        bounded["timeout"] = _remaining_lm_timeout(
+            self._fleet_deadline,
+            self,
+            bounded,
+            reserve_seconds=self._fleet_reserve_seconds,
+            error_message=self._deadline_error_message,
+        )
+        if self.budget is not None:
+            bounded["timeout"] = min(bounded["timeout"], self.budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS))
+        return bounded
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        for attempt in range(self._fleet_retry_budget + 1):
+            bounded = self._attempt_kwargs(kwargs)
+            try:
+                return self.wrapped.forward(*args, **bounded)
+            except _RETRYABLE_LM_ERRORS:
+                if attempt == self._fleet_retry_budget:
+                    raise
+        raise AssertionError("provider retry loop exhausted")
+
+    async def aforward(self, *args: Any, **kwargs: Any) -> Any:
+        for attempt in range(self._fleet_retry_budget + 1):
+            bounded = self._attempt_kwargs(kwargs)
+            try:
+                return await self.wrapped.aforward(*args, **bounded)
+            except _RETRYABLE_LM_ERRORS:
+                if attempt == self._fleet_retry_budget:
+                    raise
+        raise AssertionError("provider retry loop exhausted")
+
+
 def _copy_lm_for_deadline(
     lm: Any,
     *,
     deadline: float,
     reserve_seconds: float = 0.0,
     error_message: str = "Turn LM deadline exceeded",
+    budget: TurnBudget | None = None,
 ) -> Any:
     """Copy one LM and enforce an absolute deadline on every provider attempt."""
     copy_lm = getattr(lm, "copy", None)
@@ -739,69 +854,18 @@ def _copy_lm_for_deadline(
     retry_budget = getattr(lm, "_fleet_retry_budget", getattr(lm, "num_retries", 0))
     if not isinstance(retry_budget, int) or isinstance(retry_budget, bool) or retry_budget < 0:
         retry_budget = 0
-    copied = copy_lm(num_retries=0)
+    copied = lm.wrapped.copy(num_retries=0) if isinstance(lm, DeadlineLMProxy) else copy_lm(num_retries=0)
     if copied is lm:
         raise RLMModelBundleError("deadline-bound LM copy() must return an isolated runtime")
 
-    # DSPy's LM.copy() is intentionally shallow. Remove inherited instance
-    # wrappers before capturing the new copy's class methods so child and
-    # subsequent Turn wrappers never chain closures.
-    instance_dict = getattr(copied, "__dict__", None)
-    if isinstance(instance_dict, dict):
-        instance_dict.pop("forward", None)
-        instance_dict.pop("aforward", None)
-
-    original_forward = copied.forward
-
-    def forward_with_deadline(*args: Any, **kwargs: Any) -> Any:
-        attempt = 0
-        while True:
-            call_kwargs = dict(kwargs)
-            call_kwargs["timeout"] = _remaining_lm_timeout(
-                deadline,
-                copied,
-                call_kwargs,
-                reserve_seconds=reserve_seconds,
-                error_message=error_message,
-            )
-            try:
-                return original_forward(*args, **call_kwargs)
-            except _RETRYABLE_LM_ERRORS:
-                if attempt >= retry_budget:
-                    raise
-                attempt += 1
-
-    copied.forward = forward_with_deadline
-    original_aforward = getattr(copied, "aforward", None)
-    if callable(original_aforward):
-
-        async def aforward_with_deadline(*args: Any, **kwargs: Any) -> Any:
-            attempt = 0
-            while True:
-                call_kwargs = dict(kwargs)
-                call_kwargs["timeout"] = _remaining_lm_timeout(
-                    deadline,
-                    copied,
-                    call_kwargs,
-                    reserve_seconds=reserve_seconds,
-                    error_message=error_message,
-                )
-                try:
-                    return await original_aforward(*args, **call_kwargs)
-                except _RETRYABLE_LM_ERRORS:
-                    if attempt >= retry_budget:
-                        raise
-                    attempt += 1
-
-        copied.aforward = aforward_with_deadline
-    for name, value in (
-        ("_fleet_retry_budget", retry_budget),
-        ("_fleet_deadline", deadline),
-        ("_fleet_reserve_seconds", reserve_seconds),
-    ):
-        with contextlib.suppress(AttributeError, TypeError):
-            setattr(copied, name, value)
-    return copied
+    return DeadlineLMProxy(
+        copied,
+        deadline=deadline,
+        reserve_seconds=reserve_seconds,
+        retries=retry_budget,
+        error_message=error_message,
+        budget=budget if budget is not None else getattr(lm, "budget", None),
+    )
 
 
 def _copy_lm_for_child(lm: Any, *, deadline: float) -> Any:
@@ -914,8 +978,73 @@ def build_lm_for_tier(
 # ---------------------------------------------------------------------------
 
 
+class FleetToolKind(StrEnum):
+    SANDBOX_LOCAL = "sandbox-local"
+    HOST_AUTHORIZED = "host-authorized"
+    RECURSIVE = "recursive"
+    SETTLEMENT_ONLY = "settlement-only"
+
+
+_DSPY_BUILTIN_TOOLS = frozenset({"llm_query", "llm_query_batched", "print", "SUBMIT"})
+
+
 @dataclass(frozen=True, slots=True)
-class RLMProgramSpec:
+class FleetToolEntry:
+    tool: dspy.Tool
+    kind: FleetToolKind
+
+
+@dataclass(frozen=True, slots=True)
+class FleetToolCatalog:
+    """Immutable tool membership and authority; settlement tools never enter RLM."""
+
+    entries: tuple[FleetToolEntry, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "entries", tuple(self.entries))
+        names: set[str] = set()
+        for entry in self.entries:
+            name = entry.tool.name
+            if not isinstance(entry.kind, FleetToolKind):
+                raise RLMConfigError("tool authority must be an explicit FleetToolKind")
+            if (
+                not isinstance(name, str)
+                or not name.isidentifier()
+                or keyword.iskeyword(name)
+                or name in _DSPY_BUILTIN_TOOLS
+            ):
+                raise RLMConfigError("tool name conflicts with the DSPy execution namespace")
+            if name in names:
+                raise RLMConfigError("duplicate Fleet tool name")
+            names.add(name)
+
+    @classmethod
+    def from_tools(cls, tools: Sequence[dspy.Tool] | None) -> FleetToolCatalog:
+        entries = []
+        for value in tools or ():
+            tool = value if isinstance(value, dspy.Tool) else dspy.Tool(value)
+            kind = (
+                FleetToolKind.RECURSIVE
+                if tool.name in {"rlm_query", "rlm_query_batched"}
+                else FleetToolKind.HOST_AUTHORIZED
+            )
+            entries.append(FleetToolEntry(tool, kind))
+        return cls(tuple(entries))
+
+    def model_tools(self) -> tuple[dspy.Tool, ...]:
+        # Revalidate mutable DSPy tool objects immediately before construction.
+        self.__post_init__()
+        return tuple(entry.tool for entry in self.entries if entry.kind != FleetToolKind.SETTLEMENT_ONLY)
+
+    def validate_constructed(self, rlm: Any) -> None:
+        expected = {tool.name for tool in self.model_tools()}
+        actual = set(rlm.tools)
+        if actual != expected or actual & _DSPY_BUILTIN_TOOLS:
+            raise RLMConfigError("constructed DSPy tool namespace differs from the Fleet catalog")
+
+
+@dataclass(frozen=True, slots=True)
+class FleetProgramSpec:
     """Full specification for constructing one native DSPy RLM program."""
 
     signature: type[dspy.Signature] | str = FleetRLMSignature
@@ -925,6 +1054,19 @@ class RLMProgramSpec:
     skill_instructions: tuple[str, ...] = ()
     recursion_enabled: bool = False
     verbose: bool = True
+    tool_catalog: FleetToolCatalog | None = None
+
+    def __post_init__(self) -> None:
+        if self.tools is not None and self.tool_catalog is not None:
+            raise RLMConfigError("provide one tool catalog, not both tools and a catalog")
+        catalog = self.tool_catalog or FleetToolCatalog.from_tools(self.tools)
+        object.__setattr__(self, "tool_catalog", catalog)
+        object.__setattr__(self, "tools", catalog.model_tools())
+        object.__setattr__(self, "skill_instructions", tuple(self.skill_instructions))
+
+
+# Retain the existing import name while evolving the single construction seam.
+RLMProgramSpec = FleetProgramSpec
 
 
 def build_native_rlm(
@@ -936,48 +1078,30 @@ def build_native_rlm(
     verbose: bool = True,
 ) -> Any:
     """Build one fresh RLM through the DSPy 3.3.x constructor seam."""
+    catalog = FleetToolCatalog.from_tools(tools)
     rlm = dspy.RLM(
         signature,
         max_iters=options.max_iters,
         max_llm_calls=options.max_llm_calls,
         max_output_chars=options.max_output_chars,
         verbose=verbose,
-        tools=list(tools) if tools is not None else None,
+        tools=list(catalog.model_tools()),
         sub_lm=sub_lm,
         interpreter_factory=daytona_provider_contract,
     )
+    catalog.validate_constructed(rlm)
 
-    def build_output_fields() -> list[dict[str, Any]]:
-        output_fields: list[dict[str, Any]] = []
-        for name, sig_field in rlm.signature.output_fields.items():
-            metadata: dict[str, Any] = {"name": name, "required": sig_field.is_required()}
-            annotation = getattr(sig_field, "annotation", str)
-            if annotation in {str, int, float, bool}:
-                metadata["type"] = annotation.__name__
-            if not sig_field.is_required():
-                default = sig_field.default
-                factory = sig_field.default_factory
-                if factory is not None:
-                    default = cast(Callable[[], Any], factory)()
-                metadata["default_json"] = strict_json_dumps(default)
-            output_fields.append(metadata)
-        return output_fields
-
-    original_inject = rlm._inject_execution_context
-
-    def inject_with_fleet_metadata(interpreter: Any, execution_tools: dict[str, Any]) -> None:
-        original_inject(interpreter, execution_tools)
-        if hasattr(interpreter, "output_fields"):
-            interpreter.output_fields = build_output_fields()
-
-    rlm._inject_execution_context = inject_with_fleet_metadata
     return rlm
 
 
 def build_program(spec: RLMProgramSpec) -> Any:
     """Build a native dspy.RLM instance from an RLMProgramSpec."""
     sig = spec.signature
-    if isinstance(sig, type) and issubclass(sig, dspy.Signature):
+    if (
+        isinstance(sig, type)
+        and issubclass(sig, dspy.Signature)
+        and (spec.recursion_enabled or spec.skill_instructions)
+    ):
         sig = root_signature_for_recursion(
             sig,
             recursion_enabled=spec.recursion_enabled,
@@ -1007,12 +1131,14 @@ class RLMFactory:
         signature: type[dspy.Signature] | str | None = None,
         verbose: bool | None = None,
     ) -> Any:
-        return build_native_rlm(
-            signature=signature or FleetRLMSignature,
-            options=options,
-            tools=tools,
-            sub_lm=getattr(models, "sub_lm", None),
-            verbose=self.verbose if verbose is None else verbose,
+        return build_program(
+            FleetProgramSpec(
+                signature=signature or FleetRLMSignature,
+                options=options,
+                tools=tools,
+                sub_lm=getattr(models, "sub_lm", None),
+                verbose=self.verbose if verbose is None else verbose,
+            )
         )
 
 
@@ -1026,7 +1152,11 @@ __all__ = [
     "AttachmentContextEntry",
     "AttachmentInput",
     "FleetInputModel",
+    "FleetProgramSpec",
     "FleetRLMSignature",
+    "FleetToolCatalog",
+    "FleetToolEntry",
+    "FleetToolKind",
     "LMTier",
     "RLMFactory",
     "RLMInstructionFragments",

--- a/src/fleet_rlm/rlm/program.py
+++ b/src/fleet_rlm/rlm/program.py
@@ -654,15 +654,15 @@ class RLMModelBundle:
         self, *, deadline: float, reserve_seconds: float = 0.0, budget: TurnBudget | None = None
     ) -> RLMModelBundle:
         """Bind the root and submodel runtimes to a turn deadline.
-        
+
         Parameters:
             deadline (float): Absolute deadline in seconds, or positive infinity for no deadline.
             reserve_seconds (float): Time reserved for finalization by the submodel.
             budget (TurnBudget | None): Optional shared turn budget.
-        
+
         Returns:
             RLMModelBundle: A model bundle with deadline-bound runtimes and budget settings.
-        
+
         Raises:
             ValueError: If the deadline or reserve duration is invalid.
         """
@@ -712,12 +712,12 @@ class RLMModelBundle:
 
     def fork_for_child(self, *, deadline: float) -> RLMModelBundle:
         """Create isolated root and submodel runtimes for a recursive child bound to a shared deadline.
-        
+
         Parameters:
-        	deadline (float): The absolute deadline for all child model calls.
-        
+                deadline (float): The absolute deadline for all child model calls.
+
         Returns:
-        	RLMModelBundle: A model bundle whose root and submodel calls enforce the specified deadline.
+                RLMModelBundle: A model bundle whose root and submodel calls enforce the specified deadline.
         """
         reserve_seconds = max(0.0, self.reserve_seconds)
         return RLMModelBundle(
@@ -783,16 +783,16 @@ class DeadlineLMProxy(dspy.BaseLM):
     ) -> None:
         """
         Initialize a deadline-enforcing language-model proxy.
-        
+
         Parameters:
-        	wrapped (Any): Language-model instance to wrap.
-        	deadline (float | None): Absolute deadline for provider calls.
-        	reserve_seconds (float): Time reserved from the deadline for finalization.
-        	retries (int): Number of retry attempts for retryable provider errors.
-        	error_message (str): Message used when the deadline cannot be met.
-        	budget (TurnBudget | None): Optional turn budget shared by provider calls.
-        	admission (ProviderAdmission | None): Optional provider admission controller.
-        	can_finalize (bool): Whether the proxy may reserve time for finalization.
+                wrapped (Any): Language-model instance to wrap.
+                deadline (float | None): Absolute deadline for provider calls.
+                reserve_seconds (float): Time reserved from the deadline for finalization.
+                retries (int): Number of retry attempts for retryable provider errors.
+                error_message (str): Message used when the deadline cannot be met.
+                budget (TurnBudget | None): Optional turn budget shared by provider calls.
+                admission (ProviderAdmission | None): Optional provider admission controller.
+                can_finalize (bool): Whether the proxy may reserve time for finalization.
         """
         super().__init__(
             model=getattr(wrapped, "model", "test/deadline"),
@@ -822,9 +822,9 @@ class DeadlineLMProxy(dspy.BaseLM):
     @property
     def supports_function_calling(self) -> bool:
         """Determine whether the wrapped language model supports function calling.
-        
+
         Returns:
-        	bool: `True` if the wrapped model supports function calling, `False` otherwise.
+                bool: `True` if the wrapped model supports function calling, `False` otherwise.
         """
         return bool(getattr(self.wrapped, "supports_function_calling", False))
 
@@ -832,18 +832,18 @@ class DeadlineLMProxy(dspy.BaseLM):
     def supports_response_schema(self) -> bool:
         """
         Determine whether the wrapped language model supports response schemas.
-        
+
         Returns:
-        	bool: `True` if response schemas are supported, `False` otherwise.
+                bool: `True` if response schemas are supported, `False` otherwise.
         """
         return bool(getattr(self.wrapped, "supports_response_schema", False))
 
     @property
     def supports_reasoning(self) -> bool:
         """Indicate whether the wrapped language model supports reasoning.
-        
+
         Returns:
-        	bool: `True` if the wrapped model supports reasoning, `False` otherwise.
+                bool: `True` if the wrapped model supports reasoning, `False` otherwise.
         """
         return bool(getattr(self.wrapped, "supports_reasoning", False))
 
@@ -855,10 +855,10 @@ class DeadlineLMProxy(dspy.BaseLM):
     def copy(self, **kwargs: Any) -> Any:
         """
         Create a copy of the wrapped language model with the current deadline configuration.
-        
+
         Parameters:
             **kwargs: Options forwarded to the wrapped language model copy.
-        
+
         Returns:
             A copied deadline-enforcing language model proxy.
         """
@@ -918,10 +918,10 @@ class DeadlineLMProxy(dspy.BaseLM):
     def _attempt_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
         """
         Add a bounded timeout to language-model call parameters based on the remaining turn budget.
-        
+
         Parameters:
             kwargs (dict[str, Any]): Call parameters to copy and constrain.
-        
+
         Returns:
             dict[str, Any]: A copy of the call parameters with a calculated timeout when finite.
         """
@@ -944,10 +944,10 @@ class DeadlineLMProxy(dspy.BaseLM):
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         """
         Forward a language-model request through the wrapped model with bounded retries.
-        
+
         Returns:
             Any: The wrapped model's response.
-        
+
         Raises:
             Exception: The final retryable provider error when all retry attempts fail.
         """
@@ -963,11 +963,11 @@ class DeadlineLMProxy(dspy.BaseLM):
     async def aforward(self, *args: Any, **kwargs: Any) -> Any:
         """
         Forward a language-model request through the wrapped model with bounded retry handling.
-        
+
         Retries failures classified as retryable and propagates the final failure when the retry budget is exhausted.
-        
+
         Returns:
-        	Any: The wrapped model's response.
+                Any: The wrapped model's response.
         """
         for attempt in range(self._fleet_retry_budget + 1):
             bounded = self._attempt_kwargs(kwargs)
@@ -990,7 +990,7 @@ def _copy_lm_for_deadline(
 ) -> Any:
     """
     Create an isolated language-model runtime that enforces an absolute deadline for provider attempts.
-    
+
     Parameters:
         lm (Any): Language-model runtime to copy.
         deadline (float): Absolute deadline for provider attempts.
@@ -998,10 +998,10 @@ def _copy_lm_for_deadline(
         error_message (str): Message used when the deadline is exceeded.
         budget (TurnBudget | None): Optional turn budget for provider admission and accounting.
         can_finalize (bool): Whether the runtime may finalize its turn budget.
-    
+
     Returns:
         Any: A deadline-enforcing language-model proxy.
-    
+
     Raises:
         RLMModelBundleError: If the model cannot be copied or its copy is not isolated.
     """
@@ -1045,20 +1045,20 @@ def _remaining_lm_timeout(
 ) -> float:
     """
     Calculate the timeout available for an LM call.
-    
+
     Parameters:
-    	deadline (float | None): Absolute monotonic deadline, or `None` for no deadline.
-    	lm (Any): LM whose configured timeout may provide a fallback.
-    	call_kwargs (dict[str, Any]): Call arguments that may contain a timeout.
-    	reserve_seconds (float): Time to preserve after the call.
-    	error_message (str): Message for the timeout error.
-    
+        deadline (float | None): Absolute monotonic deadline, or `None` for no deadline.
+        lm (Any): LM whose configured timeout may provide a fallback.
+        call_kwargs (dict[str, Any]): Call arguments that may contain a timeout.
+        reserve_seconds (float): Time to preserve after the call.
+        error_message (str): Message for the timeout error.
+
     Returns:
-    	float: The smaller of the configured timeout and remaining available time.
-    
+        float: The smaller of the configured timeout and remaining available time.
+
     Raises:
-    	ValueError: If the deadline or reserve is invalid.
-    	TimeoutError: If the available time is exhausted.
+        ValueError: If the deadline or reserve is invalid.
+        TimeoutError: If the available time is exhausted.
     """
     if deadline is not None and (
         not isinstance(deadline, (int, float))
@@ -1191,7 +1191,7 @@ class FleetToolCatalog:
     def __post_init__(self) -> None:
         """
         Validate and normalize the catalog's tool entries.
-        
+
         Raises:
             RLMConfigError: If an entry has an invalid authority kind, an invalid or
                 conflicting name, or a duplicate name.
@@ -1217,10 +1217,10 @@ class FleetToolCatalog:
     def from_tools(cls, tools: Sequence[dspy.Tool] | None) -> FleetToolCatalog:
         """
         Create a tool catalog from DSPy tools.
-        
+
         Parameters:
             tools: The tools to include in the catalog. Values are converted to DSPy tools when necessary.
-        
+
         Returns:
             A catalog containing the supplied tools, classified by execution authority.
         """
@@ -1286,16 +1286,16 @@ def build_native_rlm(
 ) -> Any:
     """
     Build a configured RLM with the supplied signature, execution limits, tools, and language model.
-    
+
     Parameters:
-    	signature: The RLM signature to execute.
-    	options: Execution limits for iterations, language-model calls, and output size.
-    	tools: Tools available to the RLM.
-    	sub_lm: Optional language model for delegated calls.
-    	verbose: Whether to enable verbose execution output.
-    
+        signature: The RLM signature to execute.
+        options: Execution limits for iterations, language-model calls, and output size.
+        tools: Tools available to the RLM.
+        sub_lm: Optional language model for delegated calls.
+        verbose: Whether to enable verbose execution output.
+
     Returns:
-    	A configured RLM instance.
+        A configured RLM instance.
     """
     catalog = FleetToolCatalog.from_tools(tools)
     rlm = dspy.RLM(
@@ -1316,10 +1316,10 @@ def build_native_rlm(
 def build_program(spec: RLMProgramSpec) -> Any:
     """
     Build a native DSPy RLM from the supplied program specification.
-    
+
     Parameters:
         spec (RLMProgramSpec): Program signature, execution options, tools, submodel, and related configuration.
-    
+
     Returns:
         Any: The configured native DSPy RLM instance.
     """
@@ -1360,16 +1360,16 @@ class RLMFactory:
     ) -> Any:
         """
         Create a configured native RLM program.
-        
+
         Parameters:
-        	models (Any): Model bundle providing the optional submodel.
-        	options (RLMOptions): Execution limits and configuration for the program.
-        	tools (Sequence[dspy.Tool] | None): Tools available to the program.
-        	signature (type[dspy.Signature] | str | None): Signature defining the program interface.
-        	verbose (bool | None): Whether to enable verbose execution output.
-        
+                models (Any): Model bundle providing the optional submodel.
+                options (RLMOptions): Execution limits and configuration for the program.
+                tools (Sequence[dspy.Tool] | None): Tools available to the program.
+                signature (type[dspy.Signature] | str | None): Signature defining the program interface.
+                verbose (bool | None): Whether to enable verbose execution output.
+
         Returns:
-        	Any: The constructed RLM program.
+                Any: The constructed RLM program.
         """
         return build_program(
             FleetProgramSpec(

--- a/src/fleet_rlm/rlm/program.py
+++ b/src/fleet_rlm/rlm/program.py
@@ -664,7 +664,20 @@ class RLMModelBundle:
         rather than to clone a provider runtime. Child forks still invoke that
         hook explicitly through :meth:`fork_for_child`.
         """
-        normalized_reserve = max(0.0, float(reserve_seconds))
+        if (
+            not isinstance(deadline, (int, float))
+            or isinstance(deadline, bool)
+            or (not math.isfinite(deadline) and deadline != math.inf)
+        ):
+            raise ValueError("deadline must be finite or positive infinity")
+        if (
+            not isinstance(reserve_seconds, (int, float))
+            or isinstance(reserve_seconds, bool)
+            or not math.isfinite(reserve_seconds)
+            or reserve_seconds < 0
+        ):
+            raise ValueError("reserve_seconds must be finite and nonnegative")
+        normalized_reserve = float(reserve_seconds)
         # Preparation-only test seams intentionally use an unbounded deadline.
         # Production Turns supply a finite absolute deadline.
         turn_budget = budget
@@ -939,8 +952,21 @@ def _remaining_lm_timeout(
     reserve_seconds: float = 0.0,
     error_message: str = "Turn LM deadline exceeded",
 ) -> float:
+    if deadline is not None and (
+        not isinstance(deadline, (int, float))
+        or isinstance(deadline, bool)
+        or (not math.isfinite(deadline) and deadline != math.inf)
+    ):
+        raise ValueError("deadline must be finite, positive infinity, or None")
+    if (
+        not isinstance(reserve_seconds, (int, float))
+        or isinstance(reserve_seconds, bool)
+        or not math.isfinite(reserve_seconds)
+        or reserve_seconds < 0
+    ):
+        raise ValueError("reserve_seconds must be finite and nonnegative")
     remaining = math.inf if deadline is None else deadline - time.monotonic()
-    available = remaining - max(0.0, reserve_seconds)
+    available = remaining - float(reserve_seconds)
     if available <= 0:
         raise TimeoutError(error_message)
     configured = call_kwargs.get("timeout")

--- a/src/fleet_rlm/rlm/recursion.py
+++ b/src/fleet_rlm/rlm/recursion.py
@@ -1338,6 +1338,7 @@ class RecursiveRLMExecutor:
             adapter=FleetJSONAdapter(
                 deadline=self._deadline,
                 wrap_up_seconds=child_models.reserve_seconds,
+                budget=child_models.budget,
             ),
             callbacks=[
                 _RLMTraceCallback(
@@ -1554,7 +1555,7 @@ class RecursiveRLMExecutor:
         predictor = dspy.Predict(RecursiveSubtaskSignature)
         with dspy.context(
             lm=self._models.sub_lm,
-            adapter=FleetJSONAdapter(deadline=self._deadline),
+            adapter=FleetJSONAdapter(deadline=self._deadline, budget=self._models.budget),
             callbacks=[
                 _RLMTraceCallback(
                     root_lm=self._models.root_lm,

--- a/src/fleet_rlm/rlm/recursion.py
+++ b/src/fleet_rlm/rlm/recursion.py
@@ -25,6 +25,7 @@ from fleet_rlm.chat.session_context import SessionContextManifest
 from fleet_rlm.config.settings import Settings
 from fleet_rlm.observability.diagnostics import trace_failure_category
 from fleet_rlm.observability.tracing import start_turn_span
+from fleet_rlm.rlm.budget import BudgetDimension
 from fleet_rlm.rlm.compat_3_3_1 import CodeInterpreter, FleetJSONAdapter, _RLMTraceCallback
 from fleet_rlm.rlm.events import Status, ToolEventView, ToolObserver, observe_tool
 from fleet_rlm.rlm.output_contract import bind_output_contract
@@ -1220,6 +1221,13 @@ class RecursiveRLMExecutor:
         with self._state.lock:
             if self._state.reserved_call_count + len(prompts) > self._options.max_calls:
                 raise RuntimeError("recursive call budget exhausted")
+            turn_budget = self._models.budget
+            if turn_budget is not None:
+                # A recursive request is both a Tool invocation and a child
+                # admission. Reserve the Tool counter first so an attempted
+                # request that fails the child ceiling is still accounted for.
+                turn_budget.reserve(BudgetDimension.TOOL_CALLS, len(prompts))
+                turn_budget.reserve(BudgetDimension.RECURSIVE_CHILDREN, len(prompts))
             start = self._state.reserved_call_count + 1
             self._state.reserved_call_count += len(prompts)
             self._state.delegated_prompt_chars += sum(len(prompt) for prompt in prompts)
@@ -1280,6 +1288,9 @@ class RecursiveRLMExecutor:
         if time.monotonic() >= self._deadline:
             raise TimeoutError("recursive child deadline exceeded")
         child_models = self._models.fork_for_child(deadline=self._deadline)
+        bind_budget = getattr(lease.interpreter, "bind_turn_budget", None)
+        if callable(bind_budget):
+            bind_budget(child_models.budget)
         child_executor = RecursiveRLMExecutor(
             models=child_models,
             options=self._options,

--- a/src/fleet_rlm/rlm/recursion.py
+++ b/src/fleet_rlm/rlm/recursion.py
@@ -1216,6 +1216,18 @@ class RecursiveRLMExecutor:
         return tuple(self._make_reservation(prompt, index) for prompt, index in zip(prompts, indexes, strict=True))
 
     def _reserve_call_indexes(self, prompts: tuple[str, ...]) -> tuple[int, ...]:
+        """
+        Reserve call indexes for a batch of recursive prompts.
+        
+        Parameters:
+            prompts (tuple[str, ...]): Prompts whose recursive call capacity should be reserved.
+        
+        Returns:
+            tuple[int, ...]: Consecutive 1-based indexes assigned to the prompts.
+        
+        Raises:
+            RuntimeError: If reserving the prompts would exceed the configured recursive call limit.
+        """
         if not prompts:
             return ()
         with self._state.lock:
@@ -1284,6 +1296,18 @@ class RecursiveRLMExecutor:
         lease: ChildRuntimeLease,
         batch_cancelled: Event | None = None,
     ) -> tuple[str, dict[str, object]]:
+        """
+        Execute a recursive child using the native RLM runtime.
+        
+        Parameters:
+            prompt (str): The prompt to send to the child.
+            call (_RecursiveCall): Reserved call metadata, including the child depth.
+            lease (ChildRuntimeLease): Runtime lease used for child execution.
+            batch_cancelled (Event | None): Optional event indicating that the enclosing batch was cancelled.
+        
+        Returns:
+            tuple[str, dict[str, object]]: The child's bounded display text and completion metadata.
+        """
         self._ensure_call_authorized(batch_cancelled)
         if time.monotonic() >= self._deadline:
             raise TimeoutError("recursive child deadline exceeded")

--- a/src/fleet_rlm/rlm/recursion.py
+++ b/src/fleet_rlm/rlm/recursion.py
@@ -25,8 +25,9 @@ from fleet_rlm.chat.session_context import SessionContextManifest
 from fleet_rlm.config.settings import Settings
 from fleet_rlm.observability.diagnostics import trace_failure_category
 from fleet_rlm.observability.tracing import start_turn_span
-from fleet_rlm.rlm._dspy_compat import CodeInterpreter, FleetJSONAdapter, _RLMTraceCallback
+from fleet_rlm.rlm.compat_3_3_1 import CodeInterpreter, FleetJSONAdapter, _RLMTraceCallback
 from fleet_rlm.rlm.events import Status, ToolEventView, ToolObserver, observe_tool
+from fleet_rlm.rlm.output_contract import bind_output_contract
 from fleet_rlm.rlm.program import (
     RLMModelBundle,
     RLMOptions,
@@ -1328,6 +1329,7 @@ class RecursiveRLMExecutor:
             verbose=False,
         )
         self._ensure_call_authorized(batch_cancelled)
+        bind_output_contract(lease.interpreter, getattr(child, "signature", None))
         with dspy.context(
             lm=child_models.root_lm,
             # Same pinned JSON action protocol plus bounded corrective re-ask

--- a/src/fleet_rlm/rlm/recursion.py
+++ b/src/fleet_rlm/rlm/recursion.py
@@ -1218,13 +1218,13 @@ class RecursiveRLMExecutor:
     def _reserve_call_indexes(self, prompts: tuple[str, ...]) -> tuple[int, ...]:
         """
         Reserve call indexes for a batch of recursive prompts.
-        
+
         Parameters:
             prompts (tuple[str, ...]): Prompts whose recursive call capacity should be reserved.
-        
+
         Returns:
             tuple[int, ...]: Consecutive 1-based indexes assigned to the prompts.
-        
+
         Raises:
             RuntimeError: If reserving the prompts would exceed the configured recursive call limit.
         """
@@ -1298,13 +1298,13 @@ class RecursiveRLMExecutor:
     ) -> tuple[str, dict[str, object]]:
         """
         Execute a recursive child using the native RLM runtime.
-        
+
         Parameters:
             prompt (str): The prompt to send to the child.
             call (_RecursiveCall): Reserved call metadata, including the child depth.
             lease (ChildRuntimeLease): Runtime lease used for child execution.
             batch_cancelled (Event | None): Optional event indicating that the enclosing batch was cancelled.
-        
+
         Returns:
             tuple[str, dict[str, object]]: The child's bounded display text and completion metadata.
         """

--- a/src/fleet_rlm/rlm/runtime.py
+++ b/src/fleet_rlm/rlm/runtime.py
@@ -35,7 +35,7 @@ from fleet_rlm.attachments.models import PreparedAttachment
 from fleet_rlm.chat.run_authority import RunAuthority
 from fleet_rlm.config.settings import Settings
 from fleet_rlm.observability.diagnostics import normalize_turn_failure
-from fleet_rlm.rlm._dspy_compat import (
+from fleet_rlm.rlm.compat_3_3_1 import (
     CodeInterpreter,
     bind_native_rlm_observer,
 )
@@ -57,6 +57,7 @@ from fleet_rlm.rlm.events import (
     observe_tool,
     reconcile_trajectory,
 )
+from fleet_rlm.rlm.output_contract import bind_output_contract
 from fleet_rlm.rlm.program import (
     AttachmentContextCapsule,
     FleetRLMSignature,
@@ -1634,6 +1635,10 @@ class RLMRunner:
             if hasattr(lease.state.rlm, "sub_lm"):
                 lease.state.rlm.sub_lm = state_context.execution.models.sub_lm
             self._bind_context_capsule(state_context)
+            bind_output_contract(
+                state_context.execution.interpreter,
+                getattr(lease.state.rlm, "signature", None),
+            )
             self._bind_observer(
                 lease.state.rlm,
                 observations.publish,

--- a/src/fleet_rlm/rlm/runtime.py
+++ b/src/fleet_rlm/rlm/runtime.py
@@ -35,12 +35,14 @@ from fleet_rlm.attachments.models import PreparedAttachment
 from fleet_rlm.chat.run_authority import RunAuthority
 from fleet_rlm.config.settings import Settings
 from fleet_rlm.observability.diagnostics import normalize_turn_failure
+from fleet_rlm.rlm.budget import BudgetDimension, TurnBudget
 from fleet_rlm.rlm.compat_3_3_1 import (
     CodeInterpreter,
     bind_native_rlm_observer,
 )
 from fleet_rlm.rlm.events import (
     PROVIDER_ENDPOINT_NOT_FOUND_MESSAGE,
+    AsyncToolBridge,
     AttachmentRead,
     ExecutionTraceAssembler,
     ObservationSession,
@@ -278,6 +280,9 @@ class ExecutionRuntime:
     cancellation_requested: AsyncCancellationProbe
     deadline: float
     environment_release: RetainableEnvironmentRelease | None = None
+    # Composition-owned bridge for async host Tools called synchronously by
+    # DSPy's worker-side interpreter.
+    async_bridge: AsyncToolBridge | None = None
     # Directly constructed test/in-process contexts opt into the reserve via
     # preparation; the public TOML default is applied by the live composition.
     wrap_up_seconds: float = 0.0
@@ -480,6 +485,7 @@ class RunToolGuards:
     integrity: RunIntegrityLedger = field(default_factory=RunIntegrityLedger)
     progress: ToolProgressGuard = field(default_factory=ToolProgressGuard)
     required_targets: frozenset[str] | None = None
+    budget: TurnBudget | None = None
 
     def __post_init__(self) -> None:
         if self.required_targets is not None:
@@ -491,6 +497,11 @@ class RunToolGuards:
 
     def failed(self, tool_name: str, arguments: Mapping[str, Any]) -> None:
         self.integrity.failed(tool_name, arguments)
+
+    def reserve_tool(self) -> None:
+        """Admit one host Tool call against the Turn-wide ledger."""
+        if self.budget is not None:
+            self.budget.reserve(BudgetDimension.TOOL_CALLS)
 
 
 # ---------------------------------------------------------------------------
@@ -1448,7 +1459,10 @@ class RLMRunner:
     ]:
         """Acquire the Session lane, bind current Tools, and start one worker."""
         spec = context.capabilities.spec
-        guards = RunToolGuards(required_targets=workspace_obligations(context.session.request))
+        guards = RunToolGuards(
+            required_targets=workspace_obligations(context.session.request),
+            budget=getattr(context.execution.models, "budget", None),
+        )
         recursive_executor = None
         if context.delegation.recursive_options.enabled:
             if context.delegation.child_runtime_factory is None:
@@ -1492,6 +1506,7 @@ class RLMRunner:
                 after_result=(relay_capability_details if str(tool.name) == "load_skill" else None),
                 is_authorized=lambda: not context.identity.authority.revoked,
                 guards=guards,
+                async_bridge=getattr(context.execution, "async_bridge", None),
             )
             for tool in spec.tools
         )
@@ -1623,6 +1638,9 @@ class RLMRunner:
             observer_cleanup = clear_observers
             lease.bind_turn_cleanup(binding, observer_cleanup)
             binding_attached = True
+            bind_budget = getattr(state_context.execution.interpreter, "bind_turn_budget", None)
+            if callable(bind_budget):
+                bind_budget(getattr(state_context.execution.models, "budget", None))
             self._bind_observer(
                 state_context.execution.interpreter,
                 observations.publish,

--- a/src/fleet_rlm/rlm/runtime.py
+++ b/src/fleet_rlm/rlm/runtime.py
@@ -496,10 +496,11 @@ class RunToolGuards:
         return self.progress.completed(tool_name, arguments, result)
 
     def failed(self, tool_name: str, arguments: Mapping[str, Any]) -> None:
+        """Record that a tool operation failed without resolving its workspace obligation."""
         self.integrity.failed(tool_name, arguments)
 
     def reserve_tool(self) -> None:
-        """Admit one host Tool call against the Turn-wide ledger."""
+        """Reserve capacity for one tool call in the turn budget."""
         if self.budget is not None:
             self.budget.reserve(BudgetDimension.TOOL_CALLS)
 
@@ -1457,7 +1458,20 @@ class RLMRunner:
         RecursiveRLMExecutor | None,
         SessionRuntimeLease,
     ]:
-        """Acquire the Session lane, bind current Tools, and start one worker."""
+        """
+        Acquire and prepare the session runtime, bind turn-specific tools and context, and start the RLM worker.
+        
+        Parameters:
+            context (RLMExecutionContext): Execution identity, session data, capabilities, and runtime configuration.
+            ownership (WorkerOwnership): Ownership state for the worker and its blocking resources.
+            observations (ObservationSession): Session used to publish worker and capability events.
+        
+        Returns:
+            tuple: The execution specification, tool guards, worker handle, optional recursive executor, and session runtime lease.
+        
+        Raises:
+            RLMConfigError: If recursive execution is enabled without a child runtime or the session tool registry is unavailable.
+        """
         spec = context.capabilities.spec
         guards = RunToolGuards(
             required_targets=workspace_obligations(context.session.request),

--- a/src/fleet_rlm/rlm/runtime.py
+++ b/src/fleet_rlm/rlm/runtime.py
@@ -1460,17 +1460,19 @@ class RLMRunner:
     ]:
         """
         Acquire and prepare the session runtime, bind turn-specific tools and context, and start the RLM worker.
-        
+
         Parameters:
             context (RLMExecutionContext): Execution identity, session data, capabilities, and runtime configuration.
             ownership (WorkerOwnership): Ownership state for the worker and its blocking resources.
             observations (ObservationSession): Session used to publish worker and capability events.
-        
+
         Returns:
-            tuple: The execution specification, tool guards, worker handle, optional recursive executor, and session runtime lease.
-        
+            tuple: The execution specification, tool guards, worker handle, optional
+            recursive executor, and session runtime lease.
+
         Raises:
-            RLMConfigError: If recursive execution is enabled without a child runtime or the session tool registry is unavailable.
+            RLMConfigError: If recursive execution is enabled without a child runtime or
+            the session tool registry is unavailable.
         """
         spec = context.capabilities.spec
         guards = RunToolGuards(

--- a/src/fleet_rlm/rlm/submit_validation.py
+++ b/src/fleet_rlm/rlm/submit_validation.py
@@ -37,9 +37,9 @@ def _qualified_ast_name(node: ast.AST) -> str | None:
 def _strip_action_code_fences(code: str) -> str:
     """
     Remove surrounding Python markdown fences from action code.
-    
+
     Non-Python or malformed fences are preserved unchanged.
-    
+
     Returns:
         str: The executable action text with Python fences removed.
     """
@@ -69,12 +69,12 @@ def _strip_action_code_fences(code: str) -> str:
 def _is_safe_submit_value(node: ast.AST) -> bool:
     """
     Determine whether an AST node is an allowed expression for a SUBMIT keyword value.
-    
+
     Parameters:
-    	node (ast.AST): The expression node to validate.
-    
+        node (ast.AST): The expression node to validate.
+
     Returns:
-    	bool: True if the node uses an allowed data expression, false otherwise.
+        bool: True if the node uses an allowed data expression, false otherwise.
     """
     if isinstance(node, (ast.Constant, ast.Name)):
         return True
@@ -125,14 +125,14 @@ def _is_safe_submit_value(node: ast.AST) -> bool:
 def is_submit_only_code(code: object) -> bool:
     """
     Determine whether code contains a syntactically valid, submit-only action.
-    
+
     Parameters:
         code (object): Source code to validate.
-    
+
     Returns:
         bool: `true` if the code consists of one direct `SUBMIT` call with
             permitted keyword-value expressions, `false` otherwise.
-    
+
     This validates syntax only; it does not resolve names or evaluate operator
     behavior.
     """

--- a/src/fleet_rlm/rlm/submit_validation.py
+++ b/src/fleet_rlm/rlm/submit_validation.py
@@ -1,0 +1,134 @@
+"""Pure syntax validation for Fleet finalization actions; not a security sandbox."""
+
+from __future__ import annotations
+
+import ast
+
+_SAFE_SUBMIT_CALLS = frozenset(
+    {
+        "str",
+        "repr",
+        "int",
+        "float",
+        "bool",
+        "len",
+        "min",
+        "max",
+        "sum",
+        "round",
+        "sorted",
+        "json.dumps",
+    }
+)
+
+_PYTHON_FENCE_LANGS = frozenset({"", "python", "py"})
+
+
+def _qualified_ast_name(node: ast.AST) -> str | None:
+    """Return a dotted name for a simple AST name/attribute expression."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _qualified_ast_name(node.value)
+        return f"{parent}.{node.attr}" if parent else None
+    return None
+
+
+def _strip_action_code_fences(code: str) -> str:
+    """Mirror DSPy's public action fence handling for wrap-up validation.
+
+    Native RLM actions are commonly emitted in a Python markdown fence and
+    DSPy strips that fence before execution. Validation must inspect the same
+    executable text, while still rejecting an explicit non-Python fence.
+    """
+    text = code.strip()
+    if "```" not in text:
+        return text
+    lines = text.splitlines()
+    while len(lines) >= 2 and lines[0].strip() == "```" and lines[-1].strip() == "```":
+        lines.pop(0)
+        lines.pop()
+    text = "\n".join(lines).strip()
+    if "```" not in text:
+        return text
+    fence_start = text.find("```")
+    lang_line, separator, remainder = text[fence_start + 3 :].partition("\n")
+    if not separator:
+        return text
+    lang = (lang_line.strip().split(maxsplit=1)[0] if lang_line.strip() else "").lower()
+    if lang not in _PYTHON_FENCE_LANGS:
+        return text
+    block_end = remainder.find("```")
+    if block_end == -1:
+        return remainder.strip()
+    return remainder[:block_end].strip()
+
+
+def _is_safe_submit_value(node: ast.AST) -> bool:
+    """Allow only data expressions that cannot launch another action."""
+    if isinstance(node, (ast.Constant, ast.Name)):
+        return True
+    if isinstance(node, ast.JoinedStr):
+        return all(_is_safe_submit_value(value) for value in node.values)
+    if isinstance(node, ast.FormattedValue):
+        return _is_safe_submit_value(node.value) and (
+            node.format_spec is None or _is_safe_submit_value(node.format_spec)
+        )
+    if isinstance(node, ast.Attribute):
+        return not node.attr.startswith("_") and _is_safe_submit_value(node.value)
+    if isinstance(node, ast.Subscript):
+        return _is_safe_submit_value(node.value) and _is_safe_submit_value(node.slice)
+    if isinstance(node, ast.Slice):
+        return all(part is None or _is_safe_submit_value(part) for part in (node.lower, node.upper, node.step))
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return all(_is_safe_submit_value(item) for item in node.elts)
+    if isinstance(node, ast.Dict):
+        return all(
+            key is not None and _is_safe_submit_value(key) and _is_safe_submit_value(value)
+            for key, value in zip(node.keys, node.values, strict=True)
+        )
+    if isinstance(node, ast.Call):
+        if _qualified_ast_name(node.func) not in _SAFE_SUBMIT_CALLS:
+            return False
+        if any(isinstance(argument, ast.Starred) for argument in node.args):
+            return False
+        if any(keyword.arg is None for keyword in node.keywords):
+            return False
+        return all(_is_safe_submit_value(argument) for argument in node.args) and all(
+            _is_safe_submit_value(keyword.value) for keyword in node.keywords
+        )
+    if isinstance(node, ast.UnaryOp):
+        return _is_safe_submit_value(node.operand)
+    if isinstance(node, ast.BinOp):
+        return _is_safe_submit_value(node.left) and _is_safe_submit_value(node.right)
+    if isinstance(node, ast.BoolOp):
+        return all(_is_safe_submit_value(value) for value in node.values)
+    if isinstance(node, ast.Compare):
+        return _is_safe_submit_value(node.left) and all(_is_safe_submit_value(item) for item in node.comparators)
+    if isinstance(node, ast.IfExp):
+        return (
+            _is_safe_submit_value(node.test) and _is_safe_submit_value(node.body) and _is_safe_submit_value(node.orelse)
+        )
+    return False
+
+
+def is_submit_only_code(code: object) -> bool:
+    """Check wrap-up syntax, not runtime safety of names or overloaded operators."""
+    if not isinstance(code, str):
+        return False
+    try:
+        module = ast.parse(_strip_action_code_fences(code), mode="exec")
+    except SyntaxError:
+        return False
+    if len(module.body) != 1 or not isinstance(module.body[0], ast.Expr):
+        return False
+    expression = module.body[0].value
+    if (
+        not isinstance(expression, ast.Call)
+        or not isinstance(expression.func, ast.Name)
+        or expression.func.id != "SUBMIT"
+    ):
+        return False
+    if expression.args or any(keyword.arg is None for keyword in expression.keywords):
+        return False
+    return all(_is_safe_submit_value(keyword.value) for keyword in expression.keywords)

--- a/src/fleet_rlm/rlm/submit_validation.py
+++ b/src/fleet_rlm/rlm/submit_validation.py
@@ -35,11 +35,13 @@ def _qualified_ast_name(node: ast.AST) -> str | None:
 
 
 def _strip_action_code_fences(code: str) -> str:
-    """Mirror DSPy's public action fence handling for wrap-up validation.
-
-    Native RLM actions are commonly emitted in a Python markdown fence and
-    DSPy strips that fence before execution. Validation must inspect the same
-    executable text, while still rejecting an explicit non-Python fence.
+    """
+    Remove surrounding Python markdown fences from action code.
+    
+    Non-Python or malformed fences are preserved unchanged.
+    
+    Returns:
+        str: The executable action text with Python fences removed.
     """
     text = code.strip()
     if "```" not in text:
@@ -65,7 +67,15 @@ def _strip_action_code_fences(code: str) -> str:
 
 
 def _is_safe_submit_value(node: ast.AST) -> bool:
-    """Allow only data expressions that cannot launch another action."""
+    """
+    Determine whether an AST node is an allowed expression for a SUBMIT keyword value.
+    
+    Parameters:
+    	node (ast.AST): The expression node to validate.
+    
+    Returns:
+    	bool: True if the node uses an allowed data expression, false otherwise.
+    """
     if isinstance(node, (ast.Constant, ast.Name)):
         return True
     if isinstance(node, ast.JoinedStr):
@@ -113,7 +123,19 @@ def _is_safe_submit_value(node: ast.AST) -> bool:
 
 
 def is_submit_only_code(code: object) -> bool:
-    """Check wrap-up syntax, not runtime safety of names or overloaded operators."""
+    """
+    Determine whether code contains a syntactically valid, submit-only action.
+    
+    Parameters:
+        code (object): Source code to validate.
+    
+    Returns:
+        bool: `true` if the code consists of one direct `SUBMIT` call with
+            permitted keyword-value expressions, `false` otherwise.
+    
+    This validates syntax only; it does not resolve names or evaluate operator
+    behavior.
+    """
     if not isinstance(code, str):
         return False
     try:

--- a/src/fleet_rlm/runtime/daytona/run_environment.py
+++ b/src/fleet_rlm/runtime/daytona/run_environment.py
@@ -1249,14 +1249,14 @@ class _DaytonaEnvironmentProvider:
     async def _acquire(self, run: ClaimedRun, *, deadline: float) -> RunEnvironment:
         """
         Acquire the execution environment for a claimed run.
-        
+
         Parameters:
             run (ClaimedRun): The run whose workspace and session environment should be acquired.
             deadline (float): The absolute time by which preparation must complete.
-        
+
         Returns:
             RunEnvironment: The prepared environment and its associated resource-release callbacks.
-        
+
         Raises:
             RunPreparationTimeoutError: If preparation exceeds the deadline.
             RunPreparationUnavailableError: If the execution environment cannot be admitted.

--- a/src/fleet_rlm/runtime/daytona/run_environment.py
+++ b/src/fleet_rlm/runtime/daytona/run_environment.py
@@ -1247,7 +1247,21 @@ class _DaytonaEnvironmentProvider:
             self._maybe_release_environment_owner()
 
     async def _acquire(self, run: ClaimedRun, *, deadline: float) -> RunEnvironment:
-        """Perform one tracked environment acquisition."""
+        """
+        Acquire the execution environment for a claimed run.
+        
+        Parameters:
+            run (ClaimedRun): The run whose workspace and session environment should be acquired.
+            deadline (float): The absolute time by which preparation must complete.
+        
+        Returns:
+            RunEnvironment: The prepared environment and its associated resource-release callbacks.
+        
+        Raises:
+            RunPreparationTimeoutError: If preparation exceeds the deadline.
+            RunPreparationUnavailableError: If the execution environment cannot be admitted.
+            RuntimeError: If the acquired sandbox is unavailable.
+        """
         key = (run.access.workspace_id, run.session_id)
         preparation_gate = self._preparation_gate(key)
         gate_held = False

--- a/src/fleet_rlm/runtime/daytona/run_environment.py
+++ b/src/fleet_rlm/runtime/daytona/run_environment.py
@@ -1382,6 +1382,7 @@ class _DaytonaEnvironmentProvider:
                 release_is_resident=False,
                 history_transport=build_committed_session_history_for_claim(run),
                 mark_tainted=lambda key=key: self._mark_provider_root_tainted(key),
+                async_bridge=getattr(self.resources, "dispatcher", None),
             )
         except BaseException:
             # The preparation gate proves that no earlier same-Session Turn

--- a/tests/contracts/backend/test_host_tool_submit_binding.py
+++ b/tests/contracts/backend/test_host_tool_submit_binding.py
@@ -7,7 +7,7 @@ import json
 
 from fleet_rlm.daytona.broker import extract_final_payload, remote_submit_setup_code
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
-from fleet_rlm.rlm._dspy_compat import FinalOutput
+from fleet_rlm.rlm.compat_3_3_1 import FinalOutput
 from fleet_rlm.rlm.program import (
     FleetRLMSignature,
     RLMOptions,

--- a/tests/contracts/backend/test_native_rlm_tracer.py
+++ b/tests/contracts/backend/test_native_rlm_tracer.py
@@ -11,7 +11,7 @@ import dspy
 import pytest
 
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
-from fleet_rlm.rlm._dspy_compat import bind_native_rlm_observer
+from fleet_rlm.rlm.compat_3_3_1 import bind_native_rlm_observer
 from fleet_rlm.rlm.events import (
     RLMCode,
     RLMOutput,

--- a/tests/contracts/backend/test_turn_claim_adapter_parity.py
+++ b/tests/contracts/backend/test_turn_claim_adapter_parity.py
@@ -21,10 +21,10 @@ class _Harness:
 async def _build_harness(adapter_kind: str) -> _Harness:
     """
     Create a run-state test harness for the specified storage adapter.
-    
+
     Parameters:
         adapter_kind (str): Storage adapter to use: ``"memory"`` or ``"sql"``.
-    
+
     Returns:
         _Harness: Harness containing the initialized store, claimed turn, state reader, and cleanup callback.
     """

--- a/tests/contracts/backend/test_turn_claim_adapter_parity.py
+++ b/tests/contracts/backend/test_turn_claim_adapter_parity.py
@@ -54,6 +54,7 @@ async def _build_harness(adapter_kind: str) -> _Harness:
                 SessionRow(id=session_id, user_id=access.user_id, workspace_id=access.workspace_id, title="parity"),
             )
         )
+        await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
     store = SqlAlchemyRunStateStore(factory)
     turn = await store.begin(RunClaim(access, session_id, TurnInput("claim parity"), "parity", run_id))
     assert isinstance(turn, ClaimedRun)

--- a/tests/contracts/backend/test_turn_claim_adapter_parity.py
+++ b/tests/contracts/backend/test_turn_claim_adapter_parity.py
@@ -19,6 +19,15 @@ class _Harness:
 
 
 async def _build_harness(adapter_kind: str) -> _Harness:
+    """
+    Create a run-state test harness for the specified storage adapter.
+    
+    Parameters:
+        adapter_kind (str): Storage adapter to use: ``"memory"`` or ``"sql"``.
+    
+    Returns:
+        _Harness: Harness containing the initialized store, claimed turn, state reader, and cleanup callback.
+    """
     from fleet_rlm.chat.run_lifecycle import ClaimedRun, RunClaim
     from fleet_rlm.persistence.repositories import InMemoryRunStateStore, SqlAlchemyRunStateStore
     from fleet_rlm.sessions.models import TurnAccess, TurnInput

--- a/tests/live/backend/test_safe_gepa_daytona_policy.py
+++ b/tests/live/backend/test_safe_gepa_daytona_policy.py
@@ -34,7 +34,7 @@ from fleet_rlm.optimization.evidence import (
     write_development_daytona_canary_report,
 )
 from fleet_rlm.optimization.types import OptimizationRecord
-from fleet_rlm.rlm._dspy_compat import is_final_output
+from fleet_rlm.rlm.compat_3_3_1 import is_final_output
 
 _LIVE_VALUES = frozenset({"1", "true", "yes"})
 _PROBE_TIMEOUT_SECONDS = 20

--- a/tests/unit/backend/daytona/test_interpreter_output_cap.py
+++ b/tests/unit/backend/daytona/test_interpreter_output_cap.py
@@ -72,6 +72,12 @@ def test_turn_output_budget_is_shared_and_fail_closed() -> None:
 def test_error_feedback_includes_capped_stderr() -> None:
     class _StderrBackend:
         def run(self, code: str, variables: dict[str, object] | None = None) -> BackendExecutionResult:
+            """
+            Simulate a failed backend execution with an undefined-name error.
+            
+            Returns:
+            	BackendExecutionResult: An execution result with a fixed `NameError` message and 5,000-character stderr output.
+            """
             del code, variables
             return BackendExecutionResult(
                 stdout="", error="NameError: name 'missing' is not defined", stderr="s" * 5000

--- a/tests/unit/backend/daytona/test_interpreter_output_cap.py
+++ b/tests/unit/backend/daytona/test_interpreter_output_cap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import tomllib
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from fleet_rlm.daytona.interpreter import (
     InProcessInterpreterBackend,
     sandbox_backend,
 )
+from fleet_rlm.rlm.budget import BudgetDimension, BudgetLimits, TurnBudget, TurnBudgetExhausted
 from fleet_rlm.rlm.compat_3_3_1 import FinalOutput
 
 
@@ -47,6 +49,24 @@ def test_final_output_is_never_capped() -> None:
 
     assert isinstance(result, FinalOutput)
     assert result.output["answer"] == "x" * 5000
+
+
+def test_turn_output_budget_is_shared_and_fail_closed() -> None:
+    interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend(), execution_output_cap=400)
+    observed: list[object] = []
+    budget = TurnBudget(
+        deadline=time.monotonic() + 60,
+        limits=BudgetLimits(execution_output_bytes=3),
+    )
+    interpreter.bind_observer(observed.append)
+    interpreter.bind_turn_budget(budget)
+
+    with pytest.raises(TurnBudgetExhausted) as caught:
+        interpreter.execute("_out = 'abcd'")
+
+    assert caught.value.dimension == BudgetDimension.EXECUTION_OUTPUT_BYTES
+    assert budget.snapshot()[BudgetDimension.EXECUTION_OUTPUT_BYTES.value] == 0
+    assert not any(getattr(item, "output", "") == "Execution failed" for item in observed)
 
 
 def test_error_feedback_includes_capped_stderr() -> None:

--- a/tests/unit/backend/daytona/test_interpreter_output_cap.py
+++ b/tests/unit/backend/daytona/test_interpreter_output_cap.py
@@ -15,7 +15,7 @@ from fleet_rlm.daytona.interpreter import (
     InProcessInterpreterBackend,
     sandbox_backend,
 )
-from fleet_rlm.rlm._dspy_compat import FinalOutput
+from fleet_rlm.rlm.compat_3_3_1 import FinalOutput
 
 
 def test_large_stdout_is_head_tail_capped_with_marker() -> None:

--- a/tests/unit/backend/daytona/test_interpreter_output_cap.py
+++ b/tests/unit/backend/daytona/test_interpreter_output_cap.py
@@ -74,9 +74,10 @@ def test_error_feedback_includes_capped_stderr() -> None:
         def run(self, code: str, variables: dict[str, object] | None = None) -> BackendExecutionResult:
             """
             Simulate a failed backend execution with an undefined-name error.
-            
+
             Returns:
-            	BackendExecutionResult: An execution result with a fixed `NameError` message and 5,000-character stderr output.
+                BackendExecutionResult: An execution result with a fixed `NameError`
+                    message and 5,000-character stderr output.
             """
             del code, variables
             return BackendExecutionResult(

--- a/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
@@ -104,7 +104,7 @@ def test_dispatcher_runs_async_host_operation_from_worker_loop() -> None:
 
             asyncio.run(body())
 
-        thread = threading.Thread(target=worker, name="fleet-test-rlm-worker")
+        thread = threading.Thread(target=worker, name="fleet-test-rlm-worker", daemon=True)
         thread.start()
         thread.join(timeout=_DEADLOCK_BOUND_S)
         assert not thread.is_alive(), "async host bridge deadlocked"

--- a/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
@@ -76,6 +76,33 @@ def _call_from_worker_thread(view: SimpleNamespace, path: str) -> bytes:
     return value
 
 
+def test_dispatcher_runs_async_host_operation_from_worker_loop() -> None:
+    """The RLM async-Tool seam uses the persistent composition loop."""
+    dispatcher = SyncBridgeDispatcher()
+    with _ServingLoop("fleet-test-host-tool-loop") as server:
+        dispatcher.set_loop(server.loop)
+        result_holder: dict[str, object] = {}
+
+        def worker() -> None:
+            async def host_operation() -> tuple[str, str]:
+                return (threading.current_thread().name, asyncio.get_running_loop().__class__.__name__)
+
+            async def body() -> None:
+                result_holder["value"] = dispatcher.run(host_operation())
+
+            asyncio.run(body())
+
+        thread = threading.Thread(target=worker, name="fleet-test-rlm-worker")
+        thread.start()
+        thread.join(timeout=_DEADLOCK_BOUND_S)
+        assert not thread.is_alive(), "async host bridge deadlocked"
+        value = result_holder["value"]
+        assert isinstance(value, tuple)
+        assert value[0] == "fleet-test-host-tool-loop"
+        assert str(value[1]).endswith("EventLoop")
+        dispatcher.clear_loop(server.loop)
+
+
 def test_compositions_cannot_overwrite_each_others_bridge_authority() -> None:
     """Two composition dispatchers route their own views independently."""
     dispatcher_a = SyncBridgeDispatcher()

--- a/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
@@ -60,11 +60,11 @@ class _ServingLoop:
 def _call_from_worker_thread(view: SimpleNamespace, path: str) -> bytes:
     """
     Execute a bridged filesystem call from a worker thread.
-    
+
     Parameters:
         view (SimpleNamespace): Namespace exposing the bridged filesystem.
         path (str): Path to pass to the filesystem operation.
-    
+
     Returns:
         bytes: Data returned for the requested path.
     """
@@ -96,6 +96,7 @@ def test_dispatcher_runs_async_host_operation_from_worker_loop() -> None:
             """
             Run a bridged host operation from a worker event loop and store its result.
             """
+
             async def host_operation() -> tuple[str, str]:
                 return (threading.current_thread().name, asyncio.get_running_loop().__class__.__name__)
 

--- a/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
+++ b/tests/unit/backend/daytona/test_sync_bridge_dispatcher.py
@@ -58,7 +58,16 @@ class _ServingLoop:
 
 
 def _call_from_worker_thread(view: SimpleNamespace, path: str) -> bytes:
-    """Run one bridged SDK call on a DST-y worker thread, like DSPy _execute_code."""
+    """
+    Execute a bridged filesystem call from a worker thread.
+    
+    Parameters:
+        view (SimpleNamespace): Namespace exposing the bridged filesystem.
+        path (str): Path to pass to the filesystem operation.
+    
+    Returns:
+        bytes: Data returned for the requested path.
+    """
     holder: dict[str, object] = {}
 
     def run() -> None:
@@ -84,6 +93,9 @@ def test_dispatcher_runs_async_host_operation_from_worker_loop() -> None:
         result_holder: dict[str, object] = {}
 
         def worker() -> None:
+            """
+            Run a bridged host operation from a worker event loop and store its result.
+            """
             async def host_operation() -> tuple[str, str]:
                 return (threading.current_thread().name, asyncio.get_running_loop().__class__.__name__)
 

--- a/tests/unit/backend/packaging/_dspy_version_guard_spy.py
+++ b/tests/unit/backend/packaging/_dspy_version_guard_spy.py
@@ -48,7 +48,7 @@ def _install_ordered_spies(order: list[str], counts: dict[str, int]) -> None:
     import fleet_rlm.composition.testing as composition_common
     import fleet_rlm.daytona.platform as daytona_platform
     import fleet_rlm.persistence.database as persistence_database
-    import fleet_rlm.rlm._dspy_compat as dspy_compat
+    import fleet_rlm.rlm.compat_3_3_1 as dspy_compat
     import fleet_rlm.rlm.program as program
 
     real_guard = dspy_compat.assert_dspy_version
@@ -221,7 +221,7 @@ def main(argv: list[str]) -> int:
 
     dspy.__version__ = reported_version
 
-    import fleet_rlm.rlm._dspy_compat as dspy_compat
+    import fleet_rlm.rlm.compat_3_3_1 as dspy_compat
 
     rejection_error_type = getattr(
         dspy_compat,

--- a/tests/unit/backend/packaging/_dspy_version_guard_spy.py
+++ b/tests/unit/backend/packaging/_dspy_version_guard_spy.py
@@ -42,6 +42,13 @@ class _UnsettledGuardRejectionError(Exception):
 
 
 def _install_ordered_spies(order: list[str], counts: dict[str, int]) -> None:
+    """
+    Install spies that record DSPy guard and resource-construction order.
+    
+    Parameters:
+    	order (list[str]): Mutable sequence receiving guard and resource labels in call order.
+    	counts (dict[str, int]): Mutable mapping updated with the number of calls for each label.
+    """
     import fleet_rlm.app as app_module
     import fleet_rlm.cli as cli_module
     import fleet_rlm.composition.live as composition_daytona
@@ -211,6 +218,15 @@ def _report(payload: dict[str, Any]) -> None:
 
 
 def main(argv: list[str]) -> int:
+    """
+    Run the selected DSPy version-guard test mode and report its outcome.
+    
+    Parameters:
+    	argv (list[str]): Command-line arguments containing the harness name, mode, and reported DSPy version.
+    
+    Returns:
+    	int: The process exit code recorded by the selected mode, or a harness status code for invalid arguments, guard rejection, or unexpected errors.
+    """
     if len(argv) != 3 or argv[1] not in _MODES:
         sys.stderr.write("usage: _dspy_version_guard_spy.py <" + "|".join(sorted(_MODES)) + "> <reported-version>\n")
         return _HARNESS_ERROR

--- a/tests/unit/backend/packaging/_dspy_version_guard_spy.py
+++ b/tests/unit/backend/packaging/_dspy_version_guard_spy.py
@@ -44,10 +44,10 @@ class _UnsettledGuardRejectionError(Exception):
 def _install_ordered_spies(order: list[str], counts: dict[str, int]) -> None:
     """
     Install spies that record DSPy guard and resource-construction order.
-    
+
     Parameters:
-    	order (list[str]): Mutable sequence receiving guard and resource labels in call order.
-    	counts (dict[str, int]): Mutable mapping updated with the number of calls for each label.
+        order (list[str]): Mutable sequence receiving guard and resource labels in call order.
+        counts (dict[str, int]): Mutable mapping updated with the number of calls for each label.
     """
     import fleet_rlm.app as app_module
     import fleet_rlm.cli as cli_module
@@ -220,12 +220,13 @@ def _report(payload: dict[str, Any]) -> None:
 def main(argv: list[str]) -> int:
     """
     Run the selected DSPy version-guard test mode and report its outcome.
-    
+
     Parameters:
-    	argv (list[str]): Command-line arguments containing the harness name, mode, and reported DSPy version.
-    
+        argv (list[str]): Command-line arguments containing the harness name, mode, and reported DSPy version.
+
     Returns:
-    	int: The process exit code recorded by the selected mode, or a harness status code for invalid arguments, guard rejection, or unexpected errors.
+        int: The process exit code recorded by the selected mode, or a harness status
+        code for invalid arguments, guard rejection, or unexpected errors.
     """
     if len(argv) != 3 or argv[1] not in _MODES:
         sys.stderr.write("usage: _dspy_version_guard_spy.py <" + "|".join(sorted(_MODES)) + "> <reported-version>\n")

--- a/tests/unit/backend/packaging/test_exact_version_runtime_guard.py
+++ b/tests/unit/backend/packaging/test_exact_version_runtime_guard.py
@@ -148,7 +148,7 @@ class TestGuardStaticContract:
     """The certified constant and error shape stay pinned in production code."""
 
     def test_certified_constant_is_exact_final_release(self) -> None:
-        from fleet_rlm.rlm._dspy_compat import (
+        from fleet_rlm.rlm.compat_3_3_1 import (
             CERTIFIED_DSPY_VERSION,
             UncertifiedDSpyVersionError,
         )
@@ -157,7 +157,7 @@ class TestGuardStaticContract:
         assert issubclass(UncertifiedDSpyVersionError, RuntimeError)
 
     def test_guard_uses_literal_comparison_only(self) -> None:
-        source = (REPO_ROOT / "src" / "fleet_rlm" / "rlm" / "_dspy_compat.py").read_text(encoding="utf-8")
+        source = (REPO_ROOT / "src" / "fleet_rlm" / "rlm" / "compat_3_3_1.py").read_text(encoding="utf-8")
         assert "packaging.version" not in source
         assert "Version(" not in source
 

--- a/tests/unit/backend/rlm/test_adapter_budget_integration.py
+++ b/tests/unit/backend/rlm/test_adapter_budget_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import time
 
 import dspy
@@ -99,6 +100,21 @@ async def test_reserved_attempts_are_root_only_and_independent_of_time(asynchron
     assert (await invoke(adapter, models.root_lm, asynchronous))[0]["code"] == "SUBMIT(answer=1)"
     assert adapter.wrap_up_summary()["wrap_up_entered"]
     assert turn.snapshot()["provider_attempts"] == 2
+
+
+def test_late_response_reclassification_consumes_global_finalization_capacity() -> None:
+    turn = TurnBudget(
+        deadline=time.monotonic() + 30,
+        limits=BudgetLimits(finalization_attempts=2),
+    )
+    adapter = AdapterBudget(turn=turn, max_finalization_attempts=10)
+    turn.reserve(BudgetDimension.PROVIDER_ATTEMPTS)
+    adapter.reclassify_late_response()
+    adapter.reclassify_late_response()
+    with pytest.raises(TurnBudgetExhausted):
+        adapter.reclassify_late_response()
+    assert turn.snapshot()["provider_attempts"] == 1
+    assert adapter.finalization_used == 2
 
 
 def test_finalization_time_and_attempt_reserves_are_independently_enforced(monkeypatch) -> None:
@@ -211,11 +227,15 @@ async def test_adapter_rejects_mismatched_turn_ledger() -> None:
     "kwargs",
     [
         {"deadline": "invalid"},
-        {"deadline": float("nan")},
+        {"deadline": math.nan},
+        {"deadline": -math.inf},
         {"deadline": False},
         {"reserve_seconds": "invalid"},
-        {"reserve_seconds": float("inf")},
+        {"reserve_seconds": math.nan},
+        {"reserve_seconds": math.inf},
         {"max_parse_retries": True},
+        {"max_parse_retries": -1},
+        {"max_finalization_attempts": True},
         {"max_finalization_attempts": -1},
     ],
 )
@@ -240,6 +260,12 @@ async def test_copy_of_call_view_retains_admission_and_trace_identity() -> None:
     assert callback._last_call["role"] == "root"
     assert scope.finalization_used == 1
     assert models.budget.snapshot()["provider_attempts"] == 1
+
+
+def test_positive_infinite_adapter_deadline_is_the_unbounded_compatibility_case() -> None:
+    budget = AdapterBudget(deadline=math.inf)
+    assert budget.deadline is None
+    assert budget.remaining() is None
 
 
 def test_concurrent_finalization_admissions_do_not_overdraw():

--- a/tests/unit/backend/rlm/test_adapter_budget_integration.py
+++ b/tests/unit/backend/rlm/test_adapter_budget_integration.py
@@ -18,6 +18,15 @@ GOOD = '{"reasoning":"done","code":"SUBMIT(answer=1)"}'
 
 
 async def invoke(adapter, lm, asynchronous):
+    """
+    Execute a standard scripted request through the adapter.
+    
+    Parameters:
+    	asynchronous (bool): Whether to use the adapter's asynchronous call interface.
+    
+    Returns:
+    	The adapter's response.
+    """
     args = (lm, {}, _IterationActionSignature, [], {"iteration": "1/3"})
     return await adapter.acall(*args) if asynchronous else adapter(*args)
 
@@ -48,10 +57,22 @@ async def test_schema_fallback_cannot_bypass_global_admission(asynchronous: bool
     class StructuredLM(_ScriptedLM):
         @property
         def supported_params(self):
+            """
+            Identify the parameters supported by the adapter.
+            
+            Returns:
+            	set[str]: The supported parameter names.
+            """
             return {"response_format"}
 
         @property
         def supports_response_schema(self):
+            """
+            Indicate that response schemas are supported.
+            
+            Returns:
+                bool: `True` because response schemas are supported.
+            """
             return True
 
     source = StructuredLM(["", GOOD])
@@ -165,6 +186,16 @@ async def test_real_lm_template_is_copied_without_mutating_retries_or_history(mo
     seen = []
 
     def forward(instance, **kwargs):
+        """
+        Record a model invocation and return a successful completion response.
+        
+        Parameters:
+        	instance: Request object containing the model name.
+        	**kwargs: Additional invocation arguments.
+        
+        Returns:
+        	A completion response containing the configured content, token usage, and model name.
+        """
         seen.append((instance, kwargs))
         return SimpleNamespace(
             choices=[SimpleNamespace(message=SimpleNamespace(content=GOOD, tool_calls=None))],
@@ -173,6 +204,12 @@ async def test_real_lm_template_is_copied_without_mutating_retries_or_history(mo
         )
 
     async def aforward(instance, **kwargs):
+        """
+        Execute the adapter operation for an instance.
+        
+        Returns:
+            The operation result.
+        """
         return forward(instance, **kwargs)
 
     monkeypatch.setattr(dspy.LM, "forward", forward)
@@ -196,10 +233,22 @@ async def test_schema_fallback_consumes_finalization_ceiling(asynchronous) -> No
     class StructuredLM(_ScriptedLM):
         @property
         def supported_params(self):
+            """
+            Identify the parameters supported by the adapter.
+            
+            Returns:
+            	set[str]: The supported parameter names.
+            """
             return {"response_format"}
 
         @property
         def supports_response_schema(self):
+            """
+            Indicate that response schemas are supported.
+            
+            Returns:
+                bool: `True` because response schemas are supported.
+            """
             return True
 
     source = StructuredLM(["", "", GOOD])
@@ -274,6 +323,12 @@ def test_concurrent_finalization_admissions_do_not_overdraw():
     scope = AdapterBudget(deadline=time.monotonic() + 10)
 
     def attempt(_):
+        """
+        Attempts to reserve provider and finalization capacity for the current scope.
+        
+        Returns:
+            `true` if capacity is reserved successfully, `false` if the reservation times out.
+        """
         try:
             scope.reserve_provider(action=True, wrap_up=True, can_finalize=True)
             return True

--- a/tests/unit/backend/rlm/test_adapter_budget_integration.py
+++ b/tests/unit/backend/rlm/test_adapter_budget_integration.py
@@ -1,0 +1,259 @@
+"""Real DSPy adapter calls must enter the Turn's provider admission ledger."""
+
+from __future__ import annotations
+
+import time
+
+import dspy
+import pytest
+from dspy.utils.exceptions import LMServerError
+
+from fleet_rlm.rlm.budget import AdapterBudget, BudgetDimension, BudgetLimits, TurnBudget, TurnBudgetExhausted
+from fleet_rlm.rlm.compat_3_3_1 import FleetJSONAdapter, _RLMTraceCallback
+from fleet_rlm.rlm.program import RLMModelBundle
+from tests.unit.backend.rlm.test_fleet_json_adapter import _IterationActionSignature, _ScriptedLM
+
+GOOD = '{"reasoning":"done","code":"SUBMIT(answer=1)"}'
+
+
+async def invoke(adapter, lm, asynchronous):
+    args = (lm, {}, _IterationActionSignature, [], {"iteration": "1/3"})
+    return await adapter.acall(*args) if asynchronous else adapter(*args)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("limit", [1, 2])
+async def test_corrective_reask_shares_turn_admission(asynchronous: bool, limit: int) -> None:
+    turn = TurnBudget(deadline=time.monotonic() + 30, limits=BudgetLimits(provider_attempts=limit))
+    source = _ScriptedLM(["", GOOD])
+    models = RLMModelBundle(source, source).bind_turn_deadline(deadline=turn.deadline, budget=turn)
+    adapter = FleetJSONAdapter(budget=turn)
+    if limit == 1:
+        with pytest.raises(TurnBudgetExhausted):
+            await invoke(adapter, models.root_lm, asynchronous)
+    else:
+        result = await invoke(adapter, models.root_lm, asynchronous)
+        assert result[0]["code"] == "SUBMIT(answer=1)"
+    assert len(models.root_lm.wrapped.calls) == limit
+    assert turn.snapshot()["provider_attempts"] == limit
+    assert "budget" not in vars(source)
+    assert "forward" not in vars(source)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_schema_fallback_cannot_bypass_global_admission(asynchronous: bool) -> None:
+    class StructuredLM(_ScriptedLM):
+        @property
+        def supported_params(self):
+            return {"response_format"}
+
+        @property
+        def supports_response_schema(self):
+            return True
+
+    source = StructuredLM(["", GOOD])
+    turn = TurnBudget(deadline=time.monotonic() + 30, limits=BudgetLimits(provider_attempts=1))
+    adapter = FleetJSONAdapter(budget=turn)
+    with pytest.raises(TurnBudgetExhausted):
+        await invoke(adapter, source, asynchronous)
+    assert len(source.calls) == turn.snapshot()["provider_attempts"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_provider_retry_and_parse_correction_share_finalization_slots(asynchronous: bool) -> None:
+    class RetryOnceLM(_ScriptedLM):
+        def forward(self, **kwargs):
+            if not self.calls:
+                self.calls.append(kwargs)
+                raise LMServerError("retry")
+            return super().forward(**kwargs)
+
+    source = RetryOnceLM(["unused", "", GOOD])
+    source.num_retries = 3
+    turn = TurnBudget(deadline=time.monotonic() + 30)
+    adapter = FleetJSONAdapter(deadline=turn.deadline, wrap_up_seconds=60, budget=turn)
+    with pytest.raises(TimeoutError, match="wrap-up action"):
+        await invoke(adapter, source, asynchronous)
+    assert len(source.calls) == turn.snapshot()["provider_attempts"] == 2
+    assert adapter.wrap_up_summary()["wrap_up_attempts"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_reserved_attempts_are_root_only_and_independent_of_time(asynchronous: bool) -> None:
+    source = _ScriptedLM([GOOD])
+    turn = TurnBudget(
+        deadline=time.monotonic() + 30,
+        limits=BudgetLimits(provider_attempts=3, finalization_attempts=2),
+    )
+    models = RLMModelBundle(source, source).bind_turn_deadline(deadline=turn.deadline, budget=turn)
+    turn.reserve(BudgetDimension.PROVIDER_ATTEMPTS)
+    child = models.fork_for_child(deadline=turn.deadline)
+    with pytest.raises(TurnBudgetExhausted):
+        await invoke(FleetJSONAdapter(wrap_up_seconds=1, budget=turn), child.root_lm, asynchronous)
+    assert turn.snapshot()["provider_attempts"] == 1
+    adapter = FleetJSONAdapter(wrap_up_seconds=1, budget=turn)
+    assert (await invoke(adapter, models.root_lm, asynchronous))[0]["code"] == "SUBMIT(answer=1)"
+    assert adapter.wrap_up_summary()["wrap_up_entered"]
+    assert turn.snapshot()["provider_attempts"] == 2
+
+
+def test_finalization_time_and_attempt_reserves_are_independently_enforced(monkeypatch) -> None:
+    monkeypatch.setattr("fleet_rlm.rlm.budget.time.monotonic", lambda: 99.0)
+    turn = TurnBudget(deadline=100.0, limits=BudgetLimits(provider_attempts=3, finalization_attempts=2))
+    budget = AdapterBudget(deadline=100.0, reserve_seconds=2.0, turn=turn)
+    with pytest.raises(TimeoutError, match="reserve"):
+        budget.reserve_provider(action=True, wrap_up=False, can_finalize=True)
+    assert turn.snapshot()["provider_attempts"] == 0
+    assert budget.reserve_provider(action=True, wrap_up=True, can_finalize=True) == 1.0
+    assert budget.reserve_provider(action=True, wrap_up=True, can_finalize=True) == 1.0
+    with pytest.raises(TimeoutError, match="wrap-up"):
+        budget.reserve_provider(action=True, wrap_up=True, can_finalize=True)
+    assert turn.snapshot()["provider_attempts"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_call_local_proxy_preserves_role_and_usage_visibility(asynchronous: bool) -> None:
+    source = _ScriptedLM([GOOD])
+    models = RLMModelBundle(source, source).bind_turn_deadline(deadline=time.monotonic() + 30)
+    callback = _RLMTraceCallback(root_lm=models.root_lm, sub_lm=models.sub_lm)
+    with dspy.context(callbacks=[callback]):
+        await invoke(FleetJSONAdapter(budget=models.budget), models.root_lm, asynchronous)
+    assert callback._last_call["role"] == "root"
+    assert models.root_lm.history[-1]["usage"]["total_tokens"] == 2
+    assert len(models.root_lm.history) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_settled_budget_rejects_adapter_without_calling_provider(asynchronous: bool) -> None:
+    turn = TurnBudget(deadline=time.monotonic() + 30)
+    turn.settle()
+    lm = _ScriptedLM([GOOD])
+    with pytest.raises(TurnBudgetExhausted) as raised:
+        await invoke(FleetJSONAdapter(budget=turn), lm, asynchronous)
+    assert raised.value.dimension == BudgetDimension.SETTLED
+    assert not lm.calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_real_lm_template_is_copied_without_mutating_retries_or_history(monkeypatch, asynchronous) -> None:
+    from types import SimpleNamespace
+
+    template = dspy.LM("test/template", num_retries=4, timeout=25)
+    seen = []
+
+    def forward(instance, **kwargs):
+        seen.append((instance, kwargs))
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=GOOD, tool_calls=None))],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            model=instance.model,
+        )
+
+    async def aforward(instance, **kwargs):
+        return forward(instance, **kwargs)
+
+    monkeypatch.setattr(dspy.LM, "forward", forward)
+    monkeypatch.setattr(dspy.LM, "aforward", aforward)
+    turn = TurnBudget(deadline=time.monotonic() + 10)
+    assert (await invoke(FleetJSONAdapter(budget=turn), template, asynchronous))[0]["code"] == "SUBMIT(answer=1)"
+    assert len(seen) == 1
+    copied, kwargs = seen[0]
+    assert copied is not template
+    assert copied.num_retries == 0
+    assert template.num_retries == 4
+    assert template.history == []
+    assert template.kwargs["timeout"] == 25
+    assert 0 < kwargs["timeout"] <= 10
+    assert turn.snapshot()["provider_attempts"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_schema_fallback_consumes_finalization_ceiling(asynchronous) -> None:
+    class StructuredLM(_ScriptedLM):
+        @property
+        def supported_params(self):
+            return {"response_format"}
+
+        @property
+        def supports_response_schema(self):
+            return True
+
+    source = StructuredLM(["", "", GOOD])
+    turn = TurnBudget(deadline=time.monotonic() + 30)
+    adapter = FleetJSONAdapter(budget=turn, wrap_up_seconds=60)
+    with pytest.raises(TimeoutError, match="wrap-up action"):
+        await invoke(adapter, source, asynchronous)
+    assert len(source.calls) == turn.snapshot()["provider_attempts"] == 2
+    assert adapter.wrap_up_summary()["wrap_up_attempts"] == 2
+
+
+@pytest.mark.asyncio
+async def test_adapter_rejects_mismatched_turn_ledger() -> None:
+    source = _ScriptedLM([GOOD])
+    models = RLMModelBundle(source, source).bind_turn_deadline(deadline=time.monotonic() + 10)
+    other = TurnBudget(deadline=time.monotonic() + 10)
+    with pytest.raises(ValueError, match="switch Turn budgets"):
+        await invoke(FleetJSONAdapter(budget=other), models.root_lm, True)
+    assert not source.calls
+    assert not any(other.snapshot().values())
+    assert not any(models.budget.snapshot().values())
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"deadline": "invalid"},
+        {"deadline": float("nan")},
+        {"deadline": False},
+        {"reserve_seconds": "invalid"},
+        {"reserve_seconds": float("inf")},
+        {"max_parse_retries": True},
+        {"max_finalization_attempts": -1},
+    ],
+)
+def test_adapter_budget_rejects_invalid_policy(kwargs):
+    with pytest.raises(ValueError):
+        AdapterBudget(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_copy_of_call_view_retains_admission_and_trace_identity() -> None:
+    from fleet_rlm.rlm.program import DeadlineLMProxy
+
+    source = _ScriptedLM([GOOD])
+    models = RLMModelBundle(source, source).bind_turn_deadline(deadline=time.monotonic() + 10)
+    scope = AdapterBudget(turn=models.budget)
+    view = DeadlineLMProxy.for_adapter(models.root_lm, scope, action=True, wrap_up=True)
+    copied = view.copy()
+    assert copied.admission is view.admission
+    callback = _RLMTraceCallback(root_lm=models.root_lm, sub_lm=models.sub_lm)
+    with dspy.context(callbacks=[callback]):
+        await invoke(dspy.JSONAdapter(), copied, True)
+    assert callback._last_call["role"] == "root"
+    assert scope.finalization_used == 1
+    assert models.budget.snapshot()["provider_attempts"] == 1
+
+
+def test_concurrent_finalization_admissions_do_not_overdraw():
+    from concurrent.futures import ThreadPoolExecutor
+
+    scope = AdapterBudget(deadline=time.monotonic() + 10)
+
+    def attempt(_):
+        try:
+            scope.reserve_provider(action=True, wrap_up=True, can_finalize=True)
+            return True
+        except TimeoutError:
+            return False
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        assert sum(executor.map(attempt, range(10))) == 2
+    assert scope.finalization_used == scope.turn.snapshot()["provider_attempts"] == 2

--- a/tests/unit/backend/rlm/test_adapter_budget_integration.py
+++ b/tests/unit/backend/rlm/test_adapter_budget_integration.py
@@ -20,12 +20,12 @@ GOOD = '{"reasoning":"done","code":"SUBMIT(answer=1)"}'
 async def invoke(adapter, lm, asynchronous):
     """
     Execute a standard scripted request through the adapter.
-    
+
     Parameters:
-    	asynchronous (bool): Whether to use the adapter's asynchronous call interface.
-    
+        asynchronous (bool): Whether to use the adapter's asynchronous call interface.
+
     Returns:
-    	The adapter's response.
+        The adapter's response.
     """
     args = (lm, {}, _IterationActionSignature, [], {"iteration": "1/3"})
     return await adapter.acall(*args) if asynchronous else adapter(*args)
@@ -59,9 +59,9 @@ async def test_schema_fallback_cannot_bypass_global_admission(asynchronous: bool
         def supported_params(self):
             """
             Identify the parameters supported by the adapter.
-            
+
             Returns:
-            	set[str]: The supported parameter names.
+                set[str]: The supported parameter names.
             """
             return {"response_format"}
 
@@ -69,7 +69,7 @@ async def test_schema_fallback_cannot_bypass_global_admission(asynchronous: bool
         def supports_response_schema(self):
             """
             Indicate that response schemas are supported.
-            
+
             Returns:
                 bool: `True` because response schemas are supported.
             """
@@ -188,13 +188,13 @@ async def test_real_lm_template_is_copied_without_mutating_retries_or_history(mo
     def forward(instance, **kwargs):
         """
         Record a model invocation and return a successful completion response.
-        
+
         Parameters:
-        	instance: Request object containing the model name.
-        	**kwargs: Additional invocation arguments.
-        
+                instance: Request object containing the model name.
+                **kwargs: Additional invocation arguments.
+
         Returns:
-        	A completion response containing the configured content, token usage, and model name.
+                A completion response containing the configured content, token usage, and model name.
         """
         seen.append((instance, kwargs))
         return SimpleNamespace(
@@ -206,7 +206,7 @@ async def test_real_lm_template_is_copied_without_mutating_retries_or_history(mo
     async def aforward(instance, **kwargs):
         """
         Execute the adapter operation for an instance.
-        
+
         Returns:
             The operation result.
         """
@@ -235,9 +235,9 @@ async def test_schema_fallback_consumes_finalization_ceiling(asynchronous) -> No
         def supported_params(self):
             """
             Identify the parameters supported by the adapter.
-            
+
             Returns:
-            	set[str]: The supported parameter names.
+                set[str]: The supported parameter names.
             """
             return {"response_format"}
 
@@ -245,7 +245,7 @@ async def test_schema_fallback_consumes_finalization_ceiling(asynchronous) -> No
         def supports_response_schema(self):
             """
             Indicate that response schemas are supported.
-            
+
             Returns:
                 bool: `True` because response schemas are supported.
             """
@@ -325,7 +325,7 @@ def test_concurrent_finalization_admissions_do_not_overdraw():
     def attempt(_):
         """
         Attempts to reserve provider and finalization capacity for the current scope.
-        
+
         Returns:
             `true` if capacity is reserved successfully, `false` if the reservation times out.
         """

--- a/tests/unit/backend/rlm/test_dspy_compat_interpreter_contract.py
+++ b/tests/unit/backend/rlm/test_dspy_compat_interpreter_contract.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 def test_wrap_and_is_final_output_round_trip() -> None:
-    from fleet_rlm.rlm._dspy_compat import (
+    from fleet_rlm.rlm.compat_3_3_1 import (
         FinalOutput,
         is_final_output,
         wrap_final_output,
@@ -20,7 +20,7 @@ def test_wrap_and_is_final_output_round_trip() -> None:
 def test_interpreter_types_use_dspy_public_namespace() -> None:
     import dspy
 
-    from fleet_rlm.rlm._dspy_compat import (
+    from fleet_rlm.rlm.compat_3_3_1 import (
         CodeInterpreter,
         FinalOutput,
     )
@@ -30,7 +30,7 @@ def test_interpreter_types_use_dspy_public_namespace() -> None:
 
 
 def test_copy_output_fields_defensive_copy() -> None:
-    from fleet_rlm.rlm._dspy_compat import copy_output_fields
+    from fleet_rlm.rlm.compat_3_3_1 import copy_output_fields
 
     fields = [{"name": "answer", "type": "str"}]
     copied = copy_output_fields(fields)
@@ -40,7 +40,7 @@ def test_copy_output_fields_defensive_copy() -> None:
 
 
 def test_copy_output_fields_does_not_share_nested_metadata() -> None:
-    from fleet_rlm.rlm._dspy_compat import copy_output_fields
+    from fleet_rlm.rlm.compat_3_3_1 import copy_output_fields
 
     fields = [{"name": "answer", "metadata": {"description": "final answer"}}]
     copied = copy_output_fields(fields)
@@ -51,7 +51,7 @@ def test_copy_output_fields_does_not_share_nested_metadata() -> None:
 
 
 def test_needs_binding_refresh_uses_fleet_generation_state() -> None:
-    from fleet_rlm.rlm._dspy_compat import needs_binding_refresh
+    from fleet_rlm.rlm.compat_3_3_1 import needs_binding_refresh
 
     assert needs_binding_refresh(desired_generation=1, installed_generation=0, broker_ready=False) is True
     assert needs_binding_refresh(desired_generation=1, installed_generation=0, broker_ready=True) is True
@@ -60,6 +60,6 @@ def test_needs_binding_refresh_uses_fleet_generation_state() -> None:
 
 
 def test_public_final_output_label_is_stable() -> None:
-    from fleet_rlm.rlm._dspy_compat import PUBLIC_FINAL_OUTPUT_LABEL
+    from fleet_rlm.rlm.compat_3_3_1 import PUBLIC_FINAL_OUTPUT_LABEL
 
     assert PUBLIC_FINAL_OUTPUT_LABEL == "FINAL submitted"

--- a/tests/unit/backend/rlm/test_dspy_compat_seam.py
+++ b/tests/unit/backend/rlm/test_dspy_compat_seam.py
@@ -40,7 +40,7 @@ class _OneAction:
 
 @pytest.mark.asyncio
 async def test_daytona_provider_contract_is_zero_arg_metadata_only() -> None:
-    from fleet_rlm.rlm._dspy_compat import DAYTONA_EXECUTION_INSTRUCTIONS
+    from fleet_rlm.rlm.compat_3_3_1 import DAYTONA_EXECUTION_INSTRUCTIONS
 
     rlm = _rlm()
     provider = rlm._interpreter_factory
@@ -54,7 +54,7 @@ async def test_daytona_provider_contract_is_zero_arg_metadata_only() -> None:
 
 
 def test_daytona_action_prompt_contains_each_runtime_fact_once() -> None:
-    from fleet_rlm.rlm._dspy_compat import DAYTONA_EXECUTION_INSTRUCTIONS
+    from fleet_rlm.rlm.compat_3_3_1 import DAYTONA_EXECUTION_INSTRUCTIONS
 
     prompt = str(_rlm().generate_action.signature.instructions)
     facts = (

--- a/tests/unit/backend/rlm/test_error_taxonomy_repair.py
+++ b/tests/unit/backend/rlm/test_error_taxonomy_repair.py
@@ -264,7 +264,7 @@ def test_repair_text_is_bounded_and_safe_for_native_context() -> None:
 
 def test_provider_failure_trace_keeps_category_but_not_private_message(monkeypatch: pytest.MonkeyPatch) -> None:
     from fleet_rlm.observability import tracing as turn_tracing
-    from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
 
     captured: dict[str, object] = {}
 

--- a/tests/unit/backend/rlm/test_events_tool_observer.py
+++ b/tests/unit/backend/rlm/test_events_tool_observer.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Mapping
 from typing import Any
 
 import dspy
 import pytest
 
+from fleet_rlm.rlm.budget import BudgetDimension, BudgetLimits, TurnBudget, TurnBudgetExhausted
 from fleet_rlm.rlm.events import (
     ToolCompleted,
     ToolEventView,
@@ -19,6 +21,29 @@ from fleet_rlm.rlm.events import (
 )
 from fleet_rlm.rlm.result import RunNoProgressError
 from fleet_rlm.rlm.runtime import RunToolGuards
+
+
+def test_observe_tool_admits_calls_against_the_turn_budget() -> None:
+    calls: list[str] = []
+    observed: list[Any] = []
+    budget = TurnBudget(
+        deadline=time.monotonic() + 60,
+        limits=BudgetLimits(tool_calls=1),
+    )
+    wrapped = observe_tool(
+        dspy.Tool(lambda query: calls.append(query) or query, name="lookup"),
+        observed.append,
+        ToolEventView.metadata_only(),
+        guards=RunToolGuards(budget=budget),
+    )
+
+    assert wrapped.func("first") == "first"
+    with pytest.raises(TurnBudgetExhausted):
+        wrapped.func("second")
+
+    assert calls == ["first"]
+    assert budget.snapshot()[BudgetDimension.TOOL_CALLS.value] == 1
+    assert sum(isinstance(item, ToolFailed) for item in observed) == 1
 
 
 def test_observe_tool_creates_bounded_mlflow_tool_span(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/backend/rlm/test_fleet_json_adapter.py
+++ b/tests/unit/backend/rlm/test_fleet_json_adapter.py
@@ -293,6 +293,23 @@ def test_wrap_up_rejects_non_submit_actions_after_one_correction(bad_code: str) 
     assert len(lm.calls) == 2
 
 
+def _advance_after_provider(
+    monkeypatch: pytest.MonkeyPatch, lm: _ScriptedLM, *, start: float, after: list[float]
+) -> None:
+    now = [start]
+    remaining = iter(after)
+    original = lm.forward
+
+    def forward(*args, **kwargs):
+        try:
+            return original(*args, **kwargs)
+        finally:
+            now[0] = next(remaining)
+
+    monkeypatch.setattr("fleet_rlm.rlm.budget.time.monotonic", lambda: now[0])
+    monkeypatch.setattr(lm, "forward", forward)
+
+
 def test_late_normal_response_is_reclassified_before_action_execution(monkeypatch: pytest.MonkeyPatch) -> None:
     lm = _ScriptedLM(
         [
@@ -301,8 +318,7 @@ def test_late_normal_response_is_reclassified_before_action_execution(monkeypatc
         ]
     )
     adapter = FleetJSONAdapter(deadline=10, wrap_up_seconds=1)
-    remaining = iter((2.0, 0.5, 0.4, 0.3))
-    monkeypatch.setattr(adapter, "_remaining", lambda: next(remaining))
+    _advance_after_provider(monkeypatch, lm, start=8.0, after=[9.5, 9.7])
 
     prediction = _run_iteration_action(lm, adapter)
 
@@ -317,8 +333,7 @@ def test_late_normal_response_is_reclassified_before_action_execution(monkeypatc
 def test_late_normal_submit_is_accepted_as_the_wrap_up_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
     lm = _ScriptedLM(['{"reasoning": "submit evidence", "code": "SUBMIT(answer=answer)"}'])
     adapter = FleetJSONAdapter(deadline=10, wrap_up_seconds=1)
-    remaining = iter((2.0, 0.5))
-    monkeypatch.setattr(adapter, "_remaining", lambda: next(remaining))
+    _advance_after_provider(monkeypatch, lm, start=8.0, after=[9.5])
 
     prediction = _run_iteration_action(lm, adapter)
 
@@ -337,8 +352,7 @@ def test_normal_provider_timeout_at_reserve_transitions_to_wrap_up(monkeypatch: 
 
     lm = _TimeoutOnceLM(['{"reasoning": "submit evidence", "code": "SUBMIT(answer=answer)"}'])
     adapter = FleetJSONAdapter(deadline=10, wrap_up_seconds=1)
-    remaining = iter((2.0, 0.5, 0.4, 0.3))
-    monkeypatch.setattr(adapter, "_remaining", lambda: next(remaining))
+    _advance_after_provider(monkeypatch, lm, start=8.0, after=[9.5, 9.7])
 
     prediction = _run_iteration_action(lm, adapter)
 
@@ -439,8 +453,16 @@ async def test_distilled_trace_rejects_late_exploration_and_submits_existing_evi
         ]
     )
     adapter = FleetJSONAdapter(deadline=10, wrap_up_seconds=1)
-    remaining = iter((10.0, 10.0, 0.5, 0.4, 0.3, 0.2))
-    monkeypatch.setattr(adapter, "_remaining", lambda: next(remaining))
+    now = [0.0]
+    monkeypatch.setattr("fleet_rlm.rlm.budget.time.monotonic", lambda: now[0])
+    original = adapter.acall
+
+    async def advance_after_action(*args, **kwargs):
+        result = await original(*args, **kwargs)
+        now[0] = 9.5
+        return result
+
+    monkeypatch.setattr(adapter, "acall", advance_after_action)
     backend = InProcessInterpreterBackend()
     interpreter = DaytonaCodeInterpreter(backend=backend)
     rlm = build_native_rlm(signature="request -> answer: str", options=RLMOptions(max_iters=3), verbose=False)

--- a/tests/unit/backend/rlm/test_fleet_json_adapter.py
+++ b/tests/unit/backend/rlm/test_fleet_json_adapter.py
@@ -464,3 +464,74 @@ async def test_distilled_trace_rejects_late_exploration_and_submits_existing_evi
         "wrap_up_rejection_reason": "exploration_or_additional_code",
         "wrap_up_remaining_ms": 500,
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "texts, reserve, expected_error",
+    [
+        (['{"reasoning":"r","code":"SUBMIT(answer=1)"}'], False, None),
+        (["", '{"reasoning":"r","code":"SUBMIT(answer=1)"}'], False, None),
+        (["", ""], False, AdapterParseError),
+        (
+            ['{"reasoning":"r","code":"print(1)"}', '{"reasoning":"r","code":"SUBMIT(answer=1)"}'],
+            True,
+            None,
+        ),
+        (["", ""], True, TimeoutError),
+    ],
+)
+async def test_sync_async_repair_policy_parity(
+    monkeypatch: pytest.MonkeyPatch,
+    texts: list[str],
+    reserve: bool,
+    expected_error: type[Exception] | None,
+) -> None:
+    monkeypatch.setattr("fleet_rlm.rlm._dspy_compat.time.monotonic", lambda: 100.0)
+    sync_lm = _ScriptedLM(texts)
+    async_lm = _ScriptedLM(texts)
+    options = {"deadline": 105.0, "wrap_up_seconds": 10.0} if reserve else {}
+    sync_adapter = FleetJSONAdapter(**options)
+    async_adapter = FleetJSONAdapter(**options)
+    inputs = {"iteration": "1/5"}
+    if expected_error is not None:
+        with pytest.raises(expected_error) as sync_error:
+            sync_adapter(sync_lm, {}, _IterationActionSignature, [], inputs)
+        with pytest.raises(expected_error) as async_error:
+            await async_adapter.acall(async_lm, {}, _IterationActionSignature, [], inputs)
+        assert str(sync_error.value) == str(async_error.value)
+    else:
+        expected = sync_adapter(sync_lm, {}, _IterationActionSignature, [], inputs)
+        actual = await async_adapter.acall(async_lm, {}, _IterationActionSignature, [], inputs)
+        assert actual == expected
+    assert async_lm.calls == sync_lm.calls
+    assert async_adapter.wrap_up_summary() == sync_adapter.wrap_up_summary()
+
+
+@pytest.mark.asyncio
+async def test_async_cancellation_closes_repair_machine_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    import asyncio
+
+    adapter = FleetJSONAdapter()
+    original = adapter._repair_steps
+    machines = []
+
+    def capture(*args, **kwargs):
+        machine = original(*args, **kwargs)
+        machines.append(machine)
+        return machine
+
+    calls = 0
+
+    async def cancel(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(adapter, "_repair_steps", capture)
+    monkeypatch.setattr(dspy.JSONAdapter, "acall", cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.acall(_ScriptedLM([""]), {}, _IterationActionSignature, [], {"iteration": "1/5"})
+    assert calls == 1
+    assert len(machines) == 1
+    assert machines[0].gi_frame is None

--- a/tests/unit/backend/rlm/test_fleet_json_adapter.py
+++ b/tests/unit/backend/rlm/test_fleet_json_adapter.py
@@ -13,7 +13,7 @@ from dspy.utils.exceptions import AdapterParseError, LMTimeoutError
 
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 from fleet_rlm.observability.diagnostics import normalize_turn_failure
-from fleet_rlm.rlm._dspy_compat import FleetJSONAdapter
+from fleet_rlm.rlm.compat_3_3_1 import FleetJSONAdapter
 from fleet_rlm.rlm.program import RLMOptions, build_native_rlm
 
 
@@ -487,7 +487,7 @@ async def test_sync_async_repair_policy_parity(
     reserve: bool,
     expected_error: type[Exception] | None,
 ) -> None:
-    monkeypatch.setattr("fleet_rlm.rlm._dspy_compat.time.monotonic", lambda: 100.0)
+    monkeypatch.setattr("fleet_rlm.rlm.compat_3_3_1.time.monotonic", lambda: 100.0)
     sync_lm = _ScriptedLM(texts)
     async_lm = _ScriptedLM(texts)
     options = {"deadline": 105.0, "wrap_up_seconds": 10.0} if reserve else {}

--- a/tests/unit/backend/rlm/test_fleet_json_adapter.py
+++ b/tests/unit/backend/rlm/test_fleet_json_adapter.py
@@ -298,7 +298,7 @@ def _advance_after_provider(
 ) -> None:
     """
     Advance the mocked clock after each scripted language-model call.
-    
+
     Parameters:
         monkeypatch (pytest.MonkeyPatch): Fixture used to apply temporary patches.
         lm (_ScriptedLM): Scripted language model whose forward method is wrapped.
@@ -470,7 +470,7 @@ async def test_distilled_trace_rejects_late_exploration_and_submits_existing_evi
     async def advance_after_action(*args, **kwargs):
         """
         Run the wrapped action and advance the mocked clock after it completes.
-        
+
         Returns:
             The result produced by the wrapped action.
         """
@@ -556,13 +556,13 @@ async def test_async_cancellation_closes_repair_machine_without_retry(monkeypatc
 
     def capture(*args, **kwargs):
         """Create and record a machine produced by the original factory.
-        
+
         Parameters:
-        	*args: Positional arguments forwarded to the original factory.
-        	**kwargs: Keyword arguments forwarded to the original factory.
-        
+                *args: Positional arguments forwarded to the original factory.
+                **kwargs: Keyword arguments forwarded to the original factory.
+
         Returns:
-        	The created machine.
+                The created machine.
         """
         machine = original(*args, **kwargs)
         machines.append(machine)

--- a/tests/unit/backend/rlm/test_fleet_json_adapter.py
+++ b/tests/unit/backend/rlm/test_fleet_json_adapter.py
@@ -296,6 +296,15 @@ def test_wrap_up_rejects_non_submit_actions_after_one_correction(bad_code: str) 
 def _advance_after_provider(
     monkeypatch: pytest.MonkeyPatch, lm: _ScriptedLM, *, start: float, after: list[float]
 ) -> None:
+    """
+    Advance the mocked clock after each scripted language-model call.
+    
+    Parameters:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to apply temporary patches.
+        lm (_ScriptedLM): Scripted language model whose forward method is wrapped.
+        start (float): Initial monotonic clock value.
+        after (list[float]): Successive clock values applied after provider calls.
+    """
     now = [start]
     remaining = iter(after)
     original = lm.forward
@@ -311,6 +320,7 @@ def _advance_after_provider(
 
 
 def test_late_normal_response_is_reclassified_before_action_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that a late provider response is reclassified for wrap-up before action execution."""
     lm = _ScriptedLM(
         [
             '{"reasoning": "keep exploring", "code": "answer = tool()"}',
@@ -458,6 +468,12 @@ async def test_distilled_trace_rejects_late_exploration_and_submits_existing_evi
     original = adapter.acall
 
     async def advance_after_action(*args, **kwargs):
+        """
+        Run the wrapped action and advance the mocked clock after it completes.
+        
+        Returns:
+            The result produced by the wrapped action.
+        """
         result = await original(*args, **kwargs)
         now[0] = 9.5
         return result
@@ -539,6 +555,15 @@ async def test_async_cancellation_closes_repair_machine_without_retry(monkeypatc
     machines = []
 
     def capture(*args, **kwargs):
+        """Create and record a machine produced by the original factory.
+        
+        Parameters:
+        	*args: Positional arguments forwarded to the original factory.
+        	**kwargs: Keyword arguments forwarded to the original factory.
+        
+        Returns:
+        	The created machine.
+        """
         machine = original(*args, **kwargs)
         machines.append(machine)
         return machine
@@ -546,6 +571,7 @@ async def test_async_cancellation_closes_repair_machine_without_retry(monkeypatc
     calls = 0
 
     async def cancel(*_args, **_kwargs):
+        """Raise asyncio.CancelledError and record the cancellation attempt."""
         nonlocal calls
         calls += 1
         raise asyncio.CancelledError

--- a/tests/unit/backend/rlm/test_native_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_native_dspy_contract.py
@@ -15,6 +15,7 @@ from pydantic import Field, PlainSerializer
 
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 from fleet_rlm.rlm.events import ToolEventView, observe_tool
+from fleet_rlm.rlm.output_contract import bind_output_contract
 from fleet_rlm.rlm.program import RLMModelBundle, RLMOptions, build_native_rlm
 from fleet_rlm.rlm.result import prediction_result
 
@@ -323,7 +324,7 @@ async def test_native_json_action_contract_parses_first_and_followup_iterations(
 
 @pytest.mark.asyncio
 async def test_native_rlm_callback_observes_completed_action_without_altering_prediction() -> None:
-    from fleet_rlm.rlm._dspy_compat import bind_native_rlm_observer
+    from fleet_rlm.rlm.compat_3_3_1 import bind_native_rlm_observer
     from fleet_rlm.rlm.events import RLMReasoning
     from fleet_rlm.rlm.program import (
         RLMOptions,
@@ -355,7 +356,7 @@ async def test_native_rlm_callback_observes_completed_action_without_altering_pr
 
         def execute(self, code: str, variables: dict[str, Any] | None = None) -> Any:
             del code, variables
-            from fleet_rlm.rlm._dspy_compat import wrap_final_output
+            from fleet_rlm.rlm.compat_3_3_1 import wrap_final_output
 
             return wrap_final_output({"answer": "ok"})
 
@@ -385,7 +386,7 @@ async def test_native_rlm_callback_observes_completed_action_without_altering_pr
 def test_composition_version_guard_accepts_exact_final_3_3_1_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from fleet_rlm.rlm._dspy_compat import (
+    from fleet_rlm.rlm.compat_3_3_1 import (
         CERTIFIED_DSPY_VERSION,
         UncertifiedDSpyVersionError,
         assert_dspy_version,
@@ -419,7 +420,7 @@ def test_composition_version_guard_accepts_exact_final_3_3_1_only(
 def test_composition_version_guard_error_is_bounded_and_typed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from fleet_rlm.rlm._dspy_compat import (
+    from fleet_rlm.rlm.compat_3_3_1 import (
         UncertifiedDSpyVersionError,
         assert_dspy_version,
     )
@@ -500,7 +501,7 @@ def test_lm_trace_callback_records_role_and_failure_category(monkeypatch: pytest
     from types import SimpleNamespace
 
     from fleet_rlm.observability import tracing as turn_tracing
-    from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
 
     calls = SimpleNamespace(outputs=[])
 
@@ -587,7 +588,7 @@ def test_lm_trace_callback_records_classified_failure_detail(monkeypatch: pytest
 
     from fleet_rlm.daytona.errors import ProviderRequestError
     from fleet_rlm.observability import tracing as turn_tracing
-    from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
 
     captured = SimpleNamespace(outputs=[])
 
@@ -663,7 +664,7 @@ def test_lm_trace_callback_records_classified_failure_detail(monkeypatch: pytest
 def test_lm_trace_callback_keeps_structural_last_call_summary() -> None:
     from types import SimpleNamespace
 
-    from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
 
     root = SimpleNamespace(model="root-model", history=[])
     callback = _RLMTraceCallback(root_lm=root, sub_lm=SimpleNamespace(model="sub-model"))
@@ -683,7 +684,7 @@ def test_lm_trace_callback_keeps_structural_last_call_summary() -> None:
 
 def test_lm_trace_profiles_include_bounded_readable_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
     from fleet_rlm.observability import tracing
-    from fleet_rlm.rlm._dspy_compat import (
+    from fleet_rlm.rlm.compat_3_3_1 import (
         _lm_input_profile,
         _lm_output_profile,
     )
@@ -708,7 +709,7 @@ def test_lm_trace_callback_records_call_specific_usage_and_standard_attribute(mo
     from types import SimpleNamespace
 
     from fleet_rlm.observability import tracing as turn_tracing
-    from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
 
     calls = SimpleNamespace(outputs=[], attributes=[])
 
@@ -816,7 +817,7 @@ def test_reasoning_callback_spans_the_complete_root_action(monkeypatch: pytest.M
     from types import SimpleNamespace
 
     from fleet_rlm.observability import tracing as turn_tracing
-    from fleet_rlm.rlm._dspy_compat import _RLMReasoningCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMReasoningCallback
 
     outputs: list[dict[str, object]] = []
 
@@ -893,7 +894,7 @@ def test_malformed_provider_usage_degrades_without_losing_measured_fields(provid
 
 
 def test_lm_output_profile_reads_mapping_of_parsed_fields() -> None:
-    from fleet_rlm.rlm._dspy_compat import _lm_output_profile
+    from fleet_rlm.rlm.compat_3_3_1 import _lm_output_profile
 
     # Success path: adapter-parsed outputs arrive as a Mapping of signature fields.
     outputs = {"reasoning": "step", "code": "print(1)"}
@@ -904,7 +905,7 @@ def test_lm_output_profile_reads_mapping_of_parsed_fields() -> None:
 
 
 def test_lm_output_profile_degrades_unknown_shapes_without_raw_probing() -> None:
-    from fleet_rlm.rlm._dspy_compat import _lm_output_profile
+    from fleet_rlm.rlm.compat_3_3_1 import _lm_output_profile
 
     # P38-RLM-006/011: raw LiteLLM ModelResponse shapes are never delivered by
     # the certified DSPy 3.3.1 legacy contract and are no longer probed.
@@ -928,7 +929,7 @@ def test_latest_lm_telemetry_reads_only_the_certified_legacy_history_entry() -> 
     """
     from types import SimpleNamespace
 
-    from fleet_rlm.rlm._dspy_compat import _latest_lm_telemetry
+    from fleet_rlm.rlm.compat_3_3_1 import _latest_lm_telemetry
 
     outputs = ["parsed"]
     lm = SimpleNamespace(
@@ -961,7 +962,7 @@ def test_lm_trace_callback_emits_token_usage_output_and_mlflow_attribute(monkeyp
     from types import SimpleNamespace
 
     from fleet_rlm.observability import tracing as turn_tracing
-    from fleet_rlm.rlm._dspy_compat import _RLMTraceCallback
+    from fleet_rlm.rlm.compat_3_3_1 import _RLMTraceCallback
     from fleet_rlm.rlm.recursion import DelegationMetrics
 
     captured = SimpleNamespace(outputs=[], attributes={})
@@ -1079,6 +1080,7 @@ async def test_native_submit_honors_required_defaults_and_nullable_outputs() -> 
         note: str | None = dspy.OutputField()
 
     interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
+    bind_output_contract(interpreter, Report)
     rlm = build_native_rlm(
         signature=Report,
         options=RLMOptions(max_iters=1),
@@ -1254,3 +1256,69 @@ def test_native_contract_does_not_construct_or_shutdown_caller_owned_interpreter
 
     assert inspect.signature(rlm._interpreter_factory).parameters == {}
     assert sentinel.shutdown_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_caller_owned_interpreter_tool_injection_output_metadata_and_trajectory() -> None:
+    import json
+
+    class ItemPayload(dspy.SandboxSerializable):
+        def __init__(self, key: str, value: int) -> None:
+            self.key = key
+            self.value = value
+
+        def sandbox_setup(self) -> str:
+            return "import json as _test_json"
+
+        def to_sandbox(self) -> bytes:
+            return json.dumps({"key": self.key, "value": self.value}).encode()
+
+        def sandbox_assignment(self, var_name: str, data_expr: str) -> str:
+            return f"{var_name} = _test_json.loads({data_expr})"
+
+        def rlm_preview(self, max_chars: int = 100) -> str:
+            del max_chars
+            return f"ItemPayload(key={self.key})"
+
+    class TaskSignature(dspy.Signature):
+        request: str = dspy.InputField()
+        payload: ItemPayload = dspy.InputField()
+        answer: str = dspy.OutputField()
+        summary: str = dspy.OutputField(default="default-summary")
+
+    def lookup_tool(text: str) -> str:
+        """Echo lookup value."""
+        return f"found:{text}"
+
+    interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())
+    bind_output_contract(interpreter, TaskSignature)
+
+    rlm = build_native_rlm(
+        signature=TaskSignature,
+        tools=[lookup_tool],
+        options=RLMOptions(max_iters=2),
+        verbose=False,
+    )
+
+    action1 = 'val = lookup_tool(text=payload["key"])\nprint(val)'
+    action2 = "SUBMIT(answer=val)"
+    rlm.generate_action = _Actions(action1, action2)
+    rlm.extract = _NeverExtract()
+
+    try:
+        prediction = await rlm.acall(
+            interpreter,
+            request="fetch",
+            payload=ItemPayload("test-key", 42),
+        )
+    finally:
+        interpreter.shutdown()
+
+    assert "lookup_tool" in interpreter.tools
+    assert "llm_query" in interpreter.tools
+    assert prediction.answer == "found:test-key"
+    assert prediction.summary == "default-summary"
+    assert len(prediction.trajectory) >= 2
+    assert prediction.trajectory[0]["code"] == action1
+    assert "found:test-key" in prediction.trajectory[0]["output"]
+    assert prediction.trajectory[1]["code"] == action2

--- a/tests/unit/backend/rlm/test_native_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_native_dspy_contract.py
@@ -355,6 +355,7 @@ async def test_native_rlm_callback_observes_completed_action_without_altering_pr
             return None
 
         def execute(self, code: str, variables: dict[str, Any] | None = None) -> Any:
+            """Execute code with optional variables and return a wrapped result."""
             del code, variables
             from fleet_rlm.rlm.compat_3_3_1 import wrap_final_output
 
@@ -1266,19 +1267,31 @@ async def test_caller_owned_interpreter_tool_injection_output_metadata_and_traje
 
     class ItemPayload(dspy.SandboxSerializable):
         def __init__(self, key: str, value: int) -> None:
+            """Initialize an instance with a key and associated value."""
             self.key = key
             self.value = value
 
         def sandbox_setup(self) -> str:
+            """Provide the sandbox initialization code used by the test interpreter."""
             return "import json as _test_json"
 
         def to_sandbox(self) -> bytes:
+            """
+            Serialize the key-value pair for sandbox transfer.
+            
+            Returns:
+                bytes: UTF-8 encoded JSON representation of the key-value pair.
+            """
             return json.dumps({"key": self.key, "value": self.value}).encode()
 
         def sandbox_assignment(self, var_name: str, data_expr: str) -> str:
+            """
+            Generate a sandbox assignment statement that deserializes a JSON expression.
+            """
             return f"{var_name} = _test_json.loads({data_expr})"
 
         def rlm_preview(self, max_chars: int = 100) -> str:
+            """Return a concise representation containing the payload key."""
             del max_chars
             return f"ItemPayload(key={self.key})"
 
@@ -1289,7 +1302,11 @@ async def test_caller_owned_interpreter_tool_injection_output_metadata_and_traje
         summary: str = dspy.OutputField(default="default-summary")
 
     def lookup_tool(text: str) -> str:
-        """Echo lookup value."""
+        """Formats a lookup value with a found prefix.
+        
+        Returns:
+            The lookup value prefixed with ``"found:"``.
+        """
         return f"found:{text}"
 
     interpreter = DaytonaCodeInterpreter(backend=InProcessInterpreterBackend())

--- a/tests/unit/backend/rlm/test_native_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_native_dspy_contract.py
@@ -1196,7 +1196,9 @@ async def test_sync_and_async_tools_have_equivalent_results_and_lifecycle() -> N
     async_wrapped = observe_tool(dspy.Tool(async_tool), async_events.append, ToolEventView.metadata_only())
 
     sync_result = sync_wrapped.func(value=4, note=None)
-    async_result = async_wrapped.func(value=4, note=None)
+    # DSPy Tools are synchronous at the interpreter boundary; direct callers
+    # outside the worker loop use the short-lived credential-free path.
+    async_result = await asyncio.to_thread(async_wrapped.func, value=4, note=None)
 
     assert sync_result == async_result == {"value": 4, "note": None}
     assert [type(event).__name__ for event in sync_events] == [

--- a/tests/unit/backend/rlm/test_native_dspy_contract.py
+++ b/tests/unit/backend/rlm/test_native_dspy_contract.py
@@ -1278,7 +1278,7 @@ async def test_caller_owned_interpreter_tool_injection_output_metadata_and_traje
         def to_sandbox(self) -> bytes:
             """
             Serialize the key-value pair for sandbox transfer.
-            
+
             Returns:
                 bytes: UTF-8 encoded JSON representation of the key-value pair.
             """
@@ -1303,7 +1303,7 @@ async def test_caller_owned_interpreter_tool_injection_output_metadata_and_traje
 
     def lookup_tool(text: str) -> str:
         """Formats a lookup value with a found prefix.
-        
+
         Returns:
             The lookup value prefixed with ``"found:"``.
         """

--- a/tests/unit/backend/rlm/test_program_factory.py
+++ b/tests/unit/backend/rlm/test_program_factory.py
@@ -141,6 +141,7 @@ async def test_deadline_proxy_async_retry_preserves_attempt_timeout():
             return copied
 
         async def aforward(self, **kwargs):
+            """Execute the forward operation asynchronously and return its result."""
             return self.forward(**kwargs)
 
     source = AsyncLM([LMServerError("retry")])
@@ -166,11 +167,22 @@ async def test_deadline_proxy_preserves_dspy_sync_async_usage_and_callbacks():
             self.starts = []
 
         def on_lm_start(self, call_id, instance, inputs):
+            """
+            Record the model associated with a language-model invocation.
+            
+            Parameters:
+                instance: The language-model instance whose model name is recorded.
+            """
             del call_id, inputs
             self.starts.append(instance.model)
 
     class ScriptLM(dspy.BaseLM):
         def forward(self, prompt=None, messages=None, **kwargs):
+            """Generate a fixed successful language-model response.
+            
+            Returns:
+                A response containing ``"ok"`` and fixed token usage statistics.
+            """
             del prompt, messages, kwargs
             return SimpleNamespace(
                 model=self.model,
@@ -179,6 +191,16 @@ async def test_deadline_proxy_preserves_dspy_sync_async_usage_and_callbacks():
             )
 
         async def aforward(self, prompt=None, messages=None, **kwargs):
+            """
+            Process a prompt or message sequence.
+            
+            Parameters:
+                prompt: Optional prompt to process.
+                messages: Optional sequence of messages to process.
+            
+            Returns:
+                The model response.
+            """
             return self.forward(prompt, messages, **kwargs)
 
     callback = Callback()
@@ -250,6 +272,12 @@ def test_provider_retries_recompute_remaining_and_non_retryable_errors_stop(
     ticks = [100.0, 100.0, 101.0, 101.0]
 
     def clock() -> float:
+        """
+        Return the next scripted clock value.
+        
+        Returns:
+        	float: The next value from `ticks`, or `102.0` when no scripted values remain.
+        """
         return ticks.pop(0) if ticks else 102.0
 
     monkeypatch.setattr("fleet_rlm.rlm.program.time.monotonic", clock)

--- a/tests/unit/backend/rlm/test_program_factory.py
+++ b/tests/unit/backend/rlm/test_program_factory.py
@@ -270,6 +270,17 @@ def test_provider_retries_recompute_remaining_and_non_retryable_errors_stop(
         assert len(bound.root_lm.calls) == 1
 
 
+def test_turn_binding_rejects_nonfinite_deadline_that_would_disable_budget() -> None:
+    import math
+
+    from fleet_rlm.rlm.program import RLMModelBundle
+
+    with pytest.raises(ValueError, match="deadline"):
+        RLMModelBundle(_CopyableLM(), _CopyableLM()).bind_turn_deadline(deadline=math.nan)
+    with pytest.raises(ValueError, match="deadline"):
+        RLMModelBundle(_CopyableLM(), _CopyableLM()).bind_turn_deadline(deadline=-math.inf)
+
+
 def test_child_copy_cannot_extend_turn_budget_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     from fleet_rlm.rlm.program import RLMModelBundle
 

--- a/tests/unit/backend/rlm/test_program_factory.py
+++ b/tests/unit/backend/rlm/test_program_factory.py
@@ -169,7 +169,7 @@ async def test_deadline_proxy_preserves_dspy_sync_async_usage_and_callbacks():
         def on_lm_start(self, call_id, instance, inputs):
             """
             Record the model associated with a language-model invocation.
-            
+
             Parameters:
                 instance: The language-model instance whose model name is recorded.
             """
@@ -179,7 +179,7 @@ async def test_deadline_proxy_preserves_dspy_sync_async_usage_and_callbacks():
     class ScriptLM(dspy.BaseLM):
         def forward(self, prompt=None, messages=None, **kwargs):
             """Generate a fixed successful language-model response.
-            
+
             Returns:
                 A response containing ``"ok"`` and fixed token usage statistics.
             """
@@ -193,11 +193,11 @@ async def test_deadline_proxy_preserves_dspy_sync_async_usage_and_callbacks():
         async def aforward(self, prompt=None, messages=None, **kwargs):
             """
             Process a prompt or message sequence.
-            
+
             Parameters:
                 prompt: Optional prompt to process.
                 messages: Optional sequence of messages to process.
-            
+
             Returns:
                 The model response.
             """
@@ -274,9 +274,9 @@ def test_provider_retries_recompute_remaining_and_non_retryable_errors_stop(
     def clock() -> float:
         """
         Return the next scripted clock value.
-        
+
         Returns:
-        	float: The next value from `ticks`, or `102.0` when no scripted values remain.
+                float: The next value from `ticks`, or `102.0` when no scripted values remain.
         """
         return ticks.pop(0) if ticks else 102.0
 

--- a/tests/unit/backend/rlm/test_program_factory.py
+++ b/tests/unit/backend/rlm/test_program_factory.py
@@ -114,6 +114,84 @@ def test_model_bundle_child_lm_rejects_calls_after_turn_deadline() -> None:
         child.root_lm.forward(prompt="late")
 
 
+def test_deadline_proxy_copy_preserves_deadline_without_method_assignment() -> None:
+    import time
+
+    from fleet_rlm.rlm.program import RLMModelBundle
+
+    bound = RLMModelBundle(_CopyableLM(), _CopyableLM()).fork_for_child(deadline=time.monotonic() - 1)
+    copied = bound.root_lm.copy()
+    assert "forward" not in vars(copied)
+    assert "aforward" not in vars(copied)
+    assert copied.wrapped is not bound.root_lm.wrapped
+    with pytest.raises(TimeoutError, match="deadline exceeded"):
+        copied.forward(prompt="late")
+
+
+@pytest.mark.asyncio
+async def test_deadline_proxy_async_retry_preserves_attempt_timeout():
+    import time
+
+    from fleet_rlm.rlm.program import RLMModelBundle
+
+    class AsyncLM(_RetryingLM):
+        def copy(self, **kwargs):
+            copied = AsyncLM(self.failures)
+            copied.num_retries = kwargs["num_retries"]
+            return copied
+
+        async def aforward(self, **kwargs):
+            return self.forward(**kwargs)
+
+    source = AsyncLM([LMServerError("retry")])
+    bound = RLMModelBundle(source, source).bind_turn_deadline(deadline=time.monotonic() + 5)
+    await bound.root_lm.aforward(prompt="test")
+    assert len(bound.root_lm.calls) == 2
+    assert source.calls == []
+    assert all(0 < call["timeout"] <= 5 for call in bound.root_lm.calls)
+
+
+@pytest.mark.asyncio
+async def test_deadline_proxy_preserves_dspy_sync_async_usage_and_callbacks():
+    import time
+    from types import SimpleNamespace
+
+    import dspy
+    from dspy.utils.callback import BaseCallback
+
+    from fleet_rlm.rlm.program import RLMModelBundle
+
+    class Callback(BaseCallback):
+        def __init__(self):
+            self.starts = []
+
+        def on_lm_start(self, call_id, instance, inputs):
+            del call_id, inputs
+            self.starts.append(instance.model)
+
+    class ScriptLM(dspy.BaseLM):
+        def forward(self, prompt=None, messages=None, **kwargs):
+            del prompt, messages, kwargs
+            return SimpleNamespace(
+                model=self.model,
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+                usage={"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+            )
+
+        async def aforward(self, prompt=None, messages=None, **kwargs):
+            return self.forward(prompt, messages, **kwargs)
+
+    callback = Callback()
+    source = ScriptLM("test/script", callbacks=[callback])
+    proxy = RLMModelBundle(source, source).bind_turn_deadline(deadline=time.monotonic() + 10).root_lm
+    assert proxy("sync") == ["ok"]
+    assert await proxy.acall("async") == ["ok"]
+    assert len(proxy.history) == 2
+    assert proxy.history[-1]["usage"]["total_tokens"] == 3
+    assert source.history == []
+    assert callback.starts == ["test/script", "test/script"]
+
+
 def test_turn_binding_isolated_and_applies_role_specific_reserve() -> None:
     import time
 
@@ -169,7 +247,7 @@ def test_provider_retries_recompute_remaining_and_non_retryable_errors_stop(
 
     retry_source = _RetryingLM([LMServerError("temporary")])
     bound = RLMModelBundle(retry_source, _CopyableLM()).bind_turn_deadline(deadline=110)
-    ticks = [100.0, 101.0]
+    ticks = [100.0, 100.0, 101.0, 101.0]
 
     def clock() -> float:
         return ticks.pop(0) if ticks else 102.0
@@ -192,7 +270,7 @@ def test_provider_retries_recompute_remaining_and_non_retryable_errors_stop(
         assert len(bound.root_lm.calls) == 1
 
 
-def test_child_copy_strips_turn_wrapper_and_uses_child_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_child_copy_cannot_extend_turn_budget_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     from fleet_rlm.rlm.program import RLMModelBundle
 
     source = RLMModelBundle(_CopyableLM(), _CopyableLM())
@@ -204,7 +282,10 @@ def test_child_copy_strips_turn_wrapper_and_uses_child_deadline(monkeypatch: pyt
     child.root_lm.forward(prompt="child")
 
     assert turn.root_lm.calls[-1]["timeout"] == 1
-    assert child.root_lm.calls[-1]["timeout"] == 10
+    assert child.root_lm.calls[-1]["timeout"] == 1
+    shorter_child = turn.fork_for_child(deadline=100.5)
+    shorter_child.root_lm.forward(prompt="short child")
+    assert shorter_child.root_lm.calls[-1]["timeout"] == 0.5
 
 
 def test_invalid_options_fail_before_construction() -> None:
@@ -282,7 +363,8 @@ def test_dspy_contract_is_only_native_dspy_rlm_call_site_in_rlm_package() -> Non
     import ast
     from pathlib import Path
 
-    rlm_dir = Path(__file__).resolve().parents[3] / "src" / "fleet_rlm" / "rlm"
+    rlm_dir = Path(__file__).resolve().parents[4] / "src" / "fleet_rlm" / "rlm"
+    assert (rlm_dir / "program.py").is_file()
     offenders: list[str] = []
     for path in sorted(rlm_dir.glob("*.py")):
         if path.name in ("dspy_contract.py", "program.py"):
@@ -300,12 +382,13 @@ def test_dspy_contract_is_only_native_dspy_rlm_call_site_in_rlm_package() -> Non
 
 
 def test_dspy_primitives_imports_are_confined_to_interpreter_contract() -> None:
-    """Static guard: only dspy_interpreter_contract.py may import dspy.primitives."""
+    """Static guard: only dspy_interpreter_contract.py and compat modules may import dspy.primitives."""
     import ast
     from pathlib import Path
 
-    src_root = Path(__file__).resolve().parents[3] / "src" / "fleet_rlm"
-    allowed = {"rlm/dspy_interpreter_contract.py", "rlm/_dspy_compat.py"}
+    src_root = Path(__file__).resolve().parents[4] / "src" / "fleet_rlm"
+    allowed = {"rlm/compat_3_3_1.py"}
+    assert (src_root / "rlm" / "program.py").is_file()
     offenders: list[str] = []
     for path in sorted(src_root.rglob("*.py")):
         rel = path.relative_to(src_root).as_posix()
@@ -326,3 +409,50 @@ def test_dspy_primitives_imports_are_confined_to_interpreter_contract() -> None:
                 offenders.append(rel)
                 break
     assert offenders == [], f"dspy.primitives imported outside interpreter contract: {offenders}"
+
+
+def test_private_dspy_imports_are_confined_to_compat_layer() -> None:
+    """Static guard: only compat modules may import private DSPy internal packages."""
+    import ast
+    from pathlib import Path
+
+    src_root = Path(__file__).resolve().parents[4] / "src" / "fleet_rlm"
+    allowed = {"rlm/compat_3_3_1.py"}
+    assert (src_root / "rlm" / "program.py").is_file()
+    offenders: list[str] = []
+    for path in sorted(src_root.rglob("*.py")):
+        rel = path.relative_to(src_root).as_posix()
+        if rel in allowed:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module and (
+                    node.module.startswith("dspy.primitives")
+                    or node.module.startswith("dspy.predict")
+                    or node.module.startswith("dspy.adapters")
+                    or node.module.startswith("dspy.clients")
+                    or node.module.startswith("dspy.signatures")
+                ):
+                    offenders.append(f"{rel}: {node.module}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if (
+                        alias.name.startswith("dspy.primitives")
+                        or alias.name.startswith("dspy.predict")
+                        or alias.name.startswith("dspy.adapters")
+                        or alias.name.startswith("dspy.clients")
+                        or alias.name.startswith("dspy.signatures")
+                    ):
+                        offenders.append(f"{rel}: {alias.name}")
+    assert offenders == [], f"Private DSPy imports found outside compat layer: {offenders}"
+
+
+def test_compatibility_implementation_has_one_versioned_home() -> None:
+    from pathlib import Path
+
+    from fleet_rlm.rlm.compat_3_3_1 import FleetJSONAdapter
+
+    root = Path(__file__).resolve().parents[4] / "src" / "fleet_rlm" / "rlm"
+    assert not (root / "_dspy_compat.py").exists()
+    assert FleetJSONAdapter.__module__ == "fleet_rlm.rlm.compat_3_3_1"

--- a/tests/unit/backend/rlm/test_recursion_lease_cleanup.py
+++ b/tests/unit/backend/rlm/test_recursion_lease_cleanup.py
@@ -42,7 +42,7 @@ from fleet_rlm.chat.run_authority import RunAuthority
 from fleet_rlm.chat.session_context import SessionContextManifest
 from fleet_rlm.daytona.interpreter import DaytonaCodeInterpreter, InProcessInterpreterBackend
 from fleet_rlm.daytona.recursive_child_runtime import ChildRuntimeLease
-from fleet_rlm.rlm._dspy_compat import wrap_final_output
+from fleet_rlm.rlm.compat_3_3_1 import wrap_final_output
 from fleet_rlm.rlm.events import RunCompleted, Status
 from fleet_rlm.rlm.program import (
     RLMModelBundle,

--- a/tests/unit/backend/rlm/test_recursion_metrics.py
+++ b/tests/unit/backend/rlm/test_recursion_metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from fleet_rlm.rlm._dspy_compat import (
+from fleet_rlm.rlm.compat_3_3_1 import (
     _latest_lm_telemetry,
     _RLMTraceCallback,
 )

--- a/tests/unit/backend/rlm/test_submit_validation.py
+++ b/tests/unit/backend/rlm/test_submit_validation.py
@@ -1,0 +1,37 @@
+"""Wrap-up grammar is deliberately narrower than general interpreter code."""
+
+import pytest
+
+from fleet_rlm.rlm.submit_validation import is_submit_only_code
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        'SUBMIT(answer="done")',
+        "```python\nSUBMIT(answer=str(evidence[0]))\n```",
+        'SUBMIT(answer=json.dumps({"items": items}), count=len(items))',
+        'SUBMIT(answer=f"Found {count}")',
+    ],
+)
+def test_accepts_finalization_expressions(code: str) -> None:
+    assert is_submit_only_code(code)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        None,
+        "",
+        "SUBMIT(",
+        'print("explore"); SUBMIT(answer="done")',
+        'SUBMIT(answer=llm_query("more work"))',
+        "SUBMIT(answer=[lookup(item) for item in items])",
+        "SUBMIT(**outputs)",
+        'SUBMIT("positional")',
+        "SUBMIT(answer=obj.__dict__)",
+        '```javascript\nSUBMIT(answer="done")\n```',
+    ],
+)
+def test_rejects_non_finalization_syntax(code: object) -> None:
+    assert not is_submit_only_code(code)

--- a/tests/unit/backend/rlm/test_tool_catalog.py
+++ b/tests/unit/backend/rlm/test_tool_catalog.py
@@ -10,6 +10,7 @@ from fleet_rlm.rlm.result import RLMConfigError
 
 
 def _tool(name):
+    """Create a test tool with the specified name."""
     return dspy.Tool(lambda: "ok", name=name)
 
 

--- a/tests/unit/backend/rlm/test_tool_catalog.py
+++ b/tests/unit/backend/rlm/test_tool_catalog.py
@@ -1,0 +1,52 @@
+"""Native RLM construction retains one closed, authority-aware tool namespace."""
+
+from dataclasses import FrozenInstanceError
+
+import dspy
+import pytest
+
+from fleet_rlm.rlm.program import FleetProgramSpec, FleetToolCatalog, FleetToolEntry, FleetToolKind, build_program
+from fleet_rlm.rlm.result import RLMConfigError
+
+
+def _tool(name):
+    return dspy.Tool(lambda: "ok", name=name)
+
+
+@pytest.mark.parametrize("name", ["llm_query", "llm_query_batched", "print", "SUBMIT", "not-valid", "class"])
+def test_catalog_rejects_native_namespace_collisions(name):
+    with pytest.raises(RLMConfigError):
+        FleetToolCatalog.from_tools([_tool(name)])
+
+
+def test_catalog_excludes_settlement_and_rejects_duplicate_names():
+    catalog = FleetToolCatalog(
+        (
+            FleetToolEntry(_tool("read_data"), FleetToolKind.HOST_AUTHORIZED),
+            FleetToolEntry(_tool("commit_turn"), FleetToolKind.SETTLEMENT_ONLY),
+        )
+    )
+    assert [tool.name for tool in catalog.model_tools()] == ["read_data"]
+    rlm = build_program(FleetProgramSpec(signature="question -> answer", tool_catalog=catalog))
+    assert set(rlm.tools) == {"read_data"}
+    with pytest.raises(RLMConfigError, match="duplicate"):
+        FleetToolCatalog.from_tools([_tool("read_data"), _tool("read_data")])
+
+
+def test_program_spec_snapshots_membership_and_builds_native_module():
+    tools = [_tool("read_data")]
+    spec = FleetProgramSpec(signature="question -> answer", tools=tools)
+    tools.clear()
+    assert spec.tools
+    with pytest.raises(FrozenInstanceError):
+        spec.verbose = False
+    rlm = build_program(spec)
+    assert type(rlm) is dspy.RLM
+    assert set(rlm.tools) == {"read_data"}
+
+
+def test_catalog_checks_final_constructed_namespace():
+    catalog = FleetToolCatalog.from_tools([_tool("read_data")])
+    unrelated = dspy.RLM("question -> answer", tools=[_tool("other")])
+    with pytest.raises(RLMConfigError, match="constructed"):
+        catalog.validate_constructed(unrelated)

--- a/tests/unit/backend/rlm/test_turn_budget.py
+++ b/tests/unit/backend/rlm/test_turn_budget.py
@@ -42,6 +42,19 @@ def test_finalization_capacity_is_not_available_to_exploration() -> None:
     assert budget.snapshot()["provider_attempts"] == 5
 
 
+def test_finalization_reservation_is_enforced_independently() -> None:
+    budget = TurnBudget(
+        deadline=time.monotonic() + 60,
+        limits=BudgetLimits(finalization_attempts=2),
+    )
+    budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, finalization=True)
+    budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, finalization=True)
+    with pytest.raises(TurnBudgetExhausted) as error:
+        budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, finalization=True)
+    assert error.value.dimension == BudgetDimension.PROVIDER_ATTEMPTS
+    assert budget.snapshot()["provider_attempts"] == 2
+
+
 def test_deadline_reserve_and_settlement(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("fleet_rlm.rlm.budget.time.monotonic", lambda: 98.0)
     budget = TurnBudget(deadline=100, limits=BudgetLimits(finalization_seconds=3))

--- a/tests/unit/backend/rlm/test_turn_budget.py
+++ b/tests/unit/backend/rlm/test_turn_budget.py
@@ -1,0 +1,122 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import dspy
+import pytest
+from dspy.utils.exceptions import LMServerError
+
+from fleet_rlm.rlm.budget import BudgetDimension, BudgetLimits, TurnBudget, TurnBudgetExhausted
+from fleet_rlm.rlm.program import RLMModelBundle
+
+
+@pytest.mark.parametrize(
+    "dimension", [dimension for dimension in BudgetDimension if dimension not in {"deadline", "settled"}]
+)
+def test_atomic_reservations_never_over_admit(dimension: BudgetDimension) -> None:
+    budget = TurnBudget(deadline=time.monotonic() + 60, limits=BudgetLimits(**{dimension.value: 7}))
+
+    def attempt(_: int) -> bool:
+        try:
+            budget.reserve(dimension)
+            return True
+        except TurnBudgetExhausted as error:
+            assert error.dimension == dimension
+            return False
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        assert sum(executor.map(attempt, range(40))) == 7
+    assert budget.snapshot()[dimension.value] == 7
+
+
+def test_finalization_capacity_is_not_available_to_exploration() -> None:
+    budget = TurnBudget(
+        deadline=time.monotonic() + 60,
+        limits=BudgetLimits(provider_attempts=5, finalization_attempts=2),
+    )
+    budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, 3)
+    with pytest.raises(TurnBudgetExhausted):
+        budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS)
+    budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, 2, finalization=True)
+    with pytest.raises(TurnBudgetExhausted):
+        budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, finalization=True)
+    assert budget.snapshot()["provider_attempts"] == 5
+
+
+def test_deadline_reserve_and_settlement(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("fleet_rlm.rlm.budget.time.monotonic", lambda: 98.0)
+    budget = TurnBudget(deadline=100, limits=BudgetLimits(finalization_seconds=3))
+    with pytest.raises(TurnBudgetExhausted) as error:
+        budget.reserve(BudgetDimension.TOOL_CALLS)
+    assert error.value.dimension == BudgetDimension.DEADLINE
+    assert budget.remaining(finalization=True) == 2
+    budget.settle()
+    with pytest.raises(TurnBudgetExhausted) as error:
+        budget.reserve(BudgetDimension.PROVIDER_ATTEMPTS, finalization=True)
+    assert error.value.dimension == BudgetDimension.SETTLED
+    assert not any(budget.snapshot().values())
+
+
+@pytest.mark.parametrize("value", [-1, True, 1.5])
+def test_invalid_limits(value: int) -> None:
+    with pytest.raises(ValueError):
+        BudgetLimits(provider_attempts=value)
+
+
+def test_failed_batch_does_not_partially_debit() -> None:
+    budget = TurnBudget(deadline=time.monotonic() + 60, limits=BudgetLimits(recursive_children=2))
+    with pytest.raises(TurnBudgetExhausted):
+        budget.reserve(BudgetDimension.RECURSIVE_CHILDREN, 3)
+    assert budget.snapshot()["recursive_children"] == 0
+
+
+def test_model_children_and_copies_share_budget_without_mutating_templates() -> None:
+    class CountingLM(dspy.BaseLM):
+        def forward(self, *_args, **_kwargs):
+            return "ok"
+
+    lm = CountingLM("test/counting")
+    deadline = time.monotonic() + 60
+    budget = TurnBudget(deadline=deadline, limits=BudgetLimits(provider_attempts=2))
+    template = RLMModelBundle(root_lm=lm, sub_lm=lm)
+    bound = template.bind_turn_deadline(deadline=deadline, budget=budget)
+    child = bound.fork_for_child(deadline=deadline)
+    assert child.budget is bound.budget is budget
+    assert bound.root_lm.forward() == "ok"
+    assert child.sub_lm.copy().forward() == "ok"
+    with pytest.raises(TurnBudgetExhausted):
+        child.root_lm.forward()
+    assert budget.snapshot()["provider_attempts"] == 2
+    assert template.budget is None
+    assert "budget" not in lm.__dict__
+    assert bound.root_lm.dump_state() == bound.root_lm.wrapped.dump_state()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_each_retry_is_charged_and_stops_before_an_unadmitted_attempt(asynchronous: bool) -> None:
+    class FailingLM(dspy.BaseLM):
+        def forward(self, *_args, **_kwargs):
+            raise LMServerError("temporary")
+
+        async def aforward(self, *_args, **_kwargs):
+            return self.forward()
+
+    lm = FailingLM("test/retrying", num_retries=5)
+    deadline = time.monotonic() + 60
+    budget = TurnBudget(deadline=deadline, limits=BudgetLimits(provider_attempts=2))
+    proxy = RLMModelBundle(lm, lm).bind_turn_deadline(deadline=deadline, budget=budget).root_lm
+    with pytest.raises(TurnBudgetExhausted):
+        if asynchronous:
+            await proxy.aforward()
+        else:
+            proxy.forward()
+    assert budget.snapshot()["provider_attempts"] == 2
+
+
+def test_new_turn_does_not_reuse_a_prior_turn_budget() -> None:
+    lm = dspy.LM("test/template")
+    deadline = time.monotonic() + 60
+    first = RLMModelBundle(lm, lm).bind_turn_deadline(deadline=deadline)
+    second = first.bind_turn_deadline(deadline=deadline)
+    assert first.budget is not second.budget
+    assert second.root_lm.budget is second.sub_lm.budget is second.budget

--- a/tests/unit/backend/rlm/test_turn_budget.py
+++ b/tests/unit/backend/rlm/test_turn_budget.py
@@ -85,6 +85,12 @@ def test_failed_batch_does_not_partially_debit() -> None:
 def test_model_children_and_copies_share_budget_without_mutating_templates() -> None:
     class CountingLM(dspy.BaseLM):
         def forward(self, *_args, **_kwargs):
+            """
+            Provide a successful forward result.
+            
+            Returns:
+            	str: The string `"ok"`.
+            """
             return "ok"
 
     lm = CountingLM("test/counting")
@@ -109,9 +115,19 @@ def test_model_children_and_copies_share_budget_without_mutating_templates() -> 
 async def test_each_retry_is_charged_and_stops_before_an_unadmitted_attempt(asynchronous: bool) -> None:
     class FailingLM(dspy.BaseLM):
         def forward(self, *_args, **_kwargs):
+            """Simulate a temporary language model server failure.
+            
+            Raises:
+                LMServerError: Always raised with a temporary failure message.
+            """
             raise LMServerError("temporary")
 
         async def aforward(self, *_args, **_kwargs):
+            """Run the model's forward operation.
+            
+            Returns:
+                The result of the forward operation.
+            """
             return self.forward()
 
     lm = FailingLM("test/retrying", num_retries=5)

--- a/tests/unit/backend/rlm/test_turn_budget.py
+++ b/tests/unit/backend/rlm/test_turn_budget.py
@@ -87,9 +87,9 @@ def test_model_children_and_copies_share_budget_without_mutating_templates() -> 
         def forward(self, *_args, **_kwargs):
             """
             Provide a successful forward result.
-            
+
             Returns:
-            	str: The string `"ok"`.
+                str: The string `"ok"`.
             """
             return "ok"
 
@@ -116,7 +116,7 @@ async def test_each_retry_is_charged_and_stops_before_an_unadmitted_attempt(asyn
     class FailingLM(dspy.BaseLM):
         def forward(self, *_args, **_kwargs):
             """Simulate a temporary language model server failure.
-            
+
             Raises:
                 LMServerError: Always raised with a temporary failure message.
             """
@@ -124,7 +124,7 @@ async def test_each_retry_is_charged_and_stops_before_an_unadmitted_attempt(asyn
 
         async def aforward(self, *_args, **_kwargs):
             """Run the model's forward operation.
-            
+
             Returns:
                 The result of the forward operation.
             """

--- a/tests/unit/backend/sessions/test_history.py
+++ b/tests/unit/backend/sessions/test_history.py
@@ -383,7 +383,7 @@ async def test_sql_store_level_cross_session_history_isolation(tmp_path) -> None
         async def commit(session_id: object, request: str, answer: str, key: str) -> None:
             """
             Commit a successful answer for a session.
-            
+
             Parameters:
                 session_id (object): Identifier of the session receiving the committed turn.
                 request (str): User request associated with the turn.

--- a/tests/unit/backend/sessions/test_history.py
+++ b/tests/unit/backend/sessions/test_history.py
@@ -381,6 +381,15 @@ async def test_sql_store_level_cross_session_history_isolation(tmp_path) -> None
         store = SqlAlchemyRunStateStore(factory)
 
         async def commit(session_id: object, request: str, answer: str, key: str) -> None:
+            """
+            Commit a successful answer for a session.
+            
+            Parameters:
+                session_id (object): Identifier of the session receiving the committed turn.
+                request (str): User request associated with the turn.
+                answer (str): Final answer text for the turn.
+                key (str): Key used to claim the turn.
+            """
             claimed = await store.begin(RunClaim(access, session_id, TurnInput(request), key, uuid4()))
             assert isinstance(claimed, ClaimedRun)
             await store.commit(

--- a/tests/unit/backend/sessions/test_history.py
+++ b/tests/unit/backend/sessions/test_history.py
@@ -377,6 +377,7 @@ async def test_sql_store_level_cross_session_history_isolation(tmp_path) -> None
                     SessionRow(id=session_b, user_id=access.user_id, workspace_id=access.workspace_id, title="B"),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory)
 
         async def commit(session_id: object, request: str, answer: str, key: str) -> None:

--- a/tests/unit/backend/test_adapter_benchmark_v2.py
+++ b/tests/unit/backend/test_adapter_benchmark_v2.py
@@ -1,0 +1,30 @@
+"""Runtime v2 adapter replay measures protocol behavior, not model quality."""
+
+from scripts.benchmarks.adapter_replay import run_adapter_comparison
+from scripts.benchmarks.runtime_v2 import digest
+
+
+def test_adapter_comparison_replays_both_modes_and_measures_repair_ablation():
+    receipt = run_adapter_comparison(repetitions=2)
+    assert receipt["passed"]
+    assert all(receipt["gates"].values())
+    assert receipt["scope"] == "scripted-adapter-protocol-only"
+    assert receipt["semantic_gate"] == "not_exercised"
+    assert len(receipt["samples"]) == 14 * 4 * 2 * 2
+    summary = receipt["summary"]
+    assert summary["fleet"]["correct"] == summary["fleet"]["samples"]
+    assert summary["fleet"]["correct"] > summary["fleet-one-parse-repair"]["correct"]
+    assert summary["fleet-one-parse-repair"]["correct"] > summary["fleet-no-parse-repair"]["correct"]
+    assert summary["fleet"]["provider_attempts"] > summary["stock"]["provider_attempts"]
+    for sample in receipt["samples"]:
+        assert sample["budget_attempts"] == sample["provider_attempts"]
+        assert sample["seconds"] >= 0
+    body = {key: value for key, value in receipt.items() if key != "receipt_digest"}
+    assert receipt["receipt_digest"] == digest(body)
+
+
+def test_adapter_comparison_requires_repeated_samples():
+    import pytest
+
+    with pytest.raises(ValueError, match="two repetitions"):
+        run_adapter_comparison(repetitions=1)

--- a/tests/unit/backend/test_claim_constraint_classification.py
+++ b/tests/unit/backend/test_claim_constraint_classification.py
@@ -1,0 +1,49 @@
+"""Only expected unique claim constraints may enter race reconciliation."""
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from fleet_rlm.persistence.repositories.turns import _expected_claim_conflict
+
+
+@pytest.mark.parametrize(
+    "message,code,expected",
+    [
+        ("UNIQUE constraint failed: fleet_runs.session_id", "SQLITE_CONSTRAINT_UNIQUE", True),
+        (
+            "UNIQUE constraint failed: fleet_runs.session_id, fleet_runs.idempotency_key",
+            "SQLITE_CONSTRAINT_UNIQUE",
+            True,
+        ),
+        ("UNIQUE constraint failed: fleet_runs.id", "SQLITE_CONSTRAINT_PRIMARYKEY", False),
+        ("FOREIGN KEY constraint failed", "SQLITE_CONSTRAINT_FOREIGNKEY", False),
+        ("CHECK constraint failed: ck_fleet_runs_status", "SQLITE_CONSTRAINT_CHECK", False),
+    ],
+)
+def test_sqlite_constraint_allowlist(message, code, expected):
+    original = sqlite3.IntegrityError(message)
+    original.sqlite_errorname = code
+    assert _expected_claim_conflict(IntegrityError(None, None, original)) is expected
+
+
+@pytest.mark.parametrize(
+    "constraint,code,expected",
+    [
+        ("uq_fleet_runs_one_running", "23505", True),
+        ("uq_fleet_runs_live_idempotency", "23505", True),
+        ("uq_fleet_runs_id_session", "23505", False),
+        ("fk_fleet_turns_run_session", "23503", False),
+        ("uq_fleet_runs_one_running", "23503", False),
+    ],
+)
+def test_postgres_constraint_allowlist(constraint, code, expected):
+    class DriverError(Exception):
+        pass
+
+    original = DriverError()
+    original.sqlstate = code
+    original.diag = SimpleNamespace(constraint_name=constraint)
+    assert _expected_claim_conflict(IntegrityError(None, None, original)) is expected

--- a/tests/unit/backend/test_claim_constraint_classification.py
+++ b/tests/unit/backend/test_claim_constraint_classification.py
@@ -1,8 +1,8 @@
 """Only expected unique claim constraints may enter race reconciliation."""
 
 import sqlite3
-from types import SimpleNamespace
 
+import asyncpg
 import pytest
 from sqlalchemy.exc import IntegrityError
 
@@ -40,10 +40,7 @@ def test_sqlite_constraint_allowlist(message, code, expected):
     ],
 )
 def test_postgres_constraint_allowlist(constraint, code, expected):
-    class DriverError(Exception):
-        pass
-
-    original = DriverError()
+    original = asyncpg.exceptions.UniqueViolationError() if code == "23505" else Exception()
     original.sqlstate = code
-    original.diag = SimpleNamespace(constraint_name=constraint)
+    original.constraint_name = constraint
     assert _expected_claim_conflict(IntegrityError(None, None, original)) is expected

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -285,10 +285,14 @@ temperature = 0.2
 [defaults.rlm]
 max_iters = 3
 max_llm_calls = 4
+max_provider_attempts = 32
+max_tool_calls = 16
 max_output_chars = 500
 max_execution_output_chars = 250
+max_execution_output_bytes = 10000
 execution_timeout_s = 90
 wrap_up_seconds = 30
+finalization_attempts = 2
 verbose = true
 [defaults.storage]
 data_root = ".fleet-test"
@@ -482,6 +486,23 @@ def test_runtime_settings_reject_unknown_toml_key(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(config, "_CONFIG_PATH", policy)
 
     with pytest.raises(FleetConfigurationError, match="unknown configuration key"):
+        config.load_runtime_settings()
+
+
+def test_runtime_settings_reject_unknown_llm_role(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import fleet_rlm.config.loader as config
+
+    policy = tmp_path / "fleet.toml"
+    _policy(policy)
+    policy.write_text(
+        policy.read_text(encoding="utf-8")
+        + '\n[defaults.llm.utility]\nmodel = "openai/utility"\napi_key_env = "UTILITY_KEY"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(config, "_CONFIG_PATH", policy)
+
+    with pytest.raises(FleetConfigurationError, match=r"unknown LLM role.*utility"):
         config.load_runtime_settings()
 
 

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -258,6 +258,12 @@ def test_removed_databricks_daytona_profile_is_rejected(monkeypatch: pytest.Monk
 
 
 def _policy(path: Path) -> None:
+    """
+    Write a minimal runtime policy to the specified path for isolated tests.
+    
+    Parameters:
+    	path (Path): Destination file for the temporary TOML policy.
+    """
     path.write_text(
         """
 [config]

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -26,6 +26,18 @@ def test_profile_environment_matrix_follows_selected_toml_policy() -> None:
     )
 
 
+def test_runtime_variant_default_is_explicit_and_stable() -> None:
+    document = tomllib.loads(Path("config/fleet.toml").read_text(encoding="utf-8"))
+    assert document["defaults"]["runtime"]["variant"] == "legacy"
+    assert Settings().runtime_variant == "legacy"
+
+
+@pytest.mark.parametrize("variant", ["native", "capsule", "", "unknown"])
+def test_unimplemented_runtime_variants_are_rejected(variant: str) -> None:
+    with pytest.raises(ValidationError):
+        Settings(runtime_variant=variant)
+
+
 def test_committed_policy_declares_databricks_model_roles() -> None:
     policy_path = Path(__file__).resolve().parents[3] / "config" / "fleet.toml"
     document = tomllib.loads(policy_path.read_text(encoding="utf-8"))

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from pydantic import SecretStr, ValidationError
 
-from fleet_rlm.config.loader import _deep_merge, active_profile_contract, load_profile_environment_contracts
+from fleet_rlm.config.loader import _deep_merge, active_profile_contract, load_profile_environment_contracts, load_runtime_settings
 from fleet_rlm.config.settings import FleetConfigurationError, Settings
 
 
@@ -503,7 +503,7 @@ def test_runtime_settings_reject_unknown_llm_role(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(config, "_CONFIG_PATH", policy)
 
     with pytest.raises(FleetConfigurationError, match=r"unknown LLM role.*utility"):
-        config.load_runtime_settings()
+        load_runtime_settings()
 
 
 def test_redacted_policy_summary_never_includes_secret_values() -> None:

--- a/tests/unit/backend/test_config.py
+++ b/tests/unit/backend/test_config.py
@@ -10,7 +10,12 @@ from pathlib import Path
 import pytest
 from pydantic import SecretStr, ValidationError
 
-from fleet_rlm.config.loader import _deep_merge, active_profile_contract, load_profile_environment_contracts, load_runtime_settings
+from fleet_rlm.config.loader import (
+    _deep_merge,
+    active_profile_contract,
+    load_profile_environment_contracts,
+    load_runtime_settings,
+)
 from fleet_rlm.config.settings import FleetConfigurationError, Settings
 
 
@@ -260,9 +265,9 @@ def test_removed_databricks_daytona_profile_is_rejected(monkeypatch: pytest.Monk
 def _policy(path: Path) -> None:
     """
     Write a minimal runtime policy to the specified path for isolated tests.
-    
+
     Parameters:
-    	path (Path): Destination file for the temporary TOML policy.
+        path (Path): Destination file for the temporary TOML policy.
     """
     path.write_text(
         """

--- a/tests/unit/backend/test_config_policy.py
+++ b/tests/unit/backend/test_config_policy.py
@@ -79,6 +79,17 @@ def test_policy_update_preserves_comments_and_validates_all_profiles(tmp_path: P
     assert _field(after, "daytona-recursive", "rlm.max_iters")["value"] == 21
 
 
+def test_variant_editor_only_exposes_implemented_runtime(tmp_path: Path) -> None:
+    service, policy = _service(tmp_path)
+    snapshot = service.read()
+    field = _field(snapshot, "defaults", "runtime.variant")
+    assert field["choices"] == ["legacy"]
+    before = policy.read_bytes()
+    with pytest.raises(FleetConfigurationError):
+        service.update(scope="defaults", path="runtime.variant", value="native", revision=snapshot.revision)
+    assert policy.read_bytes() == before
+
+
 def test_policy_can_add_a_profile_override_for_an_inherited_setting(tmp_path: Path) -> None:
     service, policy = _service(tmp_path)
     before = service.read()

--- a/tests/unit/backend/test_config_schema.py
+++ b/tests/unit/backend/test_config_schema.py
@@ -177,6 +177,17 @@ _EXPECTED_INVENTORY: tuple[tuple[str, str, str, str, tuple[str, ...], str | None
     ("llm.root.timeout_seconds", "Root LLM", "Provider timeout seconds", "number", (), "root_llm_timeout_seconds"),
     ("llm.sub.timeout_seconds", "Sub LLM", "Provider timeout seconds", "number", (), "sub_llm_timeout_seconds"),
     ("runtime.variant", "Runtime", "Runtime variant", "single_choice", ("legacy",), "runtime_variant"),
+    ("rlm.max_provider_attempts", "RLM", "Maximum provider attempts", "number", (), "rlm_max_provider_attempts"),
+    ("rlm.max_tool_calls", "RLM", "Maximum Tool calls", "number", (), "rlm_max_tool_calls"),
+    (
+        "rlm.max_execution_output_bytes",
+        "RLM",
+        "Maximum execution output bytes",
+        "number",
+        (),
+        "rlm_max_execution_output_bytes",
+    ),
+    ("rlm.finalization_attempts", "RLM", "Finalization attempts", "number", (), "rlm_finalization_attempts"),
 )
 
 

--- a/tests/unit/backend/test_config_schema.py
+++ b/tests/unit/backend/test_config_schema.py
@@ -176,6 +176,7 @@ _EXPECTED_INVENTORY: tuple[tuple[str, str, str, str, tuple[str, ...], str | None
     ("rlm.wrap_up_seconds", "RLM", "Final-answer reserve (seconds)", "number", (), "rlm_wrap_up_seconds"),
     ("llm.root.timeout_seconds", "Root LLM", "Provider timeout seconds", "number", (), "root_llm_timeout_seconds"),
     ("llm.sub.timeout_seconds", "Sub LLM", "Provider timeout seconds", "number", (), "sub_llm_timeout_seconds"),
+    ("runtime.variant", "Runtime", "Runtime variant", "single_choice", ("legacy",), "runtime_variant"),
 )
 
 

--- a/tests/unit/backend/test_database_compatibility.py
+++ b/tests/unit/backend/test_database_compatibility.py
@@ -41,7 +41,7 @@ async def test_database_compatibility_rejects_database_without_alembic_revision(
 @pytest.mark.asyncio
 async def test_database_compatibility_accepts_exact_alembic_head(tmp_path: Path) -> None:
     database_url = f"sqlite+aiosqlite:///{tmp_path / 'head.sqlite3'}"
-    await _set_revision(database_url, "019fa2e4b7c1")
+    await _set_revision(database_url, "019fdb010001")
 
     await check_database_compatibility(database_url)
 
@@ -86,7 +86,7 @@ def test_existing_baseline_database_upgrades_to_settling_head(
         columns = {column["name"] for column in inspect(connection).get_columns("fleet_runs")}
         revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
     assert {"terminal_intent", "recovery_metadata_json"} <= columns
-    assert revision == "019fa2e4b7c1"
+    assert revision == "019fdb010001"
 
 
 def test_existing_baseline_database_upgrades_to_memory_intents_head(
@@ -125,4 +125,4 @@ def test_existing_baseline_database_upgrades_to_memory_intents_head(
         "claim_heartbeat_at",
         "completion_reason",
     } <= intent_columns
-    assert revision == "019fa2e4b7c1"
+    assert revision == "019fdb010001"

--- a/tests/unit/backend/test_host_tool_submit_broker.py
+++ b/tests/unit/backend/test_host_tool_submit_broker.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 import pytest
 
-from fleet_rlm.rlm._dspy_compat import FinalOutput
+from fleet_rlm.rlm.compat_3_3_1 import FinalOutput
 
 
 class _RecordingTool:

--- a/tests/unit/backend/test_live_composition.py
+++ b/tests/unit/backend/test_live_composition.py
@@ -81,7 +81,7 @@ async def test_daytona_build_cancellation_disposes_partial_engine(monkeypatch: p
     import fleet_rlm.composition.live as composition
     import fleet_rlm.daytona.provisioning as provisioning
     import fleet_rlm.persistence.database as database
-    import fleet_rlm.rlm._dspy_compat as dspy_contract
+    import fleet_rlm.rlm.compat_3_3_1 as dspy_contract
     import fleet_rlm.runtime.daytona.run_environment as run_environment
 
     class Engine:

--- a/tests/unit/backend/test_live_turn_preparation.py
+++ b/tests/unit/backend/test_live_turn_preparation.py
@@ -170,6 +170,12 @@ async def test_live_preparation_stages_attachment_and_cleans_it(
     ).prepare(turn, deadline=float("inf"))
 
     assert prepared.execution.session.attachments[0].attachment_id == attachment_id
+    budget = prepared.execution.execution.models.budget
+    assert budget is not None
+    assert budget.limits.provider_attempts == settings.rlm_max_provider_attempts
+    assert budget.limits.tool_calls == settings.rlm_max_tool_calls
+    assert budget.limits.execution_output_bytes == settings.rlm_max_execution_output_bytes
+    assert budget.limits.finalization_attempts == settings.rlm_finalization_attempts
     assert data in volume.values()
     expected_tools = {
         "create_artifact",

--- a/tests/unit/backend/test_memory_promotion_intents.py
+++ b/tests/unit/backend/test_memory_promotion_intents.py
@@ -110,7 +110,7 @@ def test_builder_fails_closed_on_bounds_and_policy() -> None:
 async def _seed_store():
     """
     Prepare an isolated in-memory persistence store with seeded user, workspace, session, and run records.
-    
+
     Returns:
         tuple: The database engine, session factory, run state store, and newly started run.
     """

--- a/tests/unit/backend/test_memory_promotion_intents.py
+++ b/tests/unit/backend/test_memory_promotion_intents.py
@@ -108,6 +108,12 @@ def test_builder_fails_closed_on_bounds_and_policy() -> None:
 
 
 async def _seed_store():
+    """
+    Prepare an isolated in-memory persistence store with seeded user, workspace, session, and run records.
+    
+    Returns:
+        tuple: The database engine, session factory, run state store, and newly started run.
+    """
     from fleet_rlm.chat.run_lifecycle import RunClaim
     from fleet_rlm.persistence.database import (
         create_async_engine_from_url,

--- a/tests/unit/backend/test_memory_promotion_intents.py
+++ b/tests/unit/backend/test_memory_promotion_intents.py
@@ -130,6 +130,7 @@ async def _seed_store():
                 SessionRow(id=session_id, user_id=access.user_id, workspace_id=access.workspace_id),
             )
         )
+        await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
     store = SqlAlchemyRunStateStore(factory)
     run = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", uuid4()))
     return engine, factory, store, run

--- a/tests/unit/backend/test_memory_promotion_outbox.py
+++ b/tests/unit/backend/test_memory_promotion_outbox.py
@@ -14,13 +14,13 @@ from sqlalchemy import select
 async def _seed_with_intents(database_url: str, *, intents: tuple = (), commit: bool = True):
     """
     Create a database-backed run with optional memory promotion intents.
-    
+
     Parameters:
-    	intents (tuple): Memory promotion intents to attach to the committed turn.
-    	commit (bool): Whether to commit a turn for the run.
-    
+        intents (tuple): Memory promotion intents to attach to the committed turn.
+        commit (bool): Whether to commit a turn for the run.
+
     Returns:
-    	tuple: The database engine, session factory, run state store, created run, and turn access context.
+        tuple: The database engine, session factory, run state store, created run, and turn access context.
     """
     from fleet_rlm.chat.run_lifecycle import RunClaim
     from fleet_rlm.persistence.database import (

--- a/tests/unit/backend/test_memory_promotion_outbox.py
+++ b/tests/unit/backend/test_memory_promotion_outbox.py
@@ -12,6 +12,16 @@ from sqlalchemy import select
 
 
 async def _seed_with_intents(database_url: str, *, intents: tuple = (), commit: bool = True):
+    """
+    Create a database-backed run with optional memory promotion intents.
+    
+    Parameters:
+    	intents (tuple): Memory promotion intents to attach to the committed turn.
+    	commit (bool): Whether to commit a turn for the run.
+    
+    Returns:
+    	tuple: The database engine, session factory, run state store, created run, and turn access context.
+    """
     from fleet_rlm.chat.run_lifecycle import RunClaim
     from fleet_rlm.persistence.database import (
         create_async_engine_from_url,

--- a/tests/unit/backend/test_memory_promotion_outbox.py
+++ b/tests/unit/backend/test_memory_promotion_outbox.py
@@ -35,6 +35,7 @@ async def _seed_with_intents(database_url: str, *, intents: tuple = (), commit: 
                 SessionRow(id=session_id, user_id=access.user_id, workspace_id=access.workspace_id),
             )
         )
+        await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
     store = SqlAlchemyRunStateStore(factory)
     run = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", uuid4()))
     if commit:

--- a/tests/unit/backend/test_orphan_cleanup.py
+++ b/tests/unit/backend/test_orphan_cleanup.py
@@ -173,6 +173,9 @@ async def test_artifact_repository_enumerates_workspace_keep_sets() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
+            await db.flush([row for row in db.new if isinstance(row, SessionRow)])
+            await db.flush([row for row in db.new if isinstance(row, RunRow)])
 
         catalog = SqlAlchemyArtifactCatalog(factory)
         assert await catalog.list_storage_refs(workspace_id=workspace_id) == frozenset({storage_ref})

--- a/tests/unit/backend/test_runtime_benchmark_v2.py
+++ b/tests/unit/backend/test_runtime_benchmark_v2.py
@@ -4,17 +4,33 @@ from copy import deepcopy
 
 import pytest
 
-from scripts.benchmarks.runtime_v2 import compare, run, seal, validate
+from scripts.benchmarks.runtime_v2 import compare, run, seal, semantic_keywords_score, validate
+
+
+def _clean_receipt(receipt):
+    clean = deepcopy(receipt)
+    clean.pop("receipt_digest", None)
+    clean["source_dirty"] = False
+    return seal(clean)
 
 
 def test_scripted_benchmark_executes_repeated_turns_and_checks_durability():
     receipt = run(repetitions=2)
     validate(receipt)
+    clean = _clean_receipt(receipt)
     assert receipt["passed"]
     assert len(receipt["samples"]) == 6
     assert receipt["runtime_variant"] == "legacy"
     assert receipt["live_semantic_gate"] == "not_exercised"
-    assert compare(receipt, receipt)["passed"]
+    assert receipt["semantic_scorer_ids"] == ["semantic-keywords/v1"]
+    assert all(sample["semantic_scores"]["semantic-keywords/v1"] for sample in receipt["samples"])
+    assert compare(clean, clean)["passed"]
+
+
+def test_semantic_keyword_scorer_normalizes_text_without_provider_calls():
+    assert semantic_keywords_score("Résumé:\n  TOKYO 東京", ["résumé", "東京"])
+    assert not semantic_keywords_score("summary only", ["résumé"])
+    assert not semantic_keywords_score("hello", [])
 
 
 def test_benchmark_rejects_single_sample():
@@ -37,4 +53,28 @@ def test_comparison_rejects_resealed_false_summary():
     receipt.pop("receipt_digest")
     receipt["latency_seconds"]["p95"] = -1
     with pytest.raises(ValueError, match="latency summary"):
+        validate(seal(receipt))
+
+
+def test_comparison_rejects_runtime_variant_drift_and_dirty_provenance():
+    receipt = _clean_receipt(run(repetitions=2))
+
+    changed = deepcopy(receipt)
+    changed.pop("receipt_digest")
+    changed["runtime_variant"] = "native"
+    assert not compare(receipt, seal(changed))["passed"]
+
+    changed = deepcopy(receipt)
+    changed.pop("receipt_digest")
+    changed["source_dirty"] = True
+    result = compare(receipt, seal(changed))
+    assert not result["passed"]
+    assert not result["gates"]["source_clean"]
+
+
+def test_benchmark_rejects_missing_semantic_scorer_evidence():
+    receipt = run(repetitions=2)
+    receipt.pop("receipt_digest")
+    receipt["semantic_scorer_ids"] = []
+    with pytest.raises(ValueError, match="semantic scorer IDs"):
         validate(seal(receipt))

--- a/tests/unit/backend/test_runtime_benchmark_v2.py
+++ b/tests/unit/backend/test_runtime_benchmark_v2.py
@@ -8,6 +8,15 @@ from scripts.benchmarks.runtime_v2 import compare, run, seal, semantic_keywords_
 
 
 def _clean_receipt(receipt):
+    """
+    Create a resealed copy of a receipt marked as clean.
+    
+    Parameters:
+    	receipt (dict): Receipt to copy and reseal.
+    
+    Returns:
+    	dict: A copy with its receipt digest removed and source marked clean.
+    """
     clean = deepcopy(receipt)
     clean.pop("receipt_digest", None)
     clean["source_dirty"] = False

--- a/tests/unit/backend/test_runtime_benchmark_v2.py
+++ b/tests/unit/backend/test_runtime_benchmark_v2.py
@@ -4,7 +4,14 @@ from copy import deepcopy
 
 import pytest
 
-from scripts.benchmarks.runtime_v2 import compare, run, seal, semantic_keywords_score, validate
+from scripts.benchmarks import runtime_v2
+from scripts.benchmarks.runtime_v2 import (
+    compare,
+    run,
+    seal,
+    semantic_keywords_score,
+    validate,
+)
 
 
 def _clean_receipt(receipt):
@@ -87,3 +94,18 @@ def test_benchmark_rejects_missing_semantic_scorer_evidence():
     receipt["semantic_scorer_ids"] = []
     with pytest.raises(ValueError, match="semantic scorer IDs"):
         validate(seal(receipt))
+
+
+def test_run_rejects_sealed_inconsistent_event_fixtures(monkeypatch):
+    original_seal = runtime_v2.seal
+
+    def seal_with_inconsistent_fixture(receipt):
+        corrupted = deepcopy(receipt)
+        scenario = next(iter(corrupted["event_fixtures"]))
+        corrupted["event_fixtures"][scenario].append("unexpected")
+        return original_seal(corrupted)
+
+    monkeypatch.setattr(runtime_v2, "seal", seal_with_inconsistent_fixture)
+
+    with pytest.raises(ValueError, match="event fixtures"):
+        runtime_v2.run(repetitions=2)

--- a/tests/unit/backend/test_runtime_benchmark_v2.py
+++ b/tests/unit/backend/test_runtime_benchmark_v2.py
@@ -1,0 +1,40 @@
+"""The benchmark executes Turns and comparison fails closed on evidence changes."""
+
+from copy import deepcopy
+
+import pytest
+
+from scripts.benchmarks.runtime_v2 import compare, run, seal, validate
+
+
+def test_scripted_benchmark_executes_repeated_turns_and_checks_durability():
+    receipt = run(repetitions=2)
+    validate(receipt)
+    assert receipt["passed"]
+    assert len(receipt["samples"]) == 6
+    assert receipt["runtime_variant"] == "legacy"
+    assert receipt["live_semantic_gate"] == "not_exercised"
+    assert compare(receipt, receipt)["passed"]
+
+
+def test_benchmark_rejects_single_sample():
+    with pytest.raises(ValueError, match="two repetitions"):
+        run(repetitions=1)
+
+
+def test_comparison_rejects_tampering_and_dataset_drift():
+    receipt = run(repetitions=2)
+    changed = deepcopy(receipt)
+    changed["dataset_digest"] = "changed"
+    with pytest.raises(ValueError, match="digest"):
+        compare(receipt, changed)
+    changed.pop("receipt_digest")
+    assert not compare(receipt, seal(changed))["passed"]
+
+
+def test_comparison_rejects_resealed_false_summary():
+    receipt = run(repetitions=2)
+    receipt.pop("receipt_digest")
+    receipt["latency_seconds"]["p95"] = -1
+    with pytest.raises(ValueError, match="latency summary"):
+        validate(seal(receipt))

--- a/tests/unit/backend/test_runtime_benchmark_v2.py
+++ b/tests/unit/backend/test_runtime_benchmark_v2.py
@@ -17,12 +17,12 @@ from scripts.benchmarks.runtime_v2 import (
 def _clean_receipt(receipt):
     """
     Create a resealed copy of a receipt marked as clean.
-    
+
     Parameters:
-    	receipt (dict): Receipt to copy and reseal.
-    
+        receipt (dict): Receipt to copy and reseal.
+
     Returns:
-    	dict: A copy with its receipt digest removed and source marked clean.
+        dict: A copy with its receipt digest removed and source marked clean.
     """
     clean = deepcopy(receipt)
     clean.pop("receipt_digest", None)

--- a/tests/unit/backend/test_sandbox_binding_repository.py
+++ b/tests/unit/backend/test_sandbox_binding_repository.py
@@ -26,6 +26,7 @@ async def test_sql_sandbox_binding_store_round_trips_and_updates_scope() -> None
                     SessionRow(id=session_id, user_id=user_id, workspace_id=workspace_id, title="bindings"),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
 
         store = SqlAlchemySandboxBindingStore(factory)
         first = await store.upsert(
@@ -83,6 +84,7 @@ async def test_sql_sandbox_binding_store_retries_lost_insert_race() -> None:
                     SessionRow(id=session_id, user_id=user_id, workspace_id=workspace_id, title="bindings"),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
 
         store = SqlAlchemySandboxBindingStore(factory)
         binding = SandboxBinding(

--- a/tests/unit/backend/test_sql_turn_state.py
+++ b/tests/unit/backend/test_sql_turn_state.py
@@ -269,6 +269,11 @@ async def test_sql_terminal_replay_and_transition_require_session_scope() -> Non
 
 @pytest.mark.asyncio
 async def test_sql_state_replaces_a_stale_claim_after_recovery() -> None:
+    """
+    Verifies that a stale claim is recovered as failed and a replacement claim can be created.
+    
+    The recovered run retains the `stale_claim` failure code and has its claim ownership and heartbeat cleared.
+    """
     from fleet_rlm.chat.run_lifecycle import ClaimedRun, RunClaim
     from fleet_rlm.persistence.database import create_async_engine_from_url, create_session_factory, create_tables
     from fleet_rlm.persistence.models import RunRow, SessionRow, UserRow, WorkspaceRow
@@ -752,6 +757,7 @@ async def test_concurrent_recovery_workers_fence_a_run_once() -> None:
 
 @pytest.mark.asyncio
 async def test_sql_cancelled_settlement_persists_bounded_tombstone_rows() -> None:
+    """Verify that cancelled turn settlement creates bounded tombstone rows and remains outside live idempotency replay."""
     from sqlalchemy import select
 
     from fleet_rlm.chat.run_lifecycle import ClaimedRun, RunClaim, RunFailure, RunLifecycleService
@@ -874,6 +880,16 @@ async def test_sql_racing_begins_fence_one_claimant() -> None:
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
 
         async def begin(run_id, key: str):
+            """
+            Begin a turn for the configured session.
+            
+            Parameters:
+                run_id: Identifier of the run to claim.
+                key (str): Key identifying the turn request.
+            
+            Returns:
+                The result of the turn-claim operation.
+            """
             return await store.begin(RunClaim(access, session_id, TurnInput(f"turn-{key}"), key, run_id))
 
         results = await asyncio.gather(

--- a/tests/unit/backend/test_sql_turn_state.py
+++ b/tests/unit/backend/test_sql_turn_state.py
@@ -61,6 +61,7 @@ async def test_sql_failure_code_is_typed_cause_not_public_message() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
 
         store = SqlAlchemyRunStateStore(factory)
         begun = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", run_id))
@@ -118,6 +119,7 @@ async def test_sql_revoke_completion_uses_policy_terminal_intent() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
 
         store = SqlAlchemyRunStateStore(factory)
         turn = await store.begin(RunClaim(access, session_id, TurnInput("one"), "one", run_id))
@@ -195,6 +197,7 @@ async def test_sql_state_round_trips_canonical_turn_without_result_mirrors() -> 
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory)
         request = RunClaim(access, session_id, TurnInput("hello"), "key", uuid4())
         begun = await store.begin(request)
@@ -241,6 +244,7 @@ async def test_sql_terminal_replay_and_transition_require_session_scope() -> Non
                     SessionRow(id=session_id, user_id=access.user_id, workspace_id=access.workspace_id, title="scope"),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory)
         begun = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", run_id))
         assert isinstance(begun, ClaimedRun)
@@ -289,6 +293,7 @@ async def test_sql_state_replaces_a_stale_claim_after_recovery() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
         first_id, replacement_id = uuid4(), uuid4()
         request = RunClaim(access, session_id, TurnInput("hello"), "key", first_id)
@@ -339,6 +344,7 @@ async def test_reconcile_recovers_stale_running_after_provider_fence() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
         started = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", run_id))
         assert isinstance(started, ClaimedRun)
@@ -389,6 +395,7 @@ async def test_startup_reconciliation_fences_a_live_prior_claim_without_waiting_
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
         assert isinstance(
             await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", run_id)), ClaimedRun
@@ -429,6 +436,7 @@ async def test_reconcile_deadline_bounds_provider_fence_and_leaves_claim_retryab
         async with factory() as db, db.begin():
             db.add(UserRow(id=access.user_id))
             db.add(WorkspaceRow(id=access.workspace_id))
+            await db.flush()
             db.add_all(
                 SessionRow(
                     id=session_id,
@@ -519,6 +527,7 @@ async def test_reconcile_retries_failed_settling_fence_without_losing_intent() -
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
         started = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", run_id))
         assert isinstance(started, ClaimedRun)
@@ -711,6 +720,7 @@ async def test_concurrent_recovery_workers_fence_a_run_once() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
         started = await store.begin(RunClaim(access, session_id, TurnInput("hello"), "key", run_id))
         assert isinstance(started, ClaimedRun)
@@ -771,6 +781,7 @@ async def test_sql_cancelled_settlement_persists_bounded_tombstone_rows() -> Non
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
 
         store = SqlAlchemyRunStateStore(factory)
         lifecycle = RunLifecycleService(store, max_artifact_bytes=1024)
@@ -859,6 +870,7 @@ async def test_sql_racing_begins_fence_one_claimant() -> None:
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
         store = SqlAlchemyRunStateStore(factory, stale_after_seconds=30)
 
         async def begin(run_id, key: str):

--- a/tests/unit/backend/test_sql_turn_state.py
+++ b/tests/unit/backend/test_sql_turn_state.py
@@ -271,7 +271,7 @@ async def test_sql_terminal_replay_and_transition_require_session_scope() -> Non
 async def test_sql_state_replaces_a_stale_claim_after_recovery() -> None:
     """
     Verifies that a stale claim is recovered as failed and a replacement claim can be created.
-    
+
     The recovered run retains the `stale_claim` failure code and has its claim ownership and heartbeat cleared.
     """
     from fleet_rlm.chat.run_lifecycle import ClaimedRun, RunClaim
@@ -757,7 +757,8 @@ async def test_concurrent_recovery_workers_fence_a_run_once() -> None:
 
 @pytest.mark.asyncio
 async def test_sql_cancelled_settlement_persists_bounded_tombstone_rows() -> None:
-    """Verify that cancelled turn settlement creates bounded tombstone rows and remains outside live idempotency replay."""
+    """Verify that cancelled turn settlement creates bounded tombstone rows and stays
+    outside live idempotency replay."""
     from sqlalchemy import select
 
     from fleet_rlm.chat.run_lifecycle import ClaimedRun, RunClaim, RunFailure, RunLifecycleService
@@ -882,11 +883,11 @@ async def test_sql_racing_begins_fence_one_claimant() -> None:
         async def begin(run_id, key: str):
             """
             Begin a turn for the configured session.
-            
+
             Parameters:
                 run_id: Identifier of the run to claim.
                 key (str): Key identifying the turn request.
-            
+
             Returns:
                 The result of the turn-claim operation.
             """

--- a/tests/unit/backend/test_turn_coordinator_commit.py
+++ b/tests/unit/backend/test_turn_coordinator_commit.py
@@ -315,6 +315,7 @@ async def test_open_commits_typed_result_through_temporary_sql(tmp_path) -> None
                     ),
                 )
             )
+            await db.flush([row for row in db.new if isinstance(row, (UserRow, WorkspaceRow))])
 
         class Prepared:
             execution = SimpleNamespace(run_id=run_id, session_id=session_id)

--- a/tests/unit/backend/test_turn_lineage_migration.py
+++ b/tests/unit/backend/test_turn_lineage_migration.py
@@ -12,13 +12,13 @@ from sqlalchemy.exc import IntegrityError
 def _database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """
     Configure a temporary SQLite database and apply the baseline migration.
-    
+
     Parameters:
-    	tmp_path (Path): Temporary directory in which to create the database.
-    	monkeypatch (pytest.MonkeyPatch): Fixture used to set the database URL environment variable.
-    
+        tmp_path (Path): Temporary directory in which to create the database.
+        monkeypatch (pytest.MonkeyPatch): Fixture used to set the database URL environment variable.
+
     Returns:
-    	tuple: The Alembic configuration and SQLAlchemy engine for the database.
+        tuple: The Alembic configuration and SQLAlchemy engine for the database.
     """
     url = f"sqlite:///{tmp_path / 'lineage.db'}"
     monkeypatch.setenv("FLEET_DATABASE_URL", url)
@@ -54,11 +54,11 @@ def _seed(connection) -> None:
 def _turn(connection, session: str, run: str = "r") -> None:
     """
     Insert a user turn associated with a session and run.
-    
+
     Parameters:
-    	connection: Database connection used to execute the insert.
-    	session: Identifier of the session associated with the turn.
-    	run: Identifier of the run associated with the turn.
+        connection: Database connection used to execute the insert.
+        session: Identifier of the session associated with the turn.
+        run: Identifier of the run associated with the turn.
     """
     connection.execute(
         text(

--- a/tests/unit/backend/test_turn_lineage_migration.py
+++ b/tests/unit/backend/test_turn_lineage_migration.py
@@ -1,0 +1,89 @@
+"""Database enforcement and reversible, fail-closed lineage migration."""
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+
+
+def _database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    url = f"sqlite:///{tmp_path / 'lineage.db'}"
+    monkeypatch.setenv("FLEET_DATABASE_URL", url)
+    config = Config("alembic.ini")
+    command.upgrade(config, "019fa2e4b7c1")
+    return config, create_engine(url)
+
+
+def _seed(connection) -> None:
+    connection.execute(text("INSERT INTO fleet_users (id) VALUES ('u')"))
+    connection.execute(text("INSERT INTO fleet_workspaces (id, name) VALUES ('w', 'test')"))
+    for session in ("s1", "s2"):
+        connection.execute(
+            text(
+                "INSERT INTO fleet_sessions (id,user_id,workspace_id,status,title,checkpoint_version) "
+                "VALUES (:id,'u','w','active','test',0)"
+            ),
+            {"id": session},
+        )
+    connection.execute(
+        text(
+            "INSERT INTO fleet_runs (id,session_id,status,idempotency_key,input_fingerprint,"
+            "base_checkpoint_version,claim_owner,claim_heartbeat_at) "
+            "VALUES ('r','s1','running','key',:fingerprint,0,'owner',CURRENT_TIMESTAMP)"
+        ),
+        {"fingerprint": "a" * 64},
+    )
+
+
+def _turn(connection, session: str, run: str = "r") -> None:
+    connection.execute(
+        text(
+            "INSERT INTO fleet_turns (id,session_id,run_id,sequence,role,user_input_json) "
+            "VALUES ('t',:session,:run,1,'user','{}')"
+        ),
+        {"session": session, "run": run},
+    )
+
+
+@pytest.mark.parametrize("session,run", [("s2", "r"), ("s1", "missing")])
+def test_upgrade_rejects_dirty_lineage_before_ddl(tmp_path, monkeypatch, session, run):
+    config, engine = _database(tmp_path, monkeypatch)
+    try:
+        with engine.begin() as connection:
+            _seed(connection)
+            _turn(connection, session, run)
+        with pytest.raises(RuntimeError, match="lineage preflight failed"):
+            command.upgrade(config, "head")
+        with engine.connect() as connection:
+            assert connection.execute(text("SELECT COUNT(*) FROM fleet_turns")).scalar_one() == 1
+            assert connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one() == "019fa2e4b7c1"
+            assert "uq_fleet_runs_id_session" not in {i["name"] for i in inspect(connection).get_indexes("fleet_runs")}
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_enforces_immediate_lineage_and_downgrade_preserves_rows(tmp_path, monkeypatch):
+    config, engine = _database(tmp_path, monkeypatch)
+    try:
+        with engine.begin() as connection:
+            _seed(connection)
+        command.upgrade(config, "head")
+        with engine.connect() as connection:
+            connection.execute(text("PRAGMA foreign_keys=ON"))
+            connection.commit()
+            with pytest.raises(IntegrityError), connection.begin():
+                _turn(connection, "s2")
+            with connection.begin():
+                _turn(connection, "s1")
+        command.downgrade(config, "019fa2e4b7c1")
+        with engine.connect() as connection:
+            assert connection.execute(text("SELECT COUNT(*) FROM fleet_turns")).scalar_one() == 1
+            assert "fk_fleet_turns_run_session" not in {
+                fk["name"] for fk in inspect(connection).get_foreign_keys("fleet_turns")
+            }
+        command.upgrade(config, "head")
+    finally:
+        engine.dispose()

--- a/tests/unit/backend/test_turn_lineage_migration.py
+++ b/tests/unit/backend/test_turn_lineage_migration.py
@@ -10,6 +10,16 @@ from sqlalchemy.exc import IntegrityError
 
 
 def _database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """
+    Configure a temporary SQLite database and apply the baseline migration.
+    
+    Parameters:
+    	tmp_path (Path): Temporary directory in which to create the database.
+    	monkeypatch (pytest.MonkeyPatch): Fixture used to set the database URL environment variable.
+    
+    Returns:
+    	tuple: The Alembic configuration and SQLAlchemy engine for the database.
+    """
     url = f"sqlite:///{tmp_path / 'lineage.db'}"
     monkeypatch.setenv("FLEET_DATABASE_URL", url)
     config = Config("alembic.ini")
@@ -18,6 +28,9 @@ def _database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 def _seed(connection) -> None:
+    """
+    Populate the database with a user, workspace, two active sessions, and a running session-associated run.
+    """
     connection.execute(text("INSERT INTO fleet_users (id) VALUES ('u')"))
     connection.execute(text("INSERT INTO fleet_workspaces (id, name) VALUES ('w', 'test')"))
     for session in ("s1", "s2"):
@@ -39,6 +52,14 @@ def _seed(connection) -> None:
 
 
 def _turn(connection, session: str, run: str = "r") -> None:
+    """
+    Insert a user turn associated with a session and run.
+    
+    Parameters:
+    	connection: Database connection used to execute the insert.
+    	session: Identifier of the session associated with the turn.
+    	run: Identifier of the run associated with the turn.
+    """
     connection.execute(
         text(
             "INSERT INTO fleet_turns (id,session_id,run_id,sequence,role,user_input_json) "
@@ -66,6 +87,7 @@ def test_upgrade_rejects_dirty_lineage_before_ddl(tmp_path, monkeypatch, session
 
 
 def test_upgrade_enforces_immediate_lineage_and_downgrade_preserves_rows(tmp_path, monkeypatch):
+    """Verify lineage enforcement after upgrade and row preservation after downgrade."""
     config, engine = _database(tmp_path, monkeypatch)
     try:
         with engine.begin() as connection:

--- a/tools/fleet-tui/AGENTS.md
+++ b/tools/fleet-tui/AGENTS.md
@@ -10,7 +10,7 @@ The maintained Fleet client is a pi-tui TypeScript terminal application. It cons
 
 - Node and pnpm versions are defined by the workspace.
 - Use pnpm from `tools/fleet-tui/`.
-- Run the complete TUI validation lane with `make tui-check`.
+- Run the complete TUI validation lane for code changes with `make tui-check`.
 
 Do not hand-edit generated files under `src/generated/`.
 
@@ -63,6 +63,8 @@ Treat profile changes as restart-target policy unless the backend contract expli
 ## Validation
 
 For focused TypeScript changes, run the relevant workspace checks/tests.
+For changes limited to documentation or agent instructions, use the root
+documentation validation lane; no terminal launch or live backend is required.
 
 Before completing substantial TUI work, run:
 


### PR DESCRIPTION
## Description

This branch establishes the governed runtime foundation for Fleet's DSPy RLM migration while keeping the legacy runtime selected by default.

### What changed

- Add the native `dspy.RLM` program/specification and tool-ownership boundaries, with pinned DSPy compatibility isolated in `compat_3_3_1.py`.
- Complete `FleetJSONAdapter` with bounded parse/finalization repair, SUBMIT validation, sync/async parity, and global provider-attempt accounting.
- Wire a shared, atomic `TurnBudget` through provider attempts, retries, Tools, recursive children, execution output, finalization, deadlines, and cleanup settlement.
- Replace per-call async Tool worker loops with a composition-owned persistent bridge and fail-closed loop-affinity checks.
- Enforce Turn/Run/Session lineage and narrowly scoped claim reconciliation.
- Add runtime-v2 lifecycle receipts and deterministic semantic keyword evidence, explicitly separate from live LLM quality evidence.
- Harden runtime configuration, release failure behavior, rollback behavior, and document the Phase 3–7 migration gates.

The public HTTP/SSE contract and TUI client implementation remain compatible; native cutover, snapshot/warm-capacity work, and legacy removal remain gated behind the roadmap feasibility evidence.

Related issue: none specified.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Validation

- [x] `make check` — backend, type, generated-contract, dependency-boundary, documentation, harness, and TUI checks passed; 78.60% backend coverage and 538 TUI tests.
- [x] `make check-docs`
- [x] Scripted runtime-v2 baseline/candidate comparison passed with clean receipts and `semantic-keywords/v1`.
- [x] `git diff --check`
- [x] Documentation and roadmap updated.
- [x] Commit messages follow repository conventions.

## Deferred / gated validation

Credentialed provider, Daytona, Postgres contention, and live semantic-baseline runs were not executed. No runtime roadmap phase is closed; these require the applicable operator authorization and Phase 3 gates.
