### PR TITLE
fix(cli): centralize safe bind host for all serve paths

### DIFF
--- a/src/fleet_rlm/cli/main.py
+++ b/src/fleet_rlm/cli/main.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import Sequence
 from typing import Any
 
-from fleet_rlm.cli.bind_safety import UnsafeBindError, require_safe_bind_host
+from fleet_rlm.cli.bind_safety import UnsafeBindError
 
 
 def _add_serve_command(
@@ -94,16 +94,6 @@ def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> 
         _run_doctor(parser, args.doctor_provider)
         return
 
-    if args.profile is not None and args.reload:
-        parser.error("--reload cannot be combined with an explicit --profile")
-
-    try:
-        require_safe_bind_host(
-            args.host,
-            allow_non_loopback=bool(args.allow_non_loopback_bind),
-        )
-    except UnsafeBindError as exc:
-        parser.exit(1, f"fleet: error: {exc}\n")
     if args.supervise_tui:
         from fleet_rlm.cli.supervisor import SupervisorError, supervise
 
@@ -117,6 +107,7 @@ def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> 
                 "reload": args.reload,
                 "run_environment": args.run_environment,
                 "tui_args": tui_args,
+                "allow_non_loopback_bind": bool(args.allow_non_loopback_bind),
             }
             if args.profile is not None:
                 supervise_kwargs["profile"] = args.profile
@@ -124,22 +115,20 @@ def _run(parser: argparse.ArgumentParser, argv: Sequence[str] | None = None) -> 
         except SupervisorError as exc:
             parser.exit(1, f"fleet: error: {exc}\n")
         return
-    if args.profile is None:
-        import uvicorn
-
-        uvicorn.run(
-            "fleet_rlm.main:app",
-            host=args.host,
-            port=args.port,
-            reload=args.reload,
-        )
-        return
     from fleet_rlm.cli.server import ProfileReloadError, serve_api
 
     try:
-        serve_api(host=args.host, port=args.port, reload=args.reload, profile=args.profile)
+        serve_api(
+            host=args.host,
+            port=args.port,
+            reload=args.reload,
+            profile=args.profile,
+            allow_non_loopback=bool(args.allow_non_loopback_bind),
+        )
     except ProfileReloadError as exc:
         parser.error(str(exc))
+    except UnsafeBindError as exc:
+        parser.exit(1, f"fleet: error: {exc}\n")
 
 
 _DOCTOR_ACTIONS = {

--- a/src/fleet_rlm/cli/server.py
+++ b/src/fleet_rlm/cli/server.py
@@ -5,9 +5,23 @@ from __future__ import annotations
 import argparse
 from collections.abc import Sequence
 
+from fleet_rlm.cli.bind_safety import UnsafeBindError, require_safe_bind_host
+
 
 class ProfileReloadError(ValueError):
     """Raised when an explicit profile is combined with Uvicorn reload."""
+
+
+def validate_serve_launch(
+    *,
+    host: str,
+    reload: bool,
+    profile: str | None,
+    allow_non_loopback: bool,
+) -> None:
+    require_safe_bind_host(host, allow_non_loopback=allow_non_loopback)
+    if profile is not None and reload:
+        raise ProfileReloadError("--reload cannot be combined with an explicit --profile")
 
 
 def serve_api(
@@ -16,6 +30,7 @@ def serve_api(
     port: int,
     reload: bool,
     profile: str | None = None,
+    allow_non_loopback: bool = False,
 ) -> None:
     """Run the FastAPI application with an optional explicit policy profile.
 
@@ -27,8 +42,12 @@ def serve_api(
     explicit profile launches reject ``--reload`` rather than falling back to
     the committed default profile.
     """
-    if profile is not None and reload:
-        raise ProfileReloadError("--reload cannot be combined with an explicit --profile")
+    validate_serve_launch(
+        host=host,
+        reload=reload,
+        profile=profile,
+        allow_non_loopback=allow_non_loopback,
+    )
 
     import uvicorn
 
@@ -55,19 +74,35 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--reload", action="store_true")
     parser.add_argument("--profile")
+    parser.add_argument(
+        "--allow-non-loopback-bind",
+        action="store_true",
+        help=(
+            "allow binding to a non-loopback address; Fleet has no caller "
+            "authentication and will expose the local API on the network"
+        ),
+    )
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
-        serve_api(host=args.host, port=args.port, reload=args.reload, profile=args.profile)
+        serve_api(
+            host=args.host,
+            port=args.port,
+            reload=args.reload,
+            profile=args.profile,
+            allow_non_loopback=bool(args.allow_non_loopback_bind),
+        )
     except ProfileReloadError as exc:
         _parser().error(str(exc))
+    except UnsafeBindError as exc:
+        _parser().exit(1, f"{_parser().prog}: error: {exc}\n")
     return 0
 
 
-__all__ = ["ProfileReloadError", "main", "serve_api"]
+__all__ = ["ProfileReloadError", "main", "serve_api", "validate_serve_launch"]
 
 
 if __name__ == "__main__":

--- a/src/fleet_rlm/cli/supervisor.py
+++ b/src/fleet_rlm/cli/supervisor.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from types import FrameType
 from typing import TYPE_CHECKING, cast
 
+from fleet_rlm.cli.bind_safety import UnsafeBindError
+from fleet_rlm.cli.server import ProfileReloadError, validate_serve_launch
 from fleet_rlm.config.loader import active_profile, load_runtime_settings
 from fleet_rlm.persistence.database import ensure_database_compatible
 
@@ -429,10 +431,18 @@ def supervise(
     profile: str | None = None,
     tui_args: Sequence[str] = (),
     repo_root: Path | None = None,
+    allow_non_loopback_bind: bool = False,
 ) -> None:
     """Run the selected backend and repository pi-tui client together."""
-    if profile is not None and reload:
-        raise SupervisorError("--reload cannot be combined with an explicit --profile")
+    try:
+        validate_serve_launch(
+            host=host,
+            reload=reload,
+            profile=profile,
+            allow_non_loopback=allow_non_loopback_bind,
+        )
+    except (ProfileReloadError, UnsafeBindError) as exc:
+        raise SupervisorError(str(exc)) from exc
     root = repo_root or Path(__file__).resolve().parents[3]
     workspace, pnpm = _validate_prerequisites(root)
     _require_available_port(host, port)
@@ -448,33 +458,21 @@ def supervise(
     log_path = logs / f"backend-{timestamp}.log"
     latest_log_path = logs / "latest.log"
     api_url = _api_url(host, port)
-    if profile is None:
-        backend_command = [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "fleet_rlm.main:app",
-            "--host",
-            host,
-            "--port",
-            str(port),
-        ]
-        if reload:
-            backend_command.append("--reload")
-    else:
-        backend_command = [
-            sys.executable,
-            "-m",
-            "fleet_rlm.cli.server",
-            "--host",
-            host,
-            "--port",
-            str(port),
-            "--profile",
-            profile,
-        ]
-        if reload:
-            backend_command.append("--reload")
+    backend_command = [
+        sys.executable,
+        "-m",
+        "fleet_rlm.cli.server",
+        "--host",
+        host,
+        "--port",
+        str(port),
+    ]
+    if reload:
+        backend_command.append("--reload")
+    if profile is not None:
+        backend_command.extend(["--profile", profile])
+    if allow_non_loopback_bind:
+        backend_command.append("--allow-non-loopback-bind")
     backend_env = dict(os.environ)
     # The backend resolves the committed TOML policy itself; do not pin an
     # ambient profile override into the child process environment.

--- a/tests/unit/backend/test_bind_safety.py
+++ b/tests/unit/backend/test_bind_safety.py
@@ -6,6 +6,7 @@ import pytest
 
 from fleet_rlm.cli.bind_safety import UnsafeBindError, is_loopback_bind_host, require_safe_bind_host
 from fleet_rlm.cli.main import fleet_main, fleet_rlm_main
+from fleet_rlm.cli.server import main as serve_api_main
 
 
 @pytest.mark.parametrize(
@@ -34,6 +35,7 @@ def test_non_loopback_hosts_require_explicit_opt_in(host: str) -> None:
         (fleet_main, ["web", "--host", "0.0.0.0"]),
         (fleet_rlm_main, ["serve-api", "--host", "0.0.0.0"]),
         (fleet_main, ["cli", "--host", "0.0.0.0"]),
+        (serve_api_main, ["--host", "0.0.0.0"]),
     ],
 )
 def test_launchers_reject_non_loopback_without_opt_in(

--- a/tests/unit/backend/test_cli.py
+++ b/tests/unit/backend/test_cli.py
@@ -226,6 +226,7 @@ def test_fleet_runtime_command_selects_environment_and_supervises_pi_tui(
             "reload": False,
             "run_environment": expected_environment,
             "tui_args": ("--session", "session-id"),
+            "allow_non_loopback_bind": True,
         }
     ]
 
@@ -247,7 +248,15 @@ def test_fleet_web_explicit_profile_uses_profile_aware_launcher(monkeypatch: pyt
 
     fleet_main(["web", "--profile", "phase4-campaign", "--port", "8124"])
 
-    assert calls == [{"host": "127.0.0.1", "port": 8124, "reload": False, "profile": "phase4-campaign"}]
+    assert calls == [
+        {
+            "host": "127.0.0.1",
+            "port": 8124,
+            "reload": False,
+            "profile": "phase4-campaign",
+            "allow_non_loopback": False,
+        }
+    ]
 
 
 def test_profile_aware_server_loads_settings_and_builds_app_before_binding(
@@ -290,9 +299,7 @@ def test_profile_reload_rejection_happens_before_uvicorn_import(monkeypatch: pyt
 
 
 def test_explicit_profile_and_reload_fail_before_launcher(monkeypatch: pytest.MonkeyPatch) -> None:
-    from fleet_rlm.cli import server
-
-    monkeypatch.setattr(server, "serve_api", lambda **_kwargs: pytest.fail("launcher must not run"))
+    monkeypatch.setitem(sys.modules, "uvicorn", None)
 
     with pytest.raises(SystemExit) as error:
         fleet_main(["web", "--profile", "phase4-campaign", "--reload"])
@@ -314,6 +321,7 @@ def test_fleet_cli_forwards_explicit_profile_to_supervisor(monkeypatch: pytest.M
             "run_environment": "daytona",
             "tui_args": (),
             "profile": "phase4-campaign",
+            "allow_non_loopback_bind": False,
         }
     ]
 

--- a/tests/unit/backend/test_cli_supervisor.py
+++ b/tests/unit/backend/test_cli_supervisor.py
@@ -593,14 +593,14 @@ def test_supervisor_runs_pi_tui_against_ready_backend_and_terminates_backend_gro
 
     backend_command, backend_options = popen_calls[0]
     assert database_calls == [tmp_path]
-    assert backend_command[-6:] == [
-        "fleet_rlm.main:app",
+    assert backend_command[-5:] == [
         "--host",
         "127.0.0.1",
         "--port",
         "8123",
         "--reload",
     ]
+    assert backend_command[:3] == [supervisor.sys.executable, "-m", "fleet_rlm.cli.server"]
     assert backend_options["start_new_session"] is True
     assert "FLEET_CONFIG_PROFILE" not in backend_options["env"]  # type: ignore[index]
     assert "FLEET_RUN_ENVIRONMENT" not in backend_options["env"]  # type: ignore[index]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Centralize CLI bind-safety and serve-launch validation so every API-serving entrypoint enforces the same rules.

**Before:** `require_safe_bind_host` ran only in `cli/main.py` `_run`, so `python -m fleet_rlm.cli.server`, supervisor-spawned uvicorn, and direct `serve_api` calls could bypass the bind guard. Profile+reload rejection was duplicated in `main.py`, `server.py`, and `supervisor.py`. The no-profile uvicorn path was duplicated between `main.py` and `server.py`.

**After:**
- `validate_serve_launch` in `cli/server.py` is the single owner for `require_safe_bind_host` and profile+reload rejection.
- `serve_api` calls it before any uvicorn import/bind.
- `cli/main.py` routes all backend-only commands through `serve_api(profile=...)`.
- `supervise` validates via the same helper (fail-fast) and always spawns `python -m fleet_rlm.cli.server`, forwarding `--allow-non-loopback-bind` when opted in.
- `python -m fleet_rlm.cli.server` gains `--allow-non-loopback-bind` and enforces bind safety on its own.

**Bypass closed:**
- `fleet web` / `fleet-rlm serve-api` → `serve_api` → `validate_serve_launch`
- `fleet cli` → `supervise` → `validate_serve_launch` + child `fleet_rlm.cli.server`
- `python -m fleet_rlm.cli.server` → `serve_api` → `validate_serve_launch`

**LOC delta:** +91 / −59 (net +32) across 6 files.

**Skipped / out of scope:** API route boundaries, history projection, OpenAPI/contracts, Daytona/god-module splits, dead code from PR #526.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Applicable validation from AGENTS.md passed; exact commands/results appear below
- [x] Documentation matches the affected implementation (no doc changes required; existing `docs/reference/cli.md` already documents `--allow-non-loopback-bind`)
- [x] Generated contracts were regenerated when their source changed (N/A)
- [x] `git diff --check` passed and unrelated changes were excluded

## Validation

```bash
uv run pytest tests/unit/backend/test_bind_safety.py tests/unit/backend/test_cli.py tests/unit/backend/test_cli_supervisor.py -q
# 61 passed

uv run ruff check src/fleet_rlm/cli/main.py src/fleet_rlm/cli/server.py src/fleet_rlm/cli/supervisor.py tests/unit/backend/test_bind_safety.py tests/unit/backend/test_cli.py tests/unit/backend/test_cli_supervisor.py
# All checks passed

uv run ruff format --check <same paths>
# 6 files already formatted

git diff --check
# passed
```

Narrow unit tests only; no live provider, database, or release certification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1562f1-3b25-50ac-9662-689f6eda64eb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1562f1-3b25-50ac-9662-689f6eda64eb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

